### PR TITLE
docs: fix PRD executive summary to reflect Phase 6

### DIFF
--- a/docs/product-requirements-document.md
+++ b/docs/product-requirements-document.md
@@ -23,8 +23,8 @@ instances; scaling to more requires only a compose edit and additional RAM
 The solution supports Linux, macOS, and Windows (WSL2) with two
 configuration tiers — shared source (simplest) and git worktree (safest).
 Two authentication paths are provided: host-first OAuth for subscription
-accounts and API key for Console accounts. Implementation spans 5 phases
-over an estimated 9-15 days.
+accounts and API key for Console accounts. Implementation spans 6 phases
+over an estimated 10-17 days.
 
 ---
 


### PR DESCRIPTION
## Summary

Fix PRD executive summary: "5 phases, 9-15 days" → "6 phases, 10-17 days" to reflect Phase 6 Cold Memory addition.

## Test plan

- [x] Line 26-27 says "6 phases" and "10-17 days"
- [x] Matches Phase 6 milestone total in Section 10