### PR TITLE
docs: replace host-first OAuth with container-internal auth model

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ per VM) by sharing a single Docker image and bind-mounting the project source.
 - **Multi-account isolation** -- Each container has its own credentials, settings, and history
 - **Shared source code** -- Bind mount (Tier A) or git worktree (Tier B) for concurrent editing
 - **Cross-platform** -- Linux, macOS, Windows (WSL2)
-- **Subscription + API key** -- Host-first OAuth for Pro/Max/Team, or `ANTHROPIC_API_KEY` for Console
+- **Subscription + API key** -- OAuth for Pro/Max/Team (via container), or `ANTHROPIC_API_KEY` for Console
 - **Scalable to N instances** -- Add accounts by copying a compose service block
 
 ## Prerequisites
 
 - [Docker Engine](https://docs.docker.com/engine/install/) 24.0+ (Linux) or [Docker Desktop](https://www.docker.com/products/docker-desktop/) (macOS / Windows)
-- [Node.js](https://nodejs.org/) 20+ (for host-side authentication only)
+- [Node.js](https://nodejs.org/) 20+ (optional -- only needed if running Claude Code on host)
 - Git
 
 **Platform-specific:**
@@ -64,15 +64,14 @@ Choose your authentication path:
 **Path A -- Subscription accounts (Pro / Max / Team):**
 
 ```bash
-# Install Claude Code on the host
-npm install -g @anthropic-ai/claude-code
-
 # Create state directories
 mkdir -p ~/.claude-state/account-a ~/.claude-state/account-b
 
-# Authenticate each account (browser opens)
-CLAUDE_CONFIG_DIR=~/.claude-state/account-a claude auth login
-CLAUDE_CONFIG_DIR=~/.claude-state/account-b claude auth login
+# Authentication happens inside containers on first launch.
+# After starting containers (step 3-4), run:
+#   scripts/claude-docker claude
+# Claude Code will prompt for OAuth login in your browser.
+# Credentials persist in the bind-mounted state directory.
 ```
 
 **Path B -- Console API keys:**
@@ -307,8 +306,9 @@ docker compose -f docker-compose.yml -f docker-compose.worktree.yml up -d
 # 1. Create state directory
 mkdir -p ~/.claude-state/account-c
 
-# 2. Authenticate (Path A)
-CLAUDE_CONFIG_DIR=~/.claude-state/account-c claude auth login
+# 2. Authenticate (Path A) -- start the container and run:
+#    scripts/claude-docker claude
+#    OAuth login will open in your browser.
 
 # 3. Copy a service block in docker-compose.yml:
 #    claude-b → claude-c (rename account-b → account-c, _B → _C)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,8 +97,8 @@ To add a third instance, add a new service to `docker-compose.yml`:
 ```
 
 And add `node_modules_c:` to the `volumes:` section. For subscription
-accounts (Path A), authenticate on the host first:
-`CLAUDE_CONFIG_DIR=~/.claude-state/account-c claude auth login`
+accounts (Path A), authenticate inside the container on first launch:
+`docker compose exec claude-c claude auth login`
 
 > The default templates ship with 2 instances. Adding more is a manual
 > compose edit — there is no dynamic scaling mechanism.
@@ -245,26 +245,27 @@ Manager <──JSON resp── Worker-N
 Two authentication paths, each primary for its account type.
 Choose based on what kind of Anthropic account you have.
 
-### Path A: Subscription Accounts (Pro / Max / Team) — Host-First OAuth
+### Path A: Subscription Accounts (Pro / Max / Team) — Container-Internal OAuth
 
-Subscription accounts use OAuth. Since OAuth requires a browser, **authenticate
-on the host first**, then mount the credentials into the container.
+Subscription accounts use OAuth. Since the container runs headless, **authenticate
+inside the container on first launch**, then credentials persist in the bind-mounted
+state directory.
 
 ```bash
-# 1. Install Claude Code on the host (if not already)
-npm install -g @anthropic-ai/claude-code
+# 1. Start the containers
+docker compose up -d
 
-# 2. Authenticate each account on the host
-CLAUDE_CONFIG_DIR=~/.claude-state/account-a claude auth login   # → browser opens
-CLAUDE_CONFIG_DIR=~/.claude-state/account-b claude auth login   # → browser opens
+# 2. Authenticate each account inside its container
+docker compose exec claude-a claude auth login   # → prints URL to visit
+docker compose exec claude-b claude auth login   # → prints URL to visit
 
 # 3. Verify
-CLAUDE_CONFIG_DIR=~/.claude-state/account-a claude auth status
-CLAUDE_CONFIG_DIR=~/.claude-state/account-b claude auth status
+docker compose exec claude-a claude auth status
+docker compose exec claude-b claude auth status
 ```
 
 Each state directory now contains `.credentials.json` with OAuth tokens.
-The containers bind-mount these directories, inheriting the authenticated state.
+The bind-mounted state directories persist credentials across container restarts.
 
 ```bash
 # .env (never committed)
@@ -274,12 +275,12 @@ PROJECT_DIR=/path/to/your/project
 > **Token refresh**: Claude Code automatically refreshes tokens using the
 > `refreshToken` in `.credentials.json`. If a token expires beyond refresh
 > (e.g., password change, account revocation), re-run `claude auth login`
-> on the host with the corresponding `CLAUDE_CONFIG_DIR`.
+> inside the corresponding container.
 
-> **Why host-first**: Running OAuth inside a headless container fails
-> (GitHub #34917). Authenticating on the host, where a browser is available,
-> avoids this entirely. The bind mount makes the host's credential the
-> single source of truth, also mitigating persistence issues (#22066, #1736).
+> **Why container-internal**: On macOS, host auth stores tokens in Keychain
+> which cannot be bind-mounted. Container-internal auth stores
+> `.credentials.json` in the bind-mounted state directory, persisting
+> across restarts on all platforms.
 > See [reference/claude-code-container.md](reference/claude-code-container.md#oauth-token-persistence) for details.
 
 ### Path B: Console API Keys — Environment Variable
@@ -302,8 +303,8 @@ it takes precedence over OAuth credentials in the mounted state directory.
 | | Path A: Subscription | Path B: API Key |
 |---|---|---|
 | Account type | Pro, Max, Team | Console (usage-based) |
-| Auth method | OAuth (host-first) | Environment variable |
-| Browser needed | Once per account, on host | Never |
+| Auth method | OAuth (container-internal) | Environment variable |
+| Browser needed | Once per account, on any device | Never |
 | Token management | Auto-refresh; re-auth on revocation | Manual key rotation |
 | Container restart | Credentials persist via bind mount | Always available via `.env` |
 | Billing | Included in subscription | Separate usage-based |

--- a/docs/product-requirements-document.md
+++ b/docs/product-requirements-document.md
@@ -22,7 +22,7 @@ instances; scaling to more requires only a compose edit and additional RAM
 
 The solution supports Linux, macOS, and Windows (WSL2) with two
 configuration tiers — shared source (simplest) and git worktree (safest).
-Two authentication paths are provided: host-first OAuth for subscription
+Two authentication paths are provided: container-internal OAuth for subscription
 accounts and API key for Console accounts. Implementation spans 6 phases
 over an estimated 10-17 days.
 
@@ -64,7 +64,7 @@ stays under 100 MB.
 | G4 | Concurrent access stability | Tier B eliminates lock contention |
 | G5 | Simple and reproducible setup | `docker compose up` on all 3 platforms |
 | G6 | Cross-platform support | Linux, macOS, Windows (WSL2) |
-| G7 | Support subscription accounts | Host-first OAuth for Pro/Max/Team |
+| G7 | Support subscription accounts | Container-internal OAuth for Pro/Max/Team |
 | G8 | Scalable to N instances | Compose pattern extends to 3+ accounts |
 | G9 | Manager-worker orchestration | 1 manager dispatches tasks to N workers via HTTP; results aggregated via Redis |
 | G10 | Shared context accumulation | Worker N reads structured findings from workers 1..N-1 before processing |
@@ -165,7 +165,7 @@ Priority: **P0** = must-have, **P1** = should-have, **P2** = nice-to-have.
 | ID | Priority | Requirement |
 |----|----------|-------------|
 | FR-6 | P0 | Each container mounts a separate `CLAUDE_CONFIG_DIR` from host `~/.claude-state/account-{a,b}/` |
-| FR-7 | P0 | Auth Path A: host-first OAuth for subscription accounts — `claude auth login` on host, bind mount credentials |
+| FR-7 | P0 | Auth Path A: container-internal OAuth for subscription accounts — user authenticates inside container on first launch; credentials stored in bind-mounted state directory |
 | FR-8 | P0 | Auth Path B: `ANTHROPIC_API_KEY` env var for Console accounts |
 | FR-9 | P0 | `.env.example` with `PROJECT_DIR` (and API key vars for Path B users) |
 
@@ -219,7 +219,7 @@ Priority: **P0** = must-have, **P1** = should-have, **P2** = nice-to-have.
 | **Resources** | Host RAM: 12 GB (Linux), 16 GB (macOS/Windows). 4 GB heap per container. 4+ CPU cores. 2 GB free disk. | [architecture.md](architecture.md) |
 | **Security** | API keys via `.env` only. No Docker socket mounting. State dirs mode 0700. Optional firewall whitelist. | [claude-code-container.md](reference/claude-code-container.md) |
 | **Portability** | Identical `docker-compose.yml` on all platforms; only `.env` values and Linux `user:` field differ. | [cross-platform.md](cross-platform.md) |
-| **Reliability** | Two primary auth paths: host-first OAuth (subscriptions) and API key (Console). Both are production-grade with documented recovery procedures. | [claude-code-container.md](reference/claude-code-container.md) |
+| **Reliability** | Two primary auth paths: container-internal OAuth (subscriptions) and API key (Console). Both are production-grade with documented recovery procedures. | [claude-code-container.md](reference/claude-code-container.md) |
 
 ---
 
@@ -252,7 +252,7 @@ incompatible with Claude Code TTY. See [windows-docker.md](reference/windows-doc
 | # | Risk | Likelihood | Impact | Mitigation |
 |---|------|-----------|--------|------------|
 | R1 | Concurrent file corruption (Tier A) | High (if both write) | High | Use Tier B (worktrees) |
-| R2 | OAuth token expiry beyond refresh | Low | Medium | Host-first auth; re-run `claude auth login` on host to recover |
+| R2 | OAuth token expiry beyond refresh | Low | Medium | Container-internal auth; re-run `claude auth login` inside container to recover |
 | R3 | macOS bind mount slowness | Certain | Low-Medium | Named volumes for `node_modules`; document OrbStack |
 | R4 | Windows NTFS path performance | High (if misconfigured) | High | Document WSL2 fs requirement prominently |
 | R5 | UID/GID mismatch on Linux | Medium | Medium | `user:` field + `HOME=/home/node` in compose |
@@ -310,7 +310,7 @@ incompatible with Claude Code TTY. See [windows-docker.md](reference/windows-doc
 | SC-1 | Storage efficiency | Each additional instance adds <= 70 MB disk overhead |
 | SC-2 | Startup time | All containers reach Claude Code prompt within 30s of `docker compose up` |
 | SC-3 | Account isolation | Each container's history, credentials, and settings are fully independent |
-| SC-4 | Subscription auth | Host-first OAuth tokens persist across container restarts via bind mount |
+| SC-4 | Subscription auth | Container-internal OAuth tokens persist across container restarts via bind mount |
 | SC-5 | Concurrent safety (Tier B) | Two containers commit to different branches without errors |
 | SC-6 | Cross-platform parity | Same compose file works on Linux, macOS, and Windows (WSL2) |
 | SC-7 | Reproducibility | New user goes from zero to two running containers in < 15 min (Linux) / < 30 min (macOS, Windows) |
@@ -328,7 +328,7 @@ incompatible with Claude Code TTY. See [windows-docker.md](reference/windows-doc
 1. **Pre-built image**: Should we publish to Docker Hub / GHCR, or require local builds only? Trade-off: convenience vs version pinning and license compliance.
 2. **Default tier**: Should Tier B (worktree) be the default compose config? Tier A is simpler for first-run; Tier B is safer for real use.
 3. **Upgrade path**: Rebuild image on new Claude Code release, or support in-place `npm update -g` inside running containers?
-4. **OAuth token refresh monitoring**: Should the setup include a health check that detects expired tokens and alerts the user to re-authenticate on the host?
+4. **OAuth token refresh monitoring**: Should the setup include a health check that detects expired tokens and alerts the user to re-authenticate inside the container?
 5. **Firewall default**: Should Phase 4 firewall be opt-in or opt-out?
 6. **Future scope**: Is there a need for a third container role (e.g., shared MCP server or language server)?
 

--- a/docs/reference/claude-code-container.md
+++ b/docs/reference/claude-code-container.md
@@ -112,14 +112,15 @@ The `CLAUDE_CONFIG_DIR` environment variable overrides the default
 
 | | Subscription (Pro/Max/Team) | Console API Key |
 |---|---|---|
-| Method | Host-first OAuth → bind mount credentials | `ANTHROPIC_API_KEY` env var |
-| Browser | Once per account, on host only | Never |
+| Method | Container-internal OAuth → credentials in bind-mounted state dir | `ANTHROPIC_API_KEY` env var |
+| Browser | Once per account, opened from container via forwarded URL | Never |
 | Container config | Mount `~/.claude-state/account-X` | Set env var in `.env` |
 
-**Subscription accounts**: Authenticate on the host with
-`CLAUDE_CONFIG_DIR=~/.claude-state/account-a claude auth login`,
-then bind-mount that directory into the container. The container
-inherits the authenticated state without needing a browser.
+**Subscription accounts**: Bind-mount the state directory into the
+container, then authenticate inside the container with
+`claude auth login`. The container forwards the OAuth URL to the
+host browser; credentials are written to the bind-mounted state
+directory and persist across container restarts.
 
 **Console API keys**: Set `ANTHROPIC_API_KEY` in `.env`. Takes
 precedence over any OAuth credentials in the mounted state directory.
@@ -156,19 +157,24 @@ Credential file structure after successful OAuth:
 - Refresh works silently as long as the container has network access to `api.anthropic.com`
 - Full re-authentication is needed only on password change or account revocation
 
-**Why host-first OAuth avoids known issues**:
+**Why container-internal OAuth with bind mount is correct**:
 
-| Issue | In-container OAuth | Host-first + bind mount |
-|-------|-------------------|------------------------|
-| #34917 — Headless redirect fails | **Affected** — no browser | **Avoided** — browser on host |
-| #22066 / #1736 — Token lost on restart | **Affected** — credential written inside container | **Mitigated** — host file is source of truth |
+On macOS, host-side `claude auth login` stores tokens in the macOS
+Keychain — which cannot be shared with a container. Running OAuth
+inside the container instead writes `.credentials.json` to the
+bind-mounted state directory, making tokens portable and persistent.
+
+| Issue | Container OAuth (no bind mount) | Container OAuth + bind mount |
+|-------|-------------------------------|------------------------------|
+| #34917 — Headless redirect fails | **Not affected** — container forwards OAuth URL to host browser | **Not affected** — same mechanism |
+| #22066 / #1736 — Token lost on restart | **Affected** — credential written inside ephemeral layer | **Mitigated** — credential file lives on host via bind mount |
 
 **Recovery when tokens expire beyond refresh**:
 
 ```bash
-# On the host (not inside the container)
-CLAUDE_CONFIG_DIR=~/.claude-state/account-a claude auth login
-# Container picks up the updated .credentials.json on next Claude Code startup
+# Inside the container
+claude auth login
+# Credentials are written to the bind-mounted state directory automatically
 ```
 
 If Claude Code is already running in the container, restart it to reload
@@ -180,18 +186,18 @@ the credential file (`docker compose restart claude-a`).
 
 - "Redirect URI not supported by client" error
 - Browser-based flow incompatible with headless Docker
-- **Fix**: Use host-first OAuth (authenticate on host, mount credentials)
+- **Fix**: Container OAuth works because the container forwards the OAuth URL to the host browser
 
 ### OAuth Not Persisting (GitHub #22066, #1736)
 
 - OAuth succeeds on first run but credentials vanish on container restart
 - **Root cause**: Credential file not loaded on subsequent starts
-- **Fix**: Use bind mount from host (host file persists independently of container lifecycle)
+- **Fix**: Container-internal auth writes to bind-mounted state dir, persisting across restarts
 
 ### Console Login Fails in DevContainers (GitHub #14528)
 
 - Anthropic Console auth broken in VS Code DevContainers
-- **Fix**: Use API key or host-first Claude.ai OAuth
+- **Fix**: Use API key or container-internal Claude.ai OAuth with bind mount
 
 ### Installation Hangs at Root (/)
 

--- a/docs/reference/linux-docker.md
+++ b/docs/reference/linux-docker.md
@@ -167,8 +167,9 @@ Structure:
 
 **For Console accounts**: Use `ANTHROPIC_API_KEY` environment variable
 (Path B) to avoid credential file management entirely.
-**For subscription accounts**: Use host-first OAuth (Path A) and bind mount
-the state directory. See [architecture.md](../architecture.md#authentication-strategy).
+**For subscription accounts**: Authenticate inside the container via OAuth
+(Path A); credentials stored in bind-mounted state directory.
+See [architecture.md](../architecture.md#authentication-strategy).
 
 ## cgroups v2 Resource Limits
 

--- a/docs/software-design-specification.md
+++ b/docs/software-design-specification.md
@@ -1481,22 +1481,16 @@ fields silently (SRS-8.5.7).
 ```
 Host                                    Docker
 ─────                                   ──────
-1. npm install -g @anthropic-ai/claude-code
-2. mkdir -p ~/.claude-state/account-{a,b}
-3. CLAUDE_CONFIG_DIR=~/.claude-state/account-a \
-     claude auth login
-   └─ Browser opens → OAuth → .credentials.json created
-4. CLAUDE_CONFIG_DIR=~/.claude-state/account-b \
-     claude auth login
-   └─ Browser opens → OAuth → .credentials.json created
-5. cp .env.example .env
+1. mkdir -p ~/.claude-state/account-{a,b}
+2. cp .env.example .env
    └─ Set PROJECT_DIR only (no API keys)
-6.                                      docker compose build
-7.                                      docker compose up -d
-8.                                      docker compose exec claude-a npm install
-9.                                      docker compose exec claude-b npm install
-10.                                     docker compose exec claude-a claude
-    └─ Claude Code starts with account-a credentials ✓
+3.                                      docker compose build
+4.                                      docker compose up -d
+5.                                      docker compose exec claude-a npm install
+6.                                      docker compose exec claude-b npm install
+7.                                      docker compose exec claude-a claude
+   └─ Claude Code initiates OAuth → browser opens
+   └─ .credentials.json created in bind-mounted state dir ✓
 ```
 
 ### 6.2 First Run — Path B (Console API Key)
@@ -1519,7 +1513,7 @@ Host                                    Docker
 
 ```
 1. Create state dir:    mkdir -p ~/.claude-state/account-c
-2. Auth (Path A):       CLAUDE_CONFIG_DIR=~/.claude-state/account-c claude auth login
+2. Auth (Path A):       docker compose exec claude-c claude auth login
    Auth (Path B):       Add CLAUDE_API_KEY_C=sk-ant-... to .env
 3. Add to compose:      Copy claude-b service block → rename to claude-c
                         Update account-b → account-c, _B → _C, node_modules_b → _c
@@ -1533,10 +1527,10 @@ Host                                    Docker
 ```
 Symptom: Claude Code shows "Authentication expired" inside container
 
-1. On HOST (not container):
-   CLAUDE_CONFIG_DIR=~/.claude-state/account-a claude auth login
+1. Inside the container (not on host):
+   docker compose exec claude-a claude auth login
 
-2. Restart container to reload credentials:
+2. Or restart container (token auto-refresh may resolve):
    docker compose restart claude-a
 
 3. Verify:
@@ -1556,9 +1550,9 @@ Container won't start
 
 Claude Code won't authenticate
 ├── Path A (OAuth)
-│   ├── "No credentials" → Re-run claude auth login on HOST
-│   ├── "Token expired" → Re-run claude auth login on HOST; restart container
-│   └── "Redirect URI error" → You're running auth INSIDE container; do it on HOST
+│   ├── "No credentials" → Re-run claude auth login INSIDE the container
+│   ├── "Token expired" → Re-run claude auth login INSIDE the container; restart container
+│   └── "Redirect URI error" → Ensure container can reach OAuth callback URL
 └── Path B (API key)
     ├── "Invalid API key" → Check .env; ensure no quotes around key value
     └── "API key not found" → Check variable name matches compose: CLAUDE_API_KEY_A
@@ -1577,20 +1571,19 @@ Bind mount not working
 Host                                    Docker
 ─────                                   ──────
 1. mkdir -p ~/.claude-state/account-{manager,w1,w2,w3}
-2. Authenticate each account:
-   Path A (OAuth):
-     CLAUDE_CONFIG_DIR=~/.claude-state/account-manager claude auth login
-     CLAUDE_CONFIG_DIR=~/.claude-state/account-w1 claude auth login
-     CLAUDE_CONFIG_DIR=~/.claude-state/account-w2 claude auth login
-     CLAUDE_CONFIG_DIR=~/.claude-state/account-w3 claude auth login
-   Path B (API key):
-     Add CLAUDE_API_KEY_MANAGER, CLAUDE_API_KEY_1~3 to .env
-3. Configure .env with orchestration variables:
-     WORKER_COUNT=3
-4.                                      docker compose -f docker-compose.yml \
+2. Configure .env:
+   Path A (OAuth): Set PROJECT_DIR and WORKER_COUNT=3 only (no API keys)
+   Path B (API key): Add CLAUDE_API_KEY_MANAGER, CLAUDE_API_KEY_1~3 to .env
+3.                                      docker compose -f docker-compose.yml \
                                           -f docker-compose.orchestration.yml build
-5.                                      docker compose -f docker-compose.yml \
+4.                                      docker compose -f docker-compose.yml \
                                           -f docker-compose.orchestration.yml up -d
+5. Authenticate each account inside containers (Path A only):
+                                        docker compose exec manager claude auth login
+                                        docker compose exec worker-1 claude auth login
+                                        docker compose exec worker-2 claude auth login
+                                        docker compose exec worker-3 claude auth login
+   └─ Each initiates OAuth → browser opens → credentials saved to bind-mounted state dir
 6.                                      docker compose -f docker-compose.yml \
                                           -f docker-compose.orchestration.yml \
                                           exec manager bash
@@ -1649,4 +1642,8 @@ Host                                    Docker
 | `docker-compose.orchestration.yml` | 5 | SRS-8.1.1~9 |
 | `scripts/worker-server.js` | 5 | SRS-8.2.1~11 |
 | `scripts/manager-helpers.sh` | 5 | SRS-8.3.1~5 |
+| `scripts/init-firewall.sh` | 4 | SRS-7.3 |
+| `scripts/claude-docker` | — | Utility: CLI wrapper |
+| `scripts/install.sh` | — | Utility: project installer |
+| `scripts/remove.sh` | — | Utility: project uninstaller |
 | `scripts/test-orchestration.sh` | 5 | SRS-8.4.1~5 |

--- a/docs/software-requirements-specification.md
+++ b/docs/software-requirements-specification.md
@@ -30,7 +30,7 @@ and git worktree).
 
 | Term | Definition |
 |------|-----------|
-| Path A | Host-first OAuth authentication for subscription accounts (Pro/Max/Team) |
+| Path A | Container-internal OAuth authentication for subscription accounts (Pro/Max/Team) |
 | Path B | `ANTHROPIC_API_KEY` environment variable for Console accounts |
 | Tier A | Both containers share a single bind-mounted project directory |
 | Tier B | Each container mounts a separate git worktree from the same repository |
@@ -75,7 +75,7 @@ The system exposes no GUI. All interaction is through:
 |-----------|------|---------|
 | Container shell | `docker compose exec claude-a bash` | Enter container interactively |
 | Claude Code REPL | `claude` (inside container) | AI-assisted coding |
-| Host auth CLI | `claude auth login` (on host) | Path A: OAuth login |
+| Container auth | `claude auth login` (inside container) | Path A: OAuth login |
 | Orchestration | `docker compose up/down/restart` | Lifecycle management |
 
 ### 3.2 Software Interfaces
@@ -135,7 +135,7 @@ Variables marked **`.env`** are set in the `.env` file.
 
 **File**: `$CLAUDE_CONFIG_DIR/.credentials.json`
 **Permissions**: `0600` (owner read/write only)
-**Created by**: `claude auth login` on host (Path A)
+**Created by**: `claude auth login` inside container (Path A)
 
 ```json
 {
@@ -150,8 +150,8 @@ Variables marked **`.env`** are set in the `.env` file.
 
 **Lifecycle**: `accessToken` expires at `expiresAt`. Claude Code uses
 `refreshToken` to silently obtain a new `accessToken` if the container
-has network access to `api.anthropic.com`. Full re-auth on host is
-needed only upon password change or account revocation.
+has network access to `api.anthropic.com`. Full re-auth inside the
+container is needed only upon password change or account revocation.
 
 ### 4.3 State Directory Layout
 
@@ -253,14 +253,14 @@ SHALL be provided with placeholder values and no real credentials.
 ### SRS-5.3 Authentication Subsystem
 
 **SRS-5.3.1 (Path A — Subscription OAuth)**:
-1. User SHALL install Claude Code on the host.
-2. User SHALL run `CLAUDE_CONFIG_DIR=~/.claude-state/account-X claude auth login` for each account.
-3. Browser SHALL open on the host for OAuth completion.
-4. `.credentials.json` SHALL be created in the specified state directory.
-5. User SHALL verify with `claude auth status`.
-6. Container SHALL inherit credentials via bind mount — no in-container auth needed.
+1. User SHALL create state directories on the host (`~/.claude-state/account-X/`).
+2. Container SHALL bind-mount the state directory to `/home/node/.claude`.
+3. On first `claude` launch inside the container, Claude Code SHALL initiate OAuth flow.
+4. Browser SHALL open on the host for OAuth completion (container forwards the URL).
+5. `.credentials.json` SHALL be created in the bind-mounted state directory.
+6. Credentials SHALL persist across container restarts via the host bind mount.
 7. Token refresh SHALL occur automatically via `refreshToken`.
-8. On token expiry beyond refresh, user SHALL re-run `claude auth login` on host.
+8. On token expiry beyond refresh, user SHALL re-run `claude auth login` inside the container.
 
 **SRS-5.3.2 (Path B — Console API Key)**:
 1. User SHALL obtain API keys from `console.anthropic.com`.
@@ -389,7 +389,7 @@ is identical; only `.env` values and optional compose overrides differ.
 | Container restart | OAuth credentials persist via host bind mount. No re-auth needed. |
 | Host reboot | Same as container restart. State directories survive on host filesystem. |
 | Token expiry (within refresh window) | Claude Code auto-refreshes silently. No user action needed. |
-| Token expiry (beyond refresh) | Claude Code prompts error. User re-runs `claude auth login` on host. |
+| Token expiry (beyond refresh) | Claude Code prompts error. User re-runs `claude auth login` inside the container. |
 | API key rotation (Path B) | User updates `.env`, runs `docker compose restart`. |
 | Network loss | Claude Code shows connection error. Resumes on reconnect. |
 
@@ -528,7 +528,7 @@ a test procedure.
 | FR-4 (WORKDIR not /) | SRS-5.1.6 | `docker inspect` image; verify `WorkingDir` is not `/` |
 | FR-5 (.dockerignore) | SRS-5.1.9 | Build image; verify `.git` and `node_modules` not in image layers |
 | FR-6 (separate CLAUDE_CONFIG_DIR) | SRS-5.2.5, 5.2.7 | Create distinct files in each state dir on host; verify visibility in respective containers only |
-| FR-7 (Path A OAuth) | SRS-5.3.1 | Run `claude auth login` on host with `CLAUDE_CONFIG_DIR`; start container; verify `claude auth status` succeeds inside container |
+| FR-7 (Path A OAuth) | SRS-5.3.1 | Start container; run `claude auth login` inside container; complete OAuth in host browser; verify `claude auth status` succeeds inside container |
 | FR-8 (Path B API key) | SRS-5.3.2 | Set `CLAUDE_API_KEY_A` in `.env`; start container; verify `claude auth status` shows API key auth |
 | FR-9 (.env.example) | SRS-4.5 | Verify `.env.example` exists with placeholder values; verify `.env` in `.gitignore` |
 | FR-10 (Tier A bind mount) | SRS-5.4.1 | Create test file on host in `PROJECT_DIR`; verify visible in both containers at `/workspace/` |


### PR DESCRIPTION
## Summary

Update all 7 documentation files to replace "host-first OAuth" with
"container-internal OAuth" model, reflecting the actual implementation
where authentication happens inside containers.

**Root cause**: On macOS, host `claude auth login` stores tokens in Keychain
(not `.credentials.json`), making them impossible to bind-mount into Linux
containers. Container-internal auth writes to the bind-mounted state dir.

## Files Changed (7)

- **README.md**: Quick Start auth flow, prerequisites (remove Node.js req), troubleshooting
- **PRD**: FR-7, G7, SC-4, NFR reliability, risks R2, open questions
- **SRS**: SRS-5.3.1 (8-step Path A flow rewritten), definitions, UI table
- **SDS**: Operational Flows 6.1/6.4/6.5/6.6, deliverable inventory
- **architecture.md**: Auth strategy rationale, comparison table
- **claude-code-container.md**: OAuth persistence rationale, known issues fixes
- **linux-docker.md**: Credential storage guidance

## Test plan

- [x] `grep -rn "host-first" docs/ README.md` returns 0 results
- [x] All auth instructions say "inside the container"
- [x] No references to host-side `claude auth login` for Path A