### PR TITLE
chore(scripts): update cleanup.sh and README for cold memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,33 @@ docker compose \
   up -d
 ```
 
+### Session Archive (Cold Memory)
+
+Save and restore analysis sessions across container restarts:
+
+```bash
+# Inside manager container:
+source /scripts/manager-helpers.sh
+
+# Save current session to archive
+save_session
+
+# List all archived sessions
+list_sessions
+
+# Restore previous session's context and findings
+restore_session latest
+# or by specific ID:
+restore_session 20260328T143000Z_a1b2c3d4
+
+# View detailed session info
+show_session 20260328T143000Z_a1b2c3d4
+```
+
+Sessions persist in `~/.claude-state/analysis-archive/` on the host and survive
+`docker compose down -v`. Maximum 50 sessions are retained; oldest are pruned
+automatically.
+
 ## Troubleshooting
 
 **"Authentication expired" inside container:**

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -20,6 +20,17 @@ if [ -n "$REPO_DIR" ] && [ -d "$REPO_DIR/.git" ]; then
     done
 fi
 
+echo "=== Preserving analysis archive ==="
+if [ -d "${HOME}/.claude-state/analysis-archive" ]; then
+    read -p "Remove analysis archive (~/.claude-state/analysis-archive)? (y/N) " confirm_archive
+    if [ "$confirm_archive" = "y" ] || [ "$confirm_archive" = "Y" ]; then
+        rm -rf "${HOME}/.claude-state/analysis-archive"
+        echo "  Analysis archive removed."
+    else
+        echo "  Analysis archive preserved."
+    fi
+fi
+
 echo "=== Removing state directories ==="
 read -p "Remove ~/.claude-state/*? (y/N) " confirm
 if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then


### PR DESCRIPTION
## Summary

- Update `scripts/cleanup.sh` to preserve archive directory during cleanup (SRS-8.5.15)
- Add session archive usage documentation to `README.md` covering save, restore, list, and show commands
- Final issue in Phase 6 Cold Memory Layer epic

## Traceability

| Layer | Reference |
|-------|-----------|
| **PRD** | FR-29 (archive persistence across cleanup) |
| **SRS** | SRS-8.5.10 (cleanup preserves archive), SRS-8.5.15 (persist across down -v) |

## Test Plan

- [ ] `cleanup.sh` does not remove `~/.claude-state/analysis-archive/`
- [ ] README documents `save_session`, `restore_session`, `list_sessions`, `show_session`
- [ ] Existing cleanup functionality unaffected

Closes #64