### PR TITLE
feat(compose): add Tier B worktree override for per-container source paths

### DIFF
--- a/docker-compose.worktree.yml
+++ b/docker-compose.worktree.yml
@@ -1,0 +1,11 @@
+# docker-compose.worktree.yml
+# Usage: docker compose -f docker-compose.yml -f docker-compose.worktree.yml up
+
+services:
+  claude-a:
+    volumes:
+      - ${PROJECT_DIR_A}:/workspace   # Replaces shared PROJECT_DIR
+
+  claude-b:
+    volumes:
+      - ${PROJECT_DIR_B}:/workspace


### PR DESCRIPTION
## What

Add `docker-compose.worktree.yml` override that replaces the shared `PROJECT_DIR` bind mount with per-container worktree paths (`PROJECT_DIR_A`, `PROJECT_DIR_B`), enabling Tier B isolated-source mode.

### Change Type
- [x] Feature (new functionality)

## Why

Tier A (base compose) mounts a single `PROJECT_DIR` into both containers — both Claude instances see the same files. For workflows requiring source isolation (e.g., parallel feature branches, conflict-free editing), Tier B gives each container its own worktree. This prevents file lock contention and allows independent git operations per container.

Closes #6

## Traceability

| Layer | Reference |
|-------|-----------|
| PRD | FR-11 (P1) — isolated source mode |
| SRS | SRS-5.4.1 ~ SRS-5.4.3 |
| SDS | Section 3.3 "Tier B — Worktree Override" |
| SC | SC-3 (volume isolation) |

## Where

### Files Changed
| File | Type of Change |
|------|---------------|
| `docker-compose.worktree.yml` | New file |

## How

### Implementation Details
- **`claude-a`**: mounts `${PROJECT_DIR_A}:/workspace` (replaces base `PROJECT_DIR`)
- **`claude-b`**: mounts `${PROJECT_DIR_B}:/workspace`
- Usage: `docker compose -f docker-compose.yml -f docker-compose.worktree.yml up`
- Can be combined with Linux override: `-f docker-compose.yml -f docker-compose.worktree.yml -f docker-compose.linux.yml`

### Design Decisions
- Separate override file keeps Tier A (shared source) as the default — users opt in to isolation
- Volume entry in the override replaces the matching mount point in the base compose (Docker Compose merge behavior)
- Variables `PROJECT_DIR_A`/`PROJECT_DIR_B` are documented in `.env.example` as "Tier B only"

### Acceptance Criteria
- [x] `docker-compose.worktree.yml` exists at project root
- [x] Each service mounts its own `PROJECT_DIR_X` to `/workspace`
- [x] Override does not modify any other service settings
- [x] Compatible with Linux override stacking