### PR TITLE
feat(compose): add archive bind mount for cold memory layer

### DIFF
--- a/docker-compose.orchestration.yml
+++ b/docker-compose.orchestration.yml
@@ -32,6 +32,7 @@ services:
       - ${HOME}/.claude-state/account-manager:/home/node/.claude # SRS-8.1.8
       - node_modules_manager:/workspace/node_modules
       - ./scripts:/scripts:ro                                   # SRS-8.1.5
+      - ${HOME}/.claude-state/analysis-archive:/archive          # SRS-8.5.1
     environment:
       - CLAUDE_CONFIG_DIR=/home/node/.claude
       - NODE_OPTIONS=--max-old-space-size=4096
@@ -39,6 +40,7 @@ services:
       - REDIS_URL=redis://redis:6379                            # SRS-8.1.7
       - ROLE=manager
       - WORKER_COUNT=${WORKER_COUNT:-3}
+      - ARCHIVE_DIR=/archive                                     # SRS-8.5.2
     deploy:
       resources:
         limits:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -437,6 +437,7 @@ create_state_dirs() {
             "$HOME/.claude-state/account-w1"
             "$HOME/.claude-state/account-w2"
             "$HOME/.claude-state/account-w3"
+            "$HOME/.claude-state/analysis-archive/sessions"
         )
     fi
 


### PR DESCRIPTION
## Summary

- Add `/archive` bind mount to manager service in orchestration compose overlay (SRS-8.5.1)
- Add `ARCHIVE_DIR=/archive` environment variable to manager (SRS-8.5.2)
- Add `analysis-archive/sessions` directory creation to `install.sh`
- Workers are excluded from archive mount per SRS-8.5.11

## Traceability

| Layer | Reference |
|-------|-----------|
| **PRD** | FR-25 (partial), FR-29 |
| **SRS** | SRS-8.5.1, SRS-8.5.2, SRS-8.5.11, SRS-8.5.15 |
| **SDS** | Section 5.6.4 |
| **SC** | SC-13 |

## Test Plan

- [ ] `docker compose -f docker-compose.yml -f docker-compose.orchestration.yml config` validates
- [ ] Manager service has `/archive` bind mount
- [ ] Workers do NOT have `/archive` mount
- [ ] `install.sh` creates `~/.claude-state/analysis-archive/sessions/`

Closes #59