### PR TITLE
feat(scripts): add cleanup script for containers, volumes, and state

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Cleanup containers, worktrees, and state (SRS-5.5, FR-17)
+set -euo pipefail
+
+echo "=== Stopping containers ==="
+docker compose down --remove-orphans 2>/dev/null || true
+
+echo "=== Removing named volumes ==="
+docker compose down -v 2>/dev/null || true
+
+echo "=== Removing worktrees (if Tier B) ==="
+REPO_DIR="${1:-}"
+if [ -n "$REPO_DIR" ] && [ -d "$REPO_DIR/.git" ]; then
+    cd "$REPO_DIR"
+    for wt in $(git worktree list --porcelain | grep "^worktree " | awk '{print $2}'); do
+        if [ "$wt" != "$(pwd)" ]; then
+            echo "  Removing worktree: $wt"
+            git worktree remove "$wt" --force 2>/dev/null || true
+        fi
+    done
+fi
+
+echo "=== Removing state directories ==="
+read -p "Remove ~/.claude-state/*? (y/N) " confirm
+if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then
+    rm -rf "${HOME}/.claude-state"
+    echo "  State directories removed."
+else
+    echo "  Skipped."
+fi
+
+echo "=== Cleanup complete ==="


### PR DESCRIPTION
## What

Add `scripts/cleanup.sh` that tears down containers, removes named volumes, cleans up git worktrees (Tier B), and optionally removes Claude state directories.

### Change Type
- [x] Feature (new functionality)

## Why

Users need a single command to fully reset their claude-docker environment — stopping containers, removing volumes (to reclaim disk space), cleaning up worktrees, and optionally wiping Claude state. Without this, cleanup requires remembering multiple docker compose and git commands.

Closes #10

## Traceability

| Layer | Reference |
|-------|-----------|
| PRD | FR-17 (P1) — environment cleanup |
| SRS | SRS-5.5 (cleanup procedures) |
| SDS | Section 5.3 "cleanup.sh" |

## Where

### Files Changed
| File | Type of Change |
|------|---------------|
| `scripts/cleanup.sh` | New file |

## How

### Implementation Details
Script performs cleanup in four stages:

1. **Stop containers**: `docker compose down --remove-orphans`
2. **Remove named volumes**: `docker compose down -v` (removes `node_modules_a`/`node_modules_b`)
3. **Remove worktrees** (optional): if `<repo-dir>` argument provided, removes all non-primary worktrees via `git worktree remove --force`
4. **Remove state directories** (interactive): prompts before deleting `~/.claude-state/` to prevent accidental data loss

### Safety Features
- `set -euo pipefail` for strict error handling
- `2>/dev/null || true` on docker commands to handle already-stopped containers gracefully
- Interactive confirmation before deleting state directories
- Worktree cleanup only runs when repo-dir argument is provided
- Skips the primary worktree (current directory) during worktree removal

### Usage
```bash
# Basic cleanup (containers + volumes)
./scripts/cleanup.sh

# Full cleanup including worktrees
./scripts/cleanup.sh /path/to/repo
```

### Acceptance Criteria
- [x] Stops containers and removes orphans
- [x] Removes named volumes
- [x] Cleans up git worktrees when repo-dir provided
- [x] Interactive confirmation for state directory removal
- [x] Graceful handling of already-stopped containers
- [x] Strict error handling with `set -euo pipefail`