### PR TITLE
feat(compose): add Linux override for host UID/GID mapping

### DIFF
--- a/docker-compose.linux.yml
+++ b/docker-compose.linux.yml
@@ -1,0 +1,13 @@
+# docker-compose.linux.yml
+# Usage: docker compose -f docker-compose.yml -f docker-compose.linux.yml up
+
+services:
+  claude-a:
+    user: "${UID}:${GID}"           # SRS-6.1.1
+    environment:
+      - HOME=/home/node             # SRS-6.1.2
+
+  claude-b:
+    user: "${UID}:${GID}"
+    environment:
+      - HOME=/home/node


### PR DESCRIPTION
## What

Add `docker-compose.linux.yml` override file that maps host UID/GID into containers, ensuring bind-mounted files have correct ownership on Linux hosts.

### Change Type
- [x] Feature (new functionality)

## Why

On Linux, Docker bind mounts preserve host UID/GID. Without explicit `user:` mapping, files created inside the container are owned by the container's `node` user (UID 1000), which may not match the host user. This causes permission errors when the host user tries to read/write files created by the container, or vice versa.

macOS/Windows don't need this because Docker Desktop transparently handles file ownership translation via VirtioFS/gRPC-FUSE.

Closes #4

## Traceability

| Layer | Reference |
|-------|-----------|
| PRD | FR-12 (P0) — cross-platform support |
| SRS | SRS-6.1.1 (UID/GID mapping), SRS-6.1.2 (HOME preservation) |
| SDS | Section 3.2 "Linux Override" |
| SC | SC-6 (cross-platform parity) |

## Where

### Files Changed
| File | Type of Change |
|------|---------------|
| `docker-compose.linux.yml` | New file |

## How

### Implementation Details
- **`user: "${UID}:${GID}"`** — maps host user identity into container (SRS-6.1.1)
- **`HOME=/home/node`** — preserves HOME so Claude config dir resolves correctly even when running as a non-default UID (SRS-6.1.2)
- Applied to both `claude-a` and `claude-b` services
- Usage: `docker compose -f docker-compose.yml -f docker-compose.linux.yml up`

### Design Decisions
- Separate override file rather than inline `user:` in base compose — keeps base compose platform-neutral (macOS/Windows work without modification)
- Only `user:` and `HOME` are overridden; all other settings inherited from base compose

### Acceptance Criteria
- [x] `docker-compose.linux.yml` exists at project root
- [x] Both services have `user: "${UID}:${GID}"` mapping
- [x] HOME environment variable set to `/home/node`
- [x] Base `docker-compose.yml` remains unchanged (no Linux-specific entries)