### PR TITLE
chore(image): add .dockerignore to exclude unnecessary files from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+node_modules
+dist
+build
+*.log
+.env
+.env.*
+.claude/
+.claude-state/


### PR DESCRIPTION
## What

Add a `.dockerignore` file to exclude unnecessary files and directories from the Docker build context, reducing image build time and preventing sensitive files from leaking into the image.

### Change Type
- [x] Chore (build/tooling improvement)

## Why

Without a `.dockerignore`, `docker build` sends the entire working directory as build context — including `.git/`, `node_modules/`, `.env` secrets, and Claude state directories. This slows builds and risks leaking sensitive data into the image layer cache.

Closes #2

## Traceability

| Layer | Reference |
|-------|-----------|
| SRS | SRS-5.1.8 (image size minimization) |
| SDS | Section 2 "Dockerfile Design" — build context optimization |

## Where

### Files Changed
| File | Type of Change |
|------|---------------|
| `.dockerignore` | New file |

## How

### Implementation Details
Excludes the following from Docker build context:
- `.git` — version control history (large, unnecessary in image)
- `node_modules`, `dist`, `build` — local build artifacts
- `*.log` — log files
- `.env`, `.env.*` — secrets and environment configuration
- `.claude/`, `.claude-state/` — Claude Code session state

### Acceptance Criteria
- [x] `.dockerignore` file exists at project root
- [x] `.git` directory excluded from build context
- [x] Secret files (`.env`, `.env.*`) excluded
- [x] Build artifacts (`node_modules`, `dist`, `build`) excluded
- [x] Claude state directories excluded