### PR TITLE
feat(image): add Dockerfile for Claude Code base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# SRS-5.1.1: Base MUST be node:20-slim (Debian/glibc, NOT Alpine)
+FROM node:20-slim
+
+# SRS-5.1.3: Version pinning via build arg
+ARG CLAUDE_CODE_VERSION
+# Why: Omitting default means "latest" when --build-arg is not passed.
+# Pinning: docker build --build-arg CLAUDE_CODE_VERSION=1.2.3 .
+
+# SRS-5.1.6: WORKDIR must NOT be / (causes full filesystem scan on install)
+WORKDIR /workspace
+
+# SRS-5.1.4: Dev tools — single layer, cache cleaned
+# SRS-5.1.8: apt cache removed in same RUN to avoid layer bloat
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       git \
+       curl \
+       jq \
+       fzf \
+       zsh \
+       sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI (gh) — separate layer for cache efficiency
+# Why: gh releases change independently from apt packages
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# SRS-5.1.2: Install Claude Code globally
+# SRS-5.1.8: npm cache cleaned in same RUN
+RUN npm install -g @anthropic-ai/claude-code${CLAUDE_CODE_VERSION:+@$CLAUDE_CODE_VERSION} \
+    && npm cache clean --force
+
+# SRS-5.1.5: Memory heap limit
+ENV NODE_OPTIONS=--max-old-space-size=4096
+
+# SRS-5.1.7: Run as non-root user
+# Why: node user (UID 1000) comes pre-created in node:20-slim
+USER node
+
+# Default command keeps container alive for docker compose exec
+CMD ["sleep", "infinity"]


### PR DESCRIPTION
## What

Create the Dockerfile that builds the Claude Code base image. This is the foundation for all containers in the claude-docker project.

### Change Type
- [x] Feature (new functionality)

## Why

All containers share a single image. Without the Dockerfile, no container can run. This is the first deliverable in the implementation pipeline.

Closes #1

## Traceability

| Layer | Reference |
|-------|-----------|
| PRD | FR-1 (P0), FR-2 (P0), FR-3 (P0), FR-4 (P0) |
| SRS | SRS-5.1.1 ~ SRS-5.1.10 |
| SDS | Section 2 "Dockerfile Design" |
| SC | SC-1 (storage efficiency), SC-2 (startup time) |

## Where

### Files Changed
| File | Type of Change |
|------|---------------|
| `Dockerfile` | New file |

## How

### Implementation Details
- **Base image**: `node:20-slim` (Debian/glibc, NOT Alpine per SRS-5.1.1)
- **Version pinning**: `ARG CLAUDE_CODE_VERSION` with no default (SRS-5.1.3)
- **WORKDIR**: `/workspace` (SRS-5.1.6)
- **Dev tools**: git, curl, jq, fzf, zsh, sudo in single layer with cache cleanup (SRS-5.1.4, SRS-5.1.8)
- **GitHub CLI**: Separate layer via official apt repo for cache efficiency
- **Claude Code**: npm global install with cache cleanup (SRS-5.1.2, SRS-5.1.8)
- **Memory**: `NODE_OPTIONS=--max-old-space-size=4096` (SRS-5.1.5)
- **Security**: Runs as non-root `node` user (SRS-5.1.7)
- **CMD**: `sleep infinity` in exec form to keep container alive

### Layer Ordering
```
apt packages (rarely change)  → stable cache
gh CLI (occasional updates)   → moderate cache
Claude Code (frequent bumps)  → rebuilt most often
```

### Acceptance Criteria
- [x] `docker build .` succeeds without errors
- [x] Base is Debian (node:20-slim), not Alpine
- [x] WorkingDir is /workspace
- [x] Dev tools installed (git, gh, curl, jq, fzf, zsh)
- [x] NODE_OPTIONS heap limit set to 4GB
- [x] Runs as non-root user (node)