### PR TITLE
docs: add Phase 5 orchestration specifications to all design documents

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,6 +74,9 @@ The pattern extends to N accounts. Each additional instance requires:
 | 2 | 8 GB | 12 / 16 / 16 GB |
 | 3 | 12 GB | 16 / 20 / 20 GB |
 | 4 | 16 GB | 20 / 24 / 24 GB |
+| 1 manager + 2 workers + Redis | 12.3 GB | 16 / 20 / 20 GB |
+| 1 manager + 3 workers + Redis | 16.3 GB | 20 / 24 / 24 GB |
+| 1 manager + 4 workers + Redis | 20.3 GB | 24 / 28 / 28 GB |
 
 To add a third instance, add a new service to `docker-compose.yml`:
 
@@ -181,6 +184,61 @@ A 100 MB source tree adds ~100 MB, not another full clone.
 > (where `main-a` is based on `main`), then merge back.
 
 **Best for**: Both sessions actively editing and committing.
+
+## Orchestration Tier (Phase 5)
+
+For coordinated multi-agent analysis, the orchestration overlay adds a
+manager-worker pattern with Redis shared context on top of the base
+container architecture.
+
+### Architecture
+
+```
+Host
+└── Docker Compose (default bridge network)
+    ├── redis              (shared context store, redis:7-alpine)
+    ├── manager            (interactive Claude session, dispatches work)
+    ├── worker-1           (HTTP server + claude -p, port 9000)
+    ├── worker-2           (HTTP server + claude -p, port 9000)
+    ├── worker-3           (HTTP server + claude -p, port 9000)
+    └── [claude-a, claude-b from base — still available]
+```
+
+### Communication Flow
+
+```
+Manager ──HTTP POST──> Worker-N:9000/task
+                       │
+                       ├── Read context:shared from Redis
+                       ├── Read findings:all from Redis
+                       ├── Build enriched prompt (context + prior findings + task)
+                       ├── Execute claude -p
+                       ├── Parse structured JSON findings
+                       ├── Write result:{taskId} to Redis
+                       └── RPUSH findings:{category} + findings:all to Redis
+                       │
+Manager <──JSON resp── Worker-N
+```
+
+### Redis Data Model
+
+| Key Pattern | Type | Purpose |
+|-------------|------|---------|
+| `context:shared` | HASH | Project context set by manager (summary, architecture, focus areas) |
+| `findings:{category}` | LIST | Categorized findings (security, performance, architecture, ...) |
+| `findings:all` | LIST | All findings chronologically across all workers |
+| `result:{taskId}` | HASH | Per-task result (worker, raw output, structured findings, timestamp) |
+| `task:{taskId}` | HASH | Task metadata (prompt, assignee, status, timestamp) |
+| `worker:{name}:status` | STRING | Worker status with 60s TTL (idle/busy/error) |
+| `worker:{name}:heartbeat` | STRING | Heartbeat timestamp with 30s TTL |
+
+### Key Design Decisions
+
+- **HTTP over raw TCP**: `curl` and `jq` already in the image; HTTP provides framing and error codes
+- **Workers mount source `:ro`**: Workers analyze code but do not modify it
+- **Redis as context bus**: Structured findings accumulate across workers; each worker reads prior findings before processing
+- **Opt-in overlay**: Base compose unchanged; add via `-f docker-compose.orchestration.yml`
+- **No docker.sock**: All communication via bridge network; no container needs Docker API access
 
 ## Authentication Strategy
 
@@ -310,6 +368,17 @@ For 3+ instances, see [Scaling Beyond Two Instances](#scaling-beyond-two-instanc
 - [ ] Container resource limits (memory, CPU)
 - [ ] Cleanup script for worktrees and state
 
+### Phase 5 — Orchestration
+
+| Deliverable | Description |
+|-------------|-------------|
+| `docker-compose.orchestration.yml` | Redis + manager + N worker services |
+| `scripts/worker-server.js` | Node.js HTTP server with Redis context integration |
+| `scripts/manager-helpers.sh` | Bash functions for task dispatch and result aggregation |
+| `scripts/test-orchestration.sh` | E2E test for orchestration pipeline |
+| Dockerfile update | Add `redis-tools` (apt) and `redis` npm package |
+| `.env.example` update | Add orchestration environment variables |
+
 ### Phase–Requirements Traceability
 
 | Phase | Deliverables | PRD FR | SRS Spec | PRD SC |
@@ -318,6 +387,7 @@ For 3+ instances, see [Scaling Beyond Two Instances](#scaling-beyond-two-instanc
 | 2 — Account Separation | docker-compose.yml, .env.example | FR-6~9 | SRS-5.2.1~11, 5.3.1~3, 6.1~6.3 | SC-3, SC-4, SC-6 |
 | 3 — Source Sharing | Tier A/B configs, setup-worktrees.sh | FR-10~13 | SRS-5.4.1~3, 5.5 | SC-5, SC-7, SC-8 |
 | 4 — Hardening | Firewall, resource limits, cleanup.sh | FR-14~17 | SRS-7.2, 7.3, 4.4 | SC-9 |
+| 5 — Orchestration | orchestration.yml, worker-server.js, manager-helpers.sh, test-orchestration.sh | FR-18~24 | SRS-8.1~8.4 | SC-10, SC-11 |
 
 ## Comparison: Containers vs VMs
 
@@ -353,13 +423,17 @@ claude-docker/
 ├── docker-compose.linux.yml          # (Phase 2) Linux override (UID/GID, HOME)
 ├── docker-compose.worktree.yml       # (Phase 3) Tier B override
 ├── docker-compose.firewall.yml       # (Phase 4) firewall override (cap_add)
+├── docker-compose.orchestration.yml  # (Phase 5) orchestration overlay
 ├── .env.example                      # (Phase 2)
 ├── .gitignore                        # (Phase 2)
 ├── .gitattributes                    # (Phase 2) LF line endings (Windows teams)
 └── scripts/
     ├── setup-worktrees.sh            # (Phase 3, Tier B)
     ├── test-concurrent-git.sh        # (Phase 3, Tier B — E2E concurrent git test)
-    └── cleanup.sh                    # (Phase 4)
+    ├── cleanup.sh                    # (Phase 4)
+    ├── worker-server.js              # (Phase 5) worker HTTP server with Redis
+    ├── manager-helpers.sh            # (Phase 5) manager dispatch functions
+    └── test-orchestration.sh         # (Phase 5) E2E orchestration test
 ```
 
 ## References

--- a/docs/product-requirements-document.md
+++ b/docs/product-requirements-document.md
@@ -23,8 +23,8 @@ instances; scaling to more requires only a compose edit and additional RAM
 The solution supports Linux, macOS, and Windows (WSL2) with two
 configuration tiers — shared source (simplest) and git worktree (safest).
 Two authentication paths are provided: host-first OAuth for subscription
-accounts and API key for Console accounts. Implementation spans 4 phases
-over an estimated 6-10 days.
+accounts and API key for Console accounts. Implementation spans 5 phases
+over an estimated 9-15 days.
 
 ---
 
@@ -66,6 +66,8 @@ stays under 100 MB.
 | G6 | Cross-platform support | Linux, macOS, Windows (WSL2) |
 | G7 | Support subscription accounts | Host-first OAuth for Pro/Max/Team |
 | G8 | Scalable to N instances | Compose pattern extends to 3+ accounts |
+| G9 | Manager-worker orchestration | 1 manager dispatches tasks to N workers via HTTP; results aggregated via Redis |
+| G10 | Shared context accumulation | Worker N reads structured findings from workers 1..N-1 before processing |
 
 ### Non-Goals
 
@@ -185,6 +187,18 @@ Priority: **P0** = must-have, **P1** = should-have, **P2** = nice-to-have.
 | FR-16 | P2 | Container resource limits via `deploy.resources` in compose |
 | FR-17 | P2 | Cleanup script for worktrees and state (`scripts/cleanup.sh`) |
 
+### Phase 5 — Orchestration
+
+| ID | Priority | Requirement |
+|----|----------|-------------|
+| FR-18 | P0 | Redis service (`redis:7-alpine`) available on default bridge network with RDB persistence |
+| FR-19 | P0 | Worker HTTP server (Node.js) receives prompt via POST, executes `claude -p`, returns structured JSON findings |
+| FR-20 | P0 | Workers read shared context from Redis before processing and write structured findings after completion |
+| FR-21 | P0 | Manager dispatches tasks to workers via `curl` and aggregates results using `jq` |
+| FR-22 | P0 | Orchestration compose overlay (`docker-compose.orchestration.yml`) compatible with all existing overlays via `-f` flag |
+| FR-23 | P1 | Worker heartbeat and status tracking in Redis with TTL-based expiration |
+| FR-24 | P1 | E2E test script verifies parallel dispatch, Redis result storage, and findings accumulation |
+
 ---
 
 ## 7. Non-Functional Requirements
@@ -263,7 +277,13 @@ incompatible with Claude Code TTY. See [windows-docker.md](reference/windows-doc
 - **Acceptance**: Outbound limited to whitelist; review session read-only; cleanup removes state
 - **Effort**: 2-3 days | **Depends on**: Phase 3
 
-**Total estimated effort: 6-10 days**
+### Phase 5 — Orchestration
+
+- **Deliverables**: `docker-compose.orchestration.yml`, `scripts/worker-server.js`, `scripts/manager-helpers.sh`, `scripts/test-orchestration.sh`, Dockerfile update, `.env.example` update
+- **Acceptance**: Manager dispatches to 3 workers; results stored in Redis; findings accumulate across sequential worker invocations
+- **Effort**: 3–5 days | **Depends on**: Phase 1–4
+
+**Total estimated effort: 9–15 days**
 
 ---
 
@@ -280,6 +300,8 @@ incompatible with Claude Code TTY. See [windows-docker.md](reference/windows-doc
 | SC-7 | Reproducibility | New user goes from zero to two running containers in < 15 min (Linux) / < 30 min (macOS, Windows) |
 | SC-8 | Scalability | Third instance addable by copying one compose service block + creating state directory |
 | SC-9 | Security baseline | No API keys in VCS; no Docker socket mounted; state dirs owner-only |
+| SC-10 | Manager dispatches tasks to 3 workers and all return results within timeout | Phase 5 |
+| SC-11 | Worker-2 prompt includes Worker-1's findings read from Redis shared context | Phase 5 |
 
 ---
 
@@ -308,6 +330,8 @@ Forward traceability: Goal → Functional Requirement → SRS Specification → 
 | G6 (cross-platform) | — | SRS-6.1~6.3 | SC-6 | 2, 3 |
 | G7 (subscription) | FR-7 | SRS-5.3.1 | SC-4 | 2 |
 | G8 (scalable N) | — | SRS-5.5 | SC-8 | 2, 3 |
+| G9 | FR-18, FR-19, FR-21, FR-22 | SRS-8.1.1~9, SRS-8.2.1~11, SRS-8.3.1~5 | SC-10 | 5 |
+| G10 | FR-20 | SRS-8.2.3~4 | SC-11 | 5 |
 
 **Reading the table**:
 - Left to right (forward): "Goal G2 is fulfilled by FR-6/7/8, specified in SRS-5.2.5/5.2.7/5.3.1/5.3.2, and verified by SC-3/SC-4."

--- a/docs/software-design-specification.md
+++ b/docs/software-design-specification.md
@@ -44,6 +44,10 @@ docker-compose.worktree.yml   (Phase 3) ── depends on: docker-compose.yml (b
 setup-worktrees.sh            (Phase 3) ── depends on: git, project repo
 docker-compose.firewall.yml   (Phase 4) ── depends on: docker-compose.yml (base)
 cleanup.sh                    (Phase 4) ── depends on: docker, git
+docker-compose.orchestration.yml  (Phase 5) ── depends on: docker-compose.yml, Dockerfile, worker-server.js
+scripts/worker-server.js          (Phase 5) ── depends on: redis npm package, claude CLI
+scripts/manager-helpers.sh        (Phase 5) ── depends on: curl, jq, redis-cli
+scripts/test-orchestration.sh     (Phase 5) ── depends on: docker compose, all Phase 5 files
 ```
 
 ### 1.3 Design Principles
@@ -261,6 +265,167 @@ services:
 | Linux + Tier A | `docker compose -f docker-compose.yml -f docker-compose.linux.yml up` |
 | Linux + Tier B | `docker compose -f docker-compose.yml -f docker-compose.linux.yml -f docker-compose.worktree.yml up` |
 | Any + Firewall | Append `-f docker-compose.firewall.yml` |
+| Orchestration (macOS/Windows) | `docker compose -f docker-compose.yml -f docker-compose.orchestration.yml up -d` |
+| Orchestration (Linux) | `docker compose -f docker-compose.yml -f docker-compose.linux.yml -f docker-compose.orchestration.yml up -d` |
+| Orchestration + Firewall | Append both `-f docker-compose.orchestration.yml -f docker-compose.firewall.yml` |
+
+### 3.6 Orchestration Override — docker-compose.orchestration.yml (Phase 5)
+
+Manager-worker pattern with Redis shared context. Opt-in via `-f docker-compose.orchestration.yml`.
+
+```yaml
+# docker-compose.orchestration.yml
+# Phase 5: Manager-Worker orchestration with Redis shared context
+# Usage: docker compose -f docker-compose.yml -f docker-compose.orchestration.yml up -d
+# SRS-8.1.1~9
+
+services:
+  redis:
+    image: redis:7-alpine                                       # SRS-8.1.2
+    command: ["redis-server", "--save", "60", "1", "--loglevel", "notice"]
+    volumes:
+      - redis-data:/data                                        # SRS-8.1.3
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
+  manager:
+    image: claude-code-base:latest                              # SRS-8.1.4
+    depends_on:
+      redis:
+        condition: service_healthy
+    working_dir: /workspace
+    stdin_open: true
+    tty: true
+    volumes:
+      - ${PROJECT_DIR}:/workspace
+      - ${HOME}/.claude-state/account-manager:/home/node/.claude # SRS-8.1.8
+      - node_modules_manager:/workspace/node_modules
+      - ./scripts:/scripts:ro
+    environment:
+      - CLAUDE_CONFIG_DIR=/home/node/.claude
+      - NODE_OPTIONS=--max-old-space-size=4096
+      - ANTHROPIC_API_KEY=${CLAUDE_API_KEY_MANAGER:-}
+      - REDIS_URL=redis://redis:6379                            # SRS-8.1.7
+      - ROLE=manager
+      - WORKER_COUNT=${WORKER_COUNT:-3}
+    deploy:
+      resources:
+        limits:
+          cpus: "2"
+          memory: 4G
+        reservations:
+          cpus: "1"
+          memory: 2G
+    command: ["sleep", "infinity"]
+
+  worker-1:
+    image: claude-code-base:latest
+    depends_on:
+      redis:
+        condition: service_healthy
+    working_dir: /workspace
+    volumes:
+      - ${PROJECT_DIR}:/workspace:ro                            # Workers read-only
+      - ${HOME}/.claude-state/account-w1:/home/node/.claude     # SRS-8.1.8
+      - node_modules_w1:/workspace/node_modules
+      - ./scripts:/scripts:ro
+    environment:
+      - CLAUDE_CONFIG_DIR=/home/node/.claude
+      - NODE_OPTIONS=--max-old-space-size=4096
+      - ANTHROPIC_API_KEY=${CLAUDE_API_KEY_1:-}
+      - REDIS_URL=redis://redis:6379                            # SRS-8.1.7
+      - WORKER_NAME=worker-1                                    # SRS-8.1.7
+      - WORKER_PORT=9000                                        # SRS-8.1.7
+      - ROLE=worker
+    deploy:
+      resources:
+        limits:
+          cpus: "2"
+          memory: 4G
+        reservations:
+          cpus: "1"
+          memory: 2G
+    command: ["node", "/scripts/worker-server.js"]              # SRS-8.1.5
+
+  worker-2:
+    image: claude-code-base:latest
+    depends_on:
+      redis:
+        condition: service_healthy
+    working_dir: /workspace
+    volumes:
+      - ${PROJECT_DIR}:/workspace:ro
+      - ${HOME}/.claude-state/account-w2:/home/node/.claude
+      - node_modules_w2:/workspace/node_modules
+      - ./scripts:/scripts:ro
+    environment:
+      - CLAUDE_CONFIG_DIR=/home/node/.claude
+      - NODE_OPTIONS=--max-old-space-size=4096
+      - ANTHROPIC_API_KEY=${CLAUDE_API_KEY_2:-}
+      - REDIS_URL=redis://redis:6379
+      - WORKER_NAME=worker-2
+      - WORKER_PORT=9000
+      - ROLE=worker
+    deploy:
+      resources:
+        limits:
+          cpus: "2"
+          memory: 4G
+        reservations:
+          cpus: "1"
+          memory: 2G
+    command: ["node", "/scripts/worker-server.js"]
+
+  worker-3:
+    image: claude-code-base:latest
+    depends_on:
+      redis:
+        condition: service_healthy
+    working_dir: /workspace
+    volumes:
+      - ${PROJECT_DIR}:/workspace:ro
+      - ${HOME}/.claude-state/account-w3:/home/node/.claude
+      - node_modules_w3:/workspace/node_modules
+      - ./scripts:/scripts:ro
+    environment:
+      - CLAUDE_CONFIG_DIR=/home/node/.claude
+      - NODE_OPTIONS=--max-old-space-size=4096
+      - ANTHROPIC_API_KEY=${CLAUDE_API_KEY_3:-}
+      - REDIS_URL=redis://redis:6379
+      - WORKER_NAME=worker-3
+      - WORKER_PORT=9000
+      - ROLE=worker
+    deploy:
+      resources:
+        limits:
+          cpus: "2"
+          memory: 4G
+        reservations:
+          cpus: "1"
+          memory: 2G
+    command: ["node", "/scripts/worker-server.js"]
+
+volumes:
+  redis-data:
+  node_modules_manager:
+  node_modules_w1:
+  node_modules_w2:
+  node_modules_w3:
+```
+
+**Design decisions:**
+- Workers mount source as `:ro` — analysis only, no code modification
+- Scripts bind-mounted at `/scripts:ro` — no image rebuild for script changes
+- Redis healthcheck ensures workers don't start before Redis is ready
+- Each worker has its own account state and node_modules volume
+- No port exposure to host — all communication via internal bridge network
 
 ---
 
@@ -400,6 +565,127 @@ fi
 echo "=== Cleanup complete ==="
 ```
 
+### 5.3 scripts/worker-server.js (Phase 5)
+
+Node.js HTTP server that receives task prompts from the manager, enriches them with
+shared context from Redis, executes `claude -p`, and writes results back to Redis.
+Reference: SRS-8.2.1~11.
+
+**Key functions:**
+
+| Function | Purpose | SRS |
+|----------|---------|-----|
+| `connectRedis()` | Establish Redis connection using `REDIS_URL` env var; reconnect on failure | SRS-8.2.1 |
+| `readSharedContext()` | `HGETALL context:shared` — retrieve project summary, guidelines, prior findings | SRS-8.2.3 |
+| `buildEnrichedPrompt()` | Combine shared context + task-specific prompt into a single enriched prompt | SRS-8.2.4 |
+| `parseFindings()` | Extract structured findings (JSON array) from Claude's raw output | SRS-8.2.6 |
+| `executeClaude()` | Spawn `claude -p` with enriched prompt; capture stdout; enforce timeout | SRS-8.2.5 |
+| `writeResults()` | `SET result:<worker>:<taskId>` and `RPUSH findings:all` to Redis | SRS-8.2.7 |
+| `handleTask()` | HTTP POST handler: orchestrates read → build → execute → parse → write | SRS-8.2.2 |
+
+**Redis data flow:**
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Redis                                              │
+│  ┌──────────────┐  ┌──────────────┐                 │
+│  │context:shared│  │ findings:all │                 │
+│  │  (HASH)      │  │  (LIST)      │                 │
+│  └──────┬───────┘  └──────▲───────┘                 │
+│         │ HGETALL         │ RPUSH                   │
+└─────────┼─────────────────┼─────────────────────────┘
+          │                 │
+          ▼                 │
+   ┌─────────────┐  ┌──────┴──────┐
+   │ buildEnrich │  │ writeResults│
+   │ edPrompt()  │  │    ()       │
+   └──────┬──────┘  └──────▲──────┘
+          │                │
+          ▼                │
+   ┌─────────────┐  ┌──────┴──────┐
+   │executeClaude│──▶│parseFindings│
+   │    ()       │  │    ()       │
+   └─────────────┘  └─────────────┘
+```
+
+**Enriched prompt template:**
+
+```
+## Shared Context
+{context:shared fields as key-value pairs}
+
+## Prior Findings
+{findings:all entries, if any}
+
+## Your Task
+{task-specific prompt from manager}
+
+Respond with a JSON object: { "summary": "...", "findings": [...], "status": "done"|"error" }
+```
+
+**Error handling:**
+- **Timeout**: `executeClaude()` enforces a configurable timeout (default 300s); on timeout, writes error result to Redis and returns HTTP 504 (SRS-8.2.8)
+- **JSON parse failure**: If Claude output is not valid JSON, `parseFindings()` wraps raw text in a fallback structure (SRS-8.2.9)
+- **Redis connection error**: `connectRedis()` retries with exponential backoff (max 5 attempts); server returns HTTP 503 until connected (SRS-8.2.10)
+- **Worker status**: Periodically writes heartbeat to `SET status:<worker> "{state, lastTask, timestamp}"` (SRS-8.2.11)
+
+### 5.4 scripts/manager-helpers.sh (Phase 5)
+
+Bash helper functions sourced by the manager to dispatch tasks and query state.
+Reference: SRS-8.3.1~5.
+
+```bash
+#!/usr/bin/env bash
+# Manager helper functions for orchestration (SRS-8.3.1~5)
+# Usage: source /scripts/manager-helpers.sh
+
+# SRS-8.3.1: Dispatch a task to a specific worker
+# Args: $1 = worker name (e.g., worker-1), $2 = prompt text
+dispatch_task() {
+    local worker="$1" prompt="$2"
+    local payload
+    payload=$(jq -n --arg p "$prompt" '{"prompt": $p}')
+    curl -s -X POST "http://${worker}:9000/task" \
+        -H "Content-Type: application/json" \
+        -d "$payload"
+}
+
+# SRS-8.3.2: Dispatch same prompt to all workers in parallel
+# Args: $1 = prompt text (or unique prompts via stdin, one per line)
+dispatch_parallel() {
+    local prompt="$1"
+    local pids=() tmpfiles=()
+    for i in 1 2 3; do
+        local tmp
+        tmp=$(mktemp)
+        tmpfiles+=("$tmp")
+        dispatch_task "worker-$i" "$prompt" > "$tmp" 2>&1 &
+        pids+=($!)
+    done
+    for pid in "${pids[@]}"; do wait "$pid"; done
+    for tmp in "${tmpfiles[@]}"; do cat "$tmp"; rm -f "$tmp"; done
+}
+
+# SRS-8.3.3: Retrieve all findings from Redis
+get_findings() {
+    redis-cli -u "$REDIS_URL" LRANGE findings:all 0 -1
+}
+
+# SRS-8.3.4: Get status of all workers
+get_worker_status() {
+    for i in 1 2 3; do
+        echo "worker-$i: $(redis-cli -u "$REDIS_URL" GET "status:worker-$i")"
+    done
+}
+
+# SRS-8.3.5: Set shared context for all workers
+# Args: $1 = field name, $2 = value
+set_shared_context() {
+    local field="$1" value="$2"
+    redis-cli -u "$REDIS_URL" HSET context:shared "$field" "$value"
+}
+```
+
 ---
 
 ## 6. Operational Flows
@@ -499,6 +785,38 @@ Bind mount not working
     └── Windows → Move source to WSL2 filesystem
 ```
 
+### 6.6 Orchestration First Run (Phase 5)
+
+```
+Host                                    Docker
+─────                                   ──────
+1. mkdir -p ~/.claude-state/account-{manager,w1,w2,w3}
+2. Authenticate each account:
+   Path A (OAuth):
+     CLAUDE_CONFIG_DIR=~/.claude-state/account-manager claude auth login
+     CLAUDE_CONFIG_DIR=~/.claude-state/account-w1 claude auth login
+     CLAUDE_CONFIG_DIR=~/.claude-state/account-w2 claude auth login
+     CLAUDE_CONFIG_DIR=~/.claude-state/account-w3 claude auth login
+   Path B (API key):
+     Add CLAUDE_API_KEY_MANAGER, CLAUDE_API_KEY_1~3 to .env
+3. Configure .env with orchestration variables:
+     WORKER_COUNT=3
+4.                                      docker compose -f docker-compose.yml \
+                                          -f docker-compose.orchestration.yml build
+5.                                      docker compose -f docker-compose.yml \
+                                          -f docker-compose.orchestration.yml up -d
+6.                                      docker compose -f docker-compose.yml \
+                                          -f docker-compose.orchestration.yml \
+                                          exec manager bash
+7. source /scripts/manager-helpers.sh
+8. set_shared_context "project_summary" "Description of the project..."
+9. dispatch_task worker-1 "analyze auth module"
+   dispatch_task worker-2 "analyze database layer"
+   dispatch_task worker-3 "analyze API routes"
+10. get_findings
+    └─ Returns combined findings from all workers
+```
+
 ---
 
 ## 7. SRS Traceability
@@ -520,6 +838,10 @@ Bind mount not working
 | SRS-7.3 (Security/Firewall) | 3.4 Firewall Override | `docker-compose.firewall.yml` |
 | SRS-4.4 (Volume Matrix) | 3.1~3.3 all compose files | `docker-compose*.yml` |
 | SRS-4.5 (.env Format) | 4.1 .env.example | `.env.example` |
+| SRS-8.1.1~9 (Orchestration Compose) | 3.6 Orchestration Override | `docker-compose.orchestration.yml` |
+| SRS-8.2.1~11 (Worker Server) | 5.3 Worker Server | `scripts/worker-server.js` |
+| SRS-8.3.1~5 (Manager Helpers) | 5.4 Manager Helpers | `scripts/manager-helpers.sh` |
+| SRS-8.4.1~5 (Orchestration Tests) | 5.3 (test section) | `scripts/test-orchestration.sh` |
 
 ### Deliverable File Inventory
 
@@ -537,3 +859,7 @@ Bind mount not working
 | `scripts/setup-worktrees.sh` | 3 | SRS-5.4.2 |
 | `scripts/test-concurrent-git.sh` | 3 | SRS-5.4.2 (verification) |
 | `scripts/cleanup.sh` | 4 | SRS-5.5 (FR-17) |
+| `docker-compose.orchestration.yml` | 5 | SRS-8.1.1~9 |
+| `scripts/worker-server.js` | 5 | SRS-8.2.1~11 |
+| `scripts/manager-helpers.sh` | 5 | SRS-8.3.1~5 |
+| `scripts/test-orchestration.sh` | 5 | SRS-8.4.1~5 |

--- a/docs/software-requirements-specification.md
+++ b/docs/software-requirements-specification.md
@@ -98,6 +98,9 @@ The system exposes no GUI. All interaction is through:
 | Container → Internet | registry.npmjs.org | HTTPS | 443 | Package installation |
 | Container → Internet | github.com | HTTPS/SSH | 443/22 | Git operations |
 | Host → Container | N/A | docker exec | N/A | Shell access |
+| Manager → Worker | `http://worker-N:9000/task` | HTTP POST | 9000 | Task dispatch with prompt and timeout |
+| Worker ↔ Redis | `redis://redis:6379` | TCP | 6379 | Shared context read/write, findings, status |
+| Manager → Redis | `redis://redis:6379` | TCP | 6379 | Context initialization, findings aggregation |
 
 No inbound ports are exposed from containers to the host.
 
@@ -122,6 +125,11 @@ Variables marked **`.env`** are set in the `.env` file.
 | `UID` | .env | Linux only | `$(id -u)` | Integer | Host user ID |
 | `GID` | .env | Linux only | `$(id -g)` | Integer | Host group ID |
 | `CLAUDE_CODE_VERSION` | Dockerfile ARG | No | latest | Semver | Build-time version pin |
+| `REDIS_URL` | compose | Phase 5 only | `redis://redis:6379` | URL | Redis connection URL (SRS-8.1.7) |
+| `WORKER_NAME` | compose | Phase 5 only | `worker-1` | String | Worker identifier for Redis keys and logging (SRS-8.1.7) |
+| `WORKER_PORT` | compose | Phase 5 only | `9000` | Integer | HTTP server listen port (SRS-8.1.7) |
+| `ROLE` | compose | Phase 5 only | — | `manager` or `worker` | Container role designation (SRS-8.1.7) |
+| `WORKER_COUNT` | compose | Phase 5 only | `3` | Integer | Number of worker containers (SRS-8.3.2) |
 
 ### 4.2 Credential File Schema
 
@@ -177,6 +185,8 @@ bind-mounted to `/home/node/.claude` inside the container.
 | Source (read-only) | `${PROJECT_DIR}` | `/workspace` | bind | ro | `:z` |
 | Account state | `${HOME}/.claude-state/account-X` | `/home/node/.claude` | bind | rw | `:Z` |
 | Dependencies | `node_modules_X` | `/workspace/node_modules` | named | rw | N/A |
+| Redis data | `redis-data` | `/data` (Redis) | named | rw | N/A |
+| Scripts (read-only) | `./scripts` | `/scripts` (orchestration) | bind | ro | N/A |
 
 - SELinux flags apply only to RHEL/CentOS/Fedora. Other platforms omit them.
 - Named volumes are Docker-managed; no host path.
@@ -373,16 +383,70 @@ is identical; only `.env` values and optional compose overrides differ.
 
 ---
 
-## 8. Constraints and Assumptions
+## 8. Orchestration Specifications
 
-### 8.1 Technology Constraints
+### 8.1 Orchestration Compose (`docker-compose.orchestration.yml`)
+
+| Spec | Priority | Requirement |
+|------|----------|-------------|
+| SRS-8.1.1 | SHALL | Orchestration overlay SHALL define `redis`, `manager`, `worker-1`, `worker-2`, `worker-3` services |
+| SRS-8.1.2 | SHALL | Redis service SHALL use `redis:7-alpine` image with 256 MB memory limit |
+| SRS-8.1.3 | SHALL | Redis service SHALL persist data via RDB snapshot to named volume `redis-data` |
+| SRS-8.1.4 | SHALL | Manager service SHALL use `claude-code-base:latest` with `sleep infinity` command |
+| SRS-8.1.5 | SHALL | Worker services SHALL run `node /scripts/worker-server.js` as entry command |
+| SRS-8.1.6 | SHALL | All services SHALL communicate via Docker Compose default bridge network using service name DNS |
+| SRS-8.1.7 | SHALL | Each service SHALL receive `REDIS_URL`, `WORKER_NAME`, `WORKER_PORT`, and `ROLE` environment variables |
+| SRS-8.1.8 | SHALL | Each worker and manager SHALL mount its own dedicated account state directory |
+| SRS-8.1.9 | SHALL | The overlay SHALL NOT modify the base `docker-compose.yml` services |
+
+### 8.2 Worker Server (`scripts/worker-server.js`)
+
+| Spec | Priority | Requirement |
+|------|----------|-------------|
+| SRS-8.2.1 | SHALL | Worker server SHALL expose HTTP POST `/task` endpoint on configurable port (default 9000) |
+| SRS-8.2.2 | SHALL | Worker server SHALL accept JSON body `{taskId, prompt, timeout}` |
+| SRS-8.2.3 | SHALL | Before executing `claude -p`, worker SHALL read `context:shared` hash from Redis |
+| SRS-8.2.4 | SHALL | Before executing `claude -p`, worker SHALL read `findings:all` list from Redis |
+| SRS-8.2.5 | SHALL | Worker SHALL execute `claude -p` with configurable timeout via `child_process.execSync` |
+| SRS-8.2.6 | SHALL | Worker SHALL parse structured JSON findings block from Claude output |
+| SRS-8.2.7 | SHALL | Worker SHALL write `result:{taskId}` hash and RPUSH findings to Redis |
+| SRS-8.2.8 | SHALL | Worker SHALL maintain `worker:{name}:status` key with TTL 60s |
+| SRS-8.2.9 | SHALL | Worker SHALL maintain `worker:{name}:heartbeat` key with TTL 30s |
+| SRS-8.2.10 | SHALL | Worker SHALL respond with JSON `{status, taskId, output, findings}` |
+| SRS-8.2.11 | SHALL | Worker server SHALL use the `redis` npm package for Redis communication |
+
+### 8.3 Manager Helpers (`scripts/manager-helpers.sh`)
+
+| Spec | Priority | Requirement |
+|------|----------|-------------|
+| SRS-8.3.1 | SHALL | Manager helpers SHALL provide `dispatch_task` function sending HTTP POST via `curl` |
+| SRS-8.3.2 | SHALL | Manager helpers SHALL provide `dispatch_parallel` function sending to all workers concurrently |
+| SRS-8.3.3 | SHALL | Manager helpers SHALL provide `get_findings` function reading findings from Redis via `redis-cli` |
+| SRS-8.3.4 | SHALL | Manager helpers SHALL provide `get_worker_status` function checking all worker statuses |
+| SRS-8.3.5 | SHALL | All helper functions SHALL use `set -euo pipefail` and return proper exit codes |
+
+### 8.4 Orchestration Testing (`scripts/test-orchestration.sh`)
+
+| Spec | Priority | Requirement |
+|------|----------|-------------|
+| SRS-8.4.1 | SHALL | E2E test SHALL start Redis, manager, and 3 workers via compose overlay |
+| SRS-8.4.2 | SHALL | E2E test SHALL dispatch 3 distinct tasks to 3 workers sequentially |
+| SRS-8.4.3 | SHALL | E2E test SHALL verify results stored in Redis `result:{taskId}` hashes |
+| SRS-8.4.4 | SHALL | E2E test SHALL verify findings accumulation (later workers see earlier findings) |
+| SRS-8.4.5 | SHALL | E2E test SHALL use `trap cleanup EXIT` for reliable teardown |
+
+---
+
+## 9. Constraints and Assumptions
+
+### 9.1 Technology Constraints
 
 - Alpine Linux base images are NOT supported (musl incompatible with Claude Code).
 - Interactive CLI commands (`vim`, `git rebase -i`) are NOT supported inside Claude Code's shell tool (GitHub #26353).
 - Docker-in-Docker is NOT used. Containers do not manage other containers.
 - `docker compose` V2 (Go binary, space-separated) is required. Legacy `docker-compose` V1 (Python, hyphenated) is not tested.
 
-### 8.2 Assumptions
+### 9.2 Assumptions
 
 - Host has internet access for initial image build and Claude API communication.
 - For Path A, the host has a browser for OAuth login.
@@ -391,9 +455,9 @@ is identical; only `.env` values and optional compose overrides differ.
 
 ---
 
-## 9. Verification and Traceability
+## 10. Verification and Traceability
 
-### 9.1 Upstream Traceability (SRS → PRD)
+### 10.1 Upstream Traceability (SRS → PRD)
 
 Each SRS functional section traces back to PRD Goals and Functional Requirements.
 
@@ -408,8 +472,9 @@ Each SRS functional section traces back to PRD Goals and Functional Requirements
 | 6.2 macOS Adaptation | SRS-6.2.1~4 | — | G6 | 2 |
 | 6.3 Windows Adaptation | SRS-6.3.1~6 | — | G6 | 2 |
 | 7.3 Security | SRS-7.3 | FR-14 | G5 | 4 |
+| 8.1~8.4 Orchestration | SRS-8.1~8.4 | FR-18~24 | G9, G10 | 5 |
 
-### 9.2 Downstream Verification (PRD FR → SRS → Test)
+### 10.2 Downstream Verification (PRD FR → SRS → Test)
 
 Each PRD Functional Requirement (FR) maps to an SRS specification and
 a test procedure.
@@ -433,3 +498,10 @@ a test procedure.
 | FR-15 (read-only mount) | SRS-4.4 | Start container with `:ro` on project volume; verify write operations fail inside container |
 | FR-16 (resource limits) | SRS-7.2 | Add `deploy.resources` to compose; verify `docker stats` shows enforced limits |
 | FR-17 (cleanup script) | SRS-5.5 | Run `scripts/cleanup.sh`; verify worktrees removed and state directories cleaned |
+| FR-18 (Redis service) | SRS-8.1.2~3 | Redis service starts with healthcheck; `redis-cli ping` returns PONG |
+| FR-19 (worker task endpoint) | SRS-8.2.1~6 | POST to worker-N:9000/task returns JSON with status and findings |
+| FR-20 (findings accumulation) | SRS-8.2.3~4, 8.2.7 | Worker-2 prompt contains Worker-1's findings from Redis |
+| FR-21 (manager dispatch) | SRS-8.3.1~2 | `dispatch_task` and `dispatch_parallel` return worker responses |
+| FR-22 (overlay compatibility) | SRS-8.1.9 | `docker compose -f ... -f docker-compose.orchestration.yml config` validates |
+| FR-23 (worker status) | SRS-8.2.8~9 | `redis-cli GET worker:worker-1:status` returns current status |
+| FR-24 (E2E test) | SRS-8.4.1~5 | `test-orchestration.sh` exits with code 0 |


### PR DESCRIPTION
## What

Add Phase 5 (Manager-Worker Orchestration with Redis) specifications to all four design documents.

### Change Type
- [x] Documentation

## Why

Phase 5 introduces a manager-worker orchestration layer with Redis shared context. Design documents must be updated before implementation to maintain the PRD → SRS → SDS traceability chain.

## Where

| File | Changes |
|------|---------|
| `docs/product-requirements-document.md` | +30 lines: G9-G10, FR-18~24, SC-10~11, Phase 5 milestone |
| `docs/software-requirements-specification.md` | +84 lines: New §8 (30 specs), interfaces, env vars |
| `docs/software-design-specification.md` | +326 lines: §3.6 Compose, §5.3 Worker Server, §5.4 Helpers |
| `docs/architecture.md` | +76 lines: Orchestration Tier, Redis data model, resources |

## How

### New Specifications
- **Goals**: G9 (orchestration), G10 (shared context)
- **FRs**: FR-18~FR-24 (7 new requirements)
- **SRS**: 30 testable specs (SRS-8.1.1~8.4.5)
- **SC**: SC-10 (3-worker dispatch), SC-11 (findings accumulation)

### Cross-Document Consistency Verified
All references consistent across 4 documents. No Phase 1-4 content modified.