### PR TITLE
docs: comprehensive update reflecting current implementation state

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,26 @@ Choose your authentication path:
 
 **Path A -- Subscription accounts (Pro / Max / Team):**
 
+macOS:
 ```bash
-# Create state directories
-mkdir -p ~/.claude-state/account-a ~/.claude-state/account-b
+# 1. Authenticate on host (one-time, opens browser)
+claude auth login
 
-# Authentication happens inside containers on first launch.
-# After starting containers (step 3-4), run:
-#   scripts/claude-docker claude
-# Claude Code will prompt for OAuth login in your browser.
-# Credentials persist in the bind-mounted state directory.
+# 2. Inject credentials into all containers
+scripts/claude-docker auth
 ```
+
+Linux / WSL2:
+```bash
+# Authenticate inside each container after starting
+scripts/claude-docker claude claude-a
+# Inside container: claude auth login
+# (follow OAuth URL in browser, paste code)
+```
+
+Note: On macOS, container-internal OAuth fails due to Docker network
+boundary limitations ([#34917](https://github.com/anthropics/claude-code/issues/34917)).
+The `auth` command extracts tokens from macOS Keychain instead.
 
 **Path B -- Console API keys:**
 
@@ -185,17 +195,23 @@ history, settings, and credentials.
 
 ### Authentication
 
-Authentication runs inside containers. Credentials are persisted in the
-bind-mounted state directory (`~/.claude-state/account-*/`).
+On macOS, `scripts/claude-docker auth` extracts OAuth credentials from the
+host's macOS Keychain and injects them into each container's state directory.
+Host-side authentication (`claude auth login`) must be completed first.
+
+On Linux/WSL2, authenticate directly inside containers.
 
 ```bash
-# Authenticate all containers at once
+# macOS: extract from Keychain → inject to all containers
 scripts/claude-docker auth
 
-# Authenticate a specific container
+# macOS: inject to specific container only
 scripts/claude-docker auth claude-a
 
-# Check authentication status
+# Linux/WSL2: authenticate inside container
+scripts/claude-docker exec claude-a claude auth login
+
+# Check status in any container
 scripts/claude-docker exec claude-a claude auth status
 ```
 
@@ -453,12 +469,17 @@ scripts/claude-docker up
 
 **"Authentication expired" inside container:**
 
+macOS:
 ```bash
-# Re-authenticate inside the container
+# Re-authenticate on host first
+claude auth login
+# Then re-inject to containers
 scripts/claude-docker auth
+```
 
-# Or authenticate a specific service
-scripts/claude-docker auth claude-a
+Linux/WSL2:
+```bash
+scripts/claude-docker exec claude-a claude auth login
 ```
 
 **Permission denied on bind mount (Linux):**

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -232,6 +232,32 @@ Manager <──JSON resp── Worker-N
 | `worker:{name}:status` | STRING | Worker status with 60s TTL (idle/busy/error) |
 | `worker:{name}:heartbeat` | STRING | Heartbeat timestamp with 30s TTL |
 
+### Worker Personas (Phase 7)
+
+Each worker runs a specialized persona injected via the `WORKER_PERSONA`
+environment variable in the orchestration compose file. The worker HTTP server
+(`worker-server.js`) reads `WORKER_PERSONA` and prepends it as a system prompt
+section to every task it receives.
+
+| Persona | Worker | Focus Area | Findings Category |
+|---------|--------|------------|-------------------|
+| **Sentinel** (Security Analyst) | worker-1 | Vulnerabilities, hardcoded secrets, injection flaws, auth weaknesses | `security` |
+| **Reviewer** (Code Quality Engineer) | worker-2 | Dead code, duplication, SOLID violations, excessive complexity | `quality` |
+| **Profiler** (Performance Engineer) | worker-3 | N+1 queries, blocking I/O, memory leaks, bundle size issues | `performance` |
+
+The `run_analysis()` function in `scripts/manager-helpers.sh` reads persona
+definitions from `scripts/personas.json`, wraps the user prompt with each
+persona's role instructions, and dispatches to all workers in parallel via
+`dispatch_task`. Results are collected, deduplicated, and presented in a
+categorized summary.
+
+**CLI entry point**: `scripts/claude-docker analyze <prompt> [timeout]`
+
+The project `CLAUDE.md` is configured so that a manager Claude Code session
+auto-orchestrates when the user mentions analysis-related keywords (analyze,
+audit, review, inspect, scan). The manager sources `manager-helpers.sh` and
+calls `run_analysis` automatically.
+
 ### Key Design Decisions
 
 - **HTTP over raw TCP**: `curl` and `jq` already in the image; HTTP provides framing and error codes
@@ -245,11 +271,39 @@ Manager <──JSON resp── Worker-N
 Two authentication paths, each primary for its account type.
 Choose based on what kind of Anthropic account you have.
 
-### Path A: Subscription Accounts (Pro / Max / Team) — Container-Internal OAuth
+### Path A: Subscription Accounts (Pro / Max / Team) — OAuth
 
-Subscription accounts use OAuth. Since the container runs headless, **authenticate
-inside the container on first launch**, then credentials persist in the bind-mounted
-state directory.
+Subscription accounts use OAuth. The authentication method differs by platform.
+
+#### macOS: Host-Side OAuth with Keychain Extraction
+
+On macOS, container-internal `claude auth login` fails because the OAuth
+localhost callback cannot cross the Docker network boundary (see upstream
+GitHub [#34917](https://github.com/anthropics/claude-code/issues/34917),
+[#30369](https://github.com/anthropics/claude-code/issues/30369)).
+
+The working solution is host-side OAuth with Keychain extraction:
+
+```bash
+# 1. Authenticate on the host (outside Docker)
+claude auth login
+
+# 2. Extract from Keychain and inject into container state directories
+scripts/claude-docker auth          # Injects into all active services
+scripts/claude-docker auth claude-a # Or target a specific service
+
+# 3. Verify
+docker compose exec claude-a claude auth status
+```
+
+Under the hood, `scripts/claude-docker auth` calls
+`security find-generic-password -s "Claude Code-credentials" -w` to extract
+the OAuth token from macOS Keychain, then writes `.credentials.json` to each
+container's bind-mounted state directory (`~/.claude-state/account-*/`).
+
+#### Linux / WSL2: Container-Internal OAuth
+
+On Linux and WSL2, container-internal OAuth works normally:
 
 ```bash
 # 1. Start the containers
@@ -274,14 +328,8 @@ PROJECT_DIR=/path/to/your/project
 
 > **Token refresh**: Claude Code automatically refreshes tokens using the
 > `refreshToken` in `.credentials.json`. If a token expires beyond refresh
-> (e.g., password change, account revocation), re-run `claude auth login`
-> inside the corresponding container.
-
-> **Why container-internal**: On macOS, host auth stores tokens in Keychain
-> which cannot be bind-mounted. Container-internal auth stores
-> `.credentials.json` in the bind-mounted state directory, persisting
-> across restarts on all platforms.
-> See [reference/claude-code-container.md](reference/claude-code-container.md#oauth-token-persistence) for details.
+> (e.g., password change, account revocation), re-run the appropriate auth
+> method for your platform.
 
 ### Path B: Console API Keys — Environment Variable
 
@@ -303,7 +351,7 @@ it takes precedence over OAuth credentials in the mounted state directory.
 | | Path A: Subscription | Path B: API Key |
 |---|---|---|
 | Account type | Pro, Max, Team | Console (usage-based) |
-| Auth method | OAuth (container-internal) | Environment variable |
+| Auth method | macOS: host OAuth + Keychain extraction; Linux/WSL2: container-internal OAuth | Environment variable |
 | Browser needed | Once per account, on any device | Never |
 | Token management | Auto-refresh; re-auth on revocation | Manual key rotation |
 | Container restart | Credentials persist via bind mount | Always available via `.env` |
@@ -346,6 +394,8 @@ For 3+ instances, see [Scaling Beyond Two Instances](#scaling-beyond-two-instanc
 - [ ] Install Claude Code via npm (Node 20 base)
 - [ ] Include essential dev tools (git, gh, fzf, jq)
 - [ ] Set NODE_OPTIONS for 4 GB heap
+- [ ] Set `NODE_PATH=/usr/local/lib/node_modules` for global npm package resolution
+  (needed by `worker-server.js` which `require('redis')` from the global install)
 - [ ] Test image build and basic `claude --version`
 
 ### Phase 2 — Account State Separation
@@ -429,13 +479,35 @@ claude-docker/
 ├── .gitignore                        # (Phase 2)
 ├── .gitattributes                    # (Phase 2) LF line endings (Windows teams)
 └── scripts/
+    ├── claude-docker                 # Unified CLI wrapper (build, auth, analyze, usage, ...)
     ├── setup-worktrees.sh            # (Phase 3, Tier B)
     ├── test-concurrent-git.sh        # (Phase 3, Tier B — E2E concurrent git test)
     ├── cleanup.sh                    # (Phase 4)
     ├── worker-server.js              # (Phase 5) worker HTTP server with Redis
     ├── manager-helpers.sh            # (Phase 5) manager dispatch functions
+    ├── personas.json                 # (Phase 7) worker persona definitions
     └── test-orchestration.sh         # (Phase 5) E2E orchestration test
 ```
+
+## Usage Tracking
+
+`scripts/claude-docker usage` aggregates token usage across all containers and
+the host into a single report. It runs on the host (requires Node.js / `npx`)
+and does not need containers to be running.
+
+Under the hood, the command builds a temporary directory with symlinks that
+merge each account's `~/.claude-state/account-*/projects/` subdirectories
+together with the host's `~/.claude/projects/`. It then invokes
+[ccusage](https://github.com/ryoppippi/ccusage) against the merged directory
+so that all session data appears as a single config root.
+
+```bash
+scripts/claude-docker usage           # daily report (default)
+scripts/claude-docker usage monthly   # monthly report
+scripts/claude-docker usage session   # per-session breakdown
+```
+
+Supported report types: `daily`, `monthly`, `session`, `blocks`, `statusline`.
 
 ## References
 

--- a/docs/cross-platform.md
+++ b/docs/cross-platform.md
@@ -44,6 +44,32 @@ These aspects of the architecture require **zero changes**:
 
 7. **Firewall script** — iptables inside the container is Linux regardless of host.
 
+## Authentication Comparison
+
+| Platform | Primary Auth Method | Credential Storage |
+|----------|--------------------|--------------------|
+| macOS | Keychain extraction via `claude-docker auth` | macOS Keychain → `.credentials.json` in bind-mounted state dir |
+| Linux | Container-internal OAuth (`claude auth login` inside container) | `.credentials.json` (bind mount) |
+| WSL2 | Container-internal OAuth (`claude auth login` inside container) | `.credentials.json` (bind mount) |
+
+**Why macOS differs**: Docker containers on macOS run inside a Linux VM
+(Apple Virtualization Framework) and cannot access the host macOS Keychain.
+Additionally, container-internal `claude auth login` fails because the
+OAuth localhost callback cannot cross the Docker network boundary — the
+container's localhost is not the host's localhost. (See GitHub #34917, #30369.)
+
+The `scripts/claude-docker auth` command solves this by extracting OAuth
+tokens from the macOS Keychain on the host side
+(`security find-generic-password -s "Claude Code-credentials" -w`) and
+writing `.credentials.json` to each service's bind-mounted state directory.
+The tokens themselves follow the same OAuth lifecycle regardless of
+platform — auto-refresh works identically once credentials are in place.
+
+On Linux and WSL2, the container can forward the OAuth URL to the host
+browser, and the localhost callback succeeds because Docker uses host
+networking or proper port forwarding. Container-internal OAuth works
+directly, so no Keychain extraction is needed.
+
 ## What Requires Platform-Specific Adjustment
 
 ### A. Source Code Location

--- a/docs/product-requirements-document.md
+++ b/docs/product-requirements-document.md
@@ -22,9 +22,10 @@ instances; scaling to more requires only a compose edit and additional RAM
 
 The solution supports Linux, macOS, and Windows (WSL2) with two
 configuration tiers — shared source (simplest) and git worktree (safest).
-Two authentication paths are provided: container-internal OAuth for subscription
-accounts and API key for Console accounts. Implementation spans 6 phases
-over an estimated 10-17 days.
+Two authentication paths are provided: host-side Keychain extraction
+(`scripts/claude-docker auth`) on macOS and container-internal OAuth on
+Linux/WSL2 for subscription accounts, plus API key for Console accounts.
+Implementation spans 7 phases over an estimated 12-20 days.
 
 ---
 
@@ -64,7 +65,7 @@ stays under 100 MB.
 | G4 | Concurrent access stability | Tier B eliminates lock contention |
 | G5 | Simple and reproducible setup | `docker compose up` on all 3 platforms |
 | G6 | Cross-platform support | Linux, macOS, Windows (WSL2) |
-| G7 | Support subscription accounts | Container-internal OAuth for Pro/Max/Team |
+| G7 | Support subscription accounts | macOS: host-side Keychain extraction; Linux/WSL2: container-internal OAuth; both for Pro/Max/Team |
 | G8 | Scalable to N instances | Compose pattern extends to 3+ accounts |
 | G9 | Manager-worker orchestration | 1 manager dispatches tasks to N workers via HTTP; results aggregated via Redis |
 | G10 | Shared context accumulation | Worker N reads structured findings from workers 1..N-1 before processing |
@@ -84,8 +85,9 @@ stays under 100 MB.
 ### P1: Solo Developer with Two Subscription Accounts
 
 Has a personal Pro subscription and a work Team subscription. Both are
-OAuth-based (no API keys). Authenticates each account on the host,
-then runs two containers. Only one session writes at a time. Linux or macOS.
+OAuth-based (no API keys). On macOS, authenticates via host-side Keychain
+extraction (`scripts/claude-docker auth`); on Linux, uses container-internal
+OAuth. Runs two containers. Only one session writes at a time.
 **Uses Tier A** (shared source).
 
 ### P2: Pair Programming Team
@@ -165,7 +167,7 @@ Priority: **P0** = must-have, **P1** = should-have, **P2** = nice-to-have.
 | ID | Priority | Requirement |
 |----|----------|-------------|
 | FR-6 | P0 | Each container mounts a separate `CLAUDE_CONFIG_DIR` from host `~/.claude-state/account-{a,b}/` |
-| FR-7 | P0 | Auth Path A: container-internal OAuth for subscription accounts — user authenticates inside container on first launch; credentials stored in bind-mounted state directory |
+| FR-7 | P0 | Auth Path A: subscription OAuth — on macOS, host-side Keychain extraction via `scripts/claude-docker auth` (container-internal OAuth fails on macOS Docker per GitHub #34917); on Linux/WSL2, container-internal OAuth on first launch. Credentials stored in bind-mounted state directory. |
 | FR-8 | P0 | Auth Path B: `ANTHROPIC_API_KEY` env var for Console accounts |
 | FR-9 | P0 | `.env.example` with `PROJECT_DIR` (and API key vars for Path B users) |
 
@@ -209,6 +211,15 @@ Priority: **P0** = must-have, **P1** = should-have, **P2** = nice-to-have.
 | FR-28 | P1 | Archive auto-prunes to 50 sessions maximum; oldest sessions deleted on save |
 | FR-29 | P1 | Cold memory layer is opt-in; orchestration works identically without archive mount |
 
+### Phase 7 — Orchestration UX
+
+| ID | Priority | Requirement |
+|----|----------|-------------|
+| FR-30 | P0 | Worker persona system: `personas.json` defines worker personas (Sentinel/Reviewer/Profiler) with name, role, worker, icon, system prompt, and category fields. `WORKER_PERSONA` env var injected at dispatch time. |
+| FR-31 | P0 | CLI analyze command: `scripts/claude-docker analyze` dispatches parallel analysis using persona-wrapped prompts and prints categorized summary |
+| FR-32 | P1 | Manager auto-orchestration: Manager `CLAUDE.md` defines trigger keywords (analyze, audit, review, inspect, scan) that invoke `run_analysis` automatically |
+| FR-33 | P1 | Unified usage tracking: `scripts/claude-docker usage` aggregates container and host token data via ccusage, including symlink merge and host inclusion |
+
 ---
 
 ## 7. Non-Functional Requirements
@@ -219,7 +230,7 @@ Priority: **P0** = must-have, **P1** = should-have, **P2** = nice-to-have.
 | **Resources** | Host RAM: 12 GB (Linux), 16 GB (macOS/Windows). 4 GB heap per container. 4+ CPU cores. 2 GB free disk. | [architecture.md](architecture.md) |
 | **Security** | API keys via `.env` only. No Docker socket mounting. State dirs mode 0700. Optional firewall whitelist. | [claude-code-container.md](reference/claude-code-container.md) |
 | **Portability** | Identical `docker-compose.yml` on all platforms; only `.env` values and Linux `user:` field differ. | [cross-platform.md](cross-platform.md) |
-| **Reliability** | Two primary auth paths: container-internal OAuth (subscriptions) and API key (Console). Both are production-grade with documented recovery procedures. | [claude-code-container.md](reference/claude-code-container.md) |
+| **Reliability** | Three auth paths: host-side Keychain extraction on macOS, container-internal OAuth on Linux/WSL2 (subscriptions), and API key (Console). All are production-grade with documented recovery procedures. | [claude-code-container.md](reference/claude-code-container.md) |
 
 ---
 
@@ -252,7 +263,7 @@ incompatible with Claude Code TTY. See [windows-docker.md](reference/windows-doc
 | # | Risk | Likelihood | Impact | Mitigation |
 |---|------|-----------|--------|------------|
 | R1 | Concurrent file corruption (Tier A) | High (if both write) | High | Use Tier B (worktrees) |
-| R2 | OAuth token expiry beyond refresh | Low | Medium | Container-internal auth; re-run `claude auth login` inside container to recover |
+| R2 | OAuth token expiry beyond refresh | Low | Medium | macOS: re-run `scripts/claude-docker auth`; Linux/WSL2: re-run `claude auth login` inside container to recover |
 | R3 | macOS bind mount slowness | Certain | Low-Medium | Named volumes for `node_modules`; document OrbStack |
 | R4 | Windows NTFS path performance | High (if misconfigured) | High | Document WSL2 fs requirement prominently |
 | R5 | UID/GID mismatch on Linux | Medium | Medium | `user:` field + `HOME=/home/node` in compose |
@@ -299,7 +310,13 @@ incompatible with Claude Code TTY. See [windows-docker.md](reference/windows-doc
 - **Acceptance**: Sessions persist across `docker compose down -v`; `restore_session latest` restores context + findings; auto-prune keeps <= 50 sessions
 - **Effort**: 1–2 days | **Depends on**: Phase 5
 
-**Total estimated effort: 10–17 days**
+### Phase 7 — Orchestration UX
+
+- **Deliverables**: `personas.json`, `scripts/claude-docker` CLI updates (`analyze`, `usage` subcommands), Manager `CLAUDE.md` auto-orchestration triggers
+- **Acceptance**: `scripts/claude-docker analyze` dispatches to 3 workers with persona-wrapped prompts; `scripts/claude-docker usage` aggregates token data; Manager auto-invokes `run_analysis` on trigger keywords
+- **Effort**: 2–3 days | **Depends on**: Phase 5, 6
+
+**Total estimated effort: 12–20 days**
 
 ---
 
@@ -310,7 +327,7 @@ incompatible with Claude Code TTY. See [windows-docker.md](reference/windows-doc
 | SC-1 | Storage efficiency | Each additional instance adds <= 70 MB disk overhead |
 | SC-2 | Startup time | All containers reach Claude Code prompt within 30s of `docker compose up` |
 | SC-3 | Account isolation | Each container's history, credentials, and settings are fully independent |
-| SC-4 | Subscription auth | Container-internal OAuth tokens persist across container restarts via bind mount |
+| SC-4 | Subscription auth | macOS: Keychain-extracted credentials injected via `scripts/claude-docker auth`; Linux/WSL2: container-internal OAuth tokens persist across container restarts via bind mount |
 | SC-5 | Concurrent safety (Tier B) | Two containers commit to different branches without errors |
 | SC-6 | Cross-platform parity | Same compose file works on Linux, macOS, and Windows (WSL2) |
 | SC-7 | Reproducibility | New user goes from zero to two running containers in < 15 min (Linux) / < 30 min (macOS, Windows) |
@@ -320,6 +337,9 @@ incompatible with Claude Code TTY. See [windows-docker.md](reference/windows-doc
 | SC-11 | Worker-2 prompt includes Worker-1's findings read from Redis shared context | Phase 5 |
 | SC-12 | `save_session` creates self-contained JSON archive; `restore_session latest` restores context + findings into Redis | Phase 6 |
 | SC-13 | Archive persists across `docker compose down -v`; auto-prunes at 50 sessions | Phase 6 |
+| SC-14 | `scripts/claude-docker analyze` dispatches persona-wrapped prompts to 3 workers; categorized summary printed | Phase 7 |
+| SC-15 | Manager auto-invokes `run_analysis` on trigger keywords without explicit user command | Phase 7 |
+| SC-16 | `scripts/claude-docker usage` aggregates container + host token data via ccusage | Phase 7 |
 
 ---
 
@@ -328,7 +348,7 @@ incompatible with Claude Code TTY. See [windows-docker.md](reference/windows-doc
 1. **Pre-built image**: Should we publish to Docker Hub / GHCR, or require local builds only? Trade-off: convenience vs version pinning and license compliance.
 2. **Default tier**: Should Tier B (worktree) be the default compose config? Tier A is simpler for first-run; Tier B is safer for real use.
 3. **Upgrade path**: Rebuild image on new Claude Code release, or support in-place `npm update -g` inside running containers?
-4. **OAuth token refresh monitoring**: Should the setup include a health check that detects expired tokens and alerts the user to re-authenticate inside the container?
+4. **OAuth token refresh monitoring**: Should the setup include a health check that detects expired tokens and alerts the user to re-authenticate (via `scripts/claude-docker auth` on macOS or `claude auth login` inside the container on Linux/WSL2)?
 5. **Firewall default**: Should Phase 4 firewall be opt-in or opt-out?
 6. **Future scope**: Is there a need for a third container role (e.g., shared MCP server or language server)?
 
@@ -351,6 +371,8 @@ Forward traceability: Goal → Functional Requirement → SRS Specification → 
 | G9 | FR-18, FR-19, FR-20, FR-21, FR-22, FR-23, FR-24 | SRS-8.1.1–9, SRS-8.2.1–16, SRS-8.3.1–7, SRS-8.4.1–5 | SC-10 | 5 |
 | G10 (hot) | FR-20 | SRS-8.2.3–4, SRS-8.2.7, SRS-8.3.3 | SC-11 | 5 |
 | G10 (cold) | FR-25, FR-26, FR-27, FR-28, FR-29 | SRS-8.5.1–15 | SC-12, SC-13 | 6 |
+| G9 (orchestration UX) | FR-30, FR-31, FR-32 | SRS-8.6.1–5 | SC-14, SC-15 | 7 |
+| — (usage tracking) | FR-33 | SRS-8.7.1–3 | SC-16 | 7 |
 
 **Reading the table**:
 - Left to right (forward): "Goal G2 is fulfilled by FR-6/7/8, specified in SRS-5.2.5/5.2.7/5.3.1/5.3.2, and verified by SC-3/SC-4."

--- a/docs/reference/claude-code-container.md
+++ b/docs/reference/claude-code-container.md
@@ -112,15 +112,42 @@ The `CLAUDE_CONFIG_DIR` environment variable overrides the default
 
 | | Subscription (Pro/Max/Team) | Console API Key |
 |---|---|---|
-| Method | Container-internal OAuth → credentials in bind-mounted state dir | `ANTHROPIC_API_KEY` env var |
-| Browser | Once per account, opened from container via forwarded URL | Never |
+| Method (macOS) | Keychain extraction via `claude-docker auth` | `ANTHROPIC_API_KEY` env var |
+| Method (Linux/WSL2) | Container-internal OAuth → credentials in bind-mounted state dir | `ANTHROPIC_API_KEY` env var |
+| Browser | Once per account (macOS: on host; Linux: forwarded URL from container) | Never |
 | Container config | Mount `~/.claude-state/account-X` | Set env var in `.env` |
 
-**Subscription accounts**: Bind-mount the state directory into the
-container, then authenticate inside the container with
-`claude auth login`. The container forwards the OAuth URL to the
-host browser; credentials are written to the bind-mounted state
-directory and persist across container restarts.
+#### macOS Keychain Extraction (Primary for macOS)
+
+On macOS, `claude auth login` on the host stores OAuth tokens in the
+macOS Keychain under the service name `Claude Code-credentials`. Since
+Docker containers cannot access the host Keychain, and container-internal
+OAuth fails due to the localhost callback boundary (GitHub #34917, #30369),
+the `claude-docker auth` command extracts tokens from the Keychain
+and writes them to bind-mounted state directories:
+
+```bash
+# How it works (inside scripts/claude-docker):
+security find-generic-password -s "Claude Code-credentials" -w
+# Returns JSON with claudeAiOauth tokens
+
+# The auth command writes .credentials.json to each state dir:
+scripts/claude-docker auth              # All services
+scripts/claude-docker auth manager      # Specific service
+```
+
+#### Container-Internal OAuth (Linux / WSL2)
+
+On Linux and WSL2, container-internal OAuth works because the container
+can forward the OAuth URL to the host browser. Bind-mount the state
+directory into the container, then authenticate:
+
+```bash
+docker compose exec claude-a claude auth login
+```
+
+Credentials are written to the bind-mounted state directory and persist
+across container restarts.
 
 **Console API keys**: Set `ANTHROPIC_API_KEY` in `.env`. Takes
 precedence over any OAuth credentials in the mounted state directory.
@@ -157,12 +184,19 @@ Credential file structure after successful OAuth:
 - Refresh works silently as long as the container has network access to `api.anthropic.com`
 - Full re-authentication is needed only on password change or account revocation
 
-**Why container-internal OAuth with bind mount is correct**:
+**Why Keychain extraction on macOS, container OAuth on Linux**:
 
 On macOS, host-side `claude auth login` stores tokens in the macOS
-Keychain — which cannot be shared with a container. Running OAuth
-inside the container instead writes `.credentials.json` to the
-bind-mounted state directory, making tokens portable and persistent.
+Keychain, which cannot be shared with a container. Container-internal
+`claude auth login` fails in Docker because the localhost OAuth callback
+cannot cross the Docker network boundary (GitHub #34917, #30369).
+The solution is Keychain extraction: read tokens from the host Keychain
+and write `.credentials.json` to the bind-mounted state directory.
+
+On Linux/WSL2, container-internal OAuth works because the container
+can forward the OAuth URL to the host browser, and the callback
+succeeds. Credentials are written directly to the bind-mounted state
+directory.
 
 | Issue | Container OAuth (no bind mount) | Container OAuth + bind mount |
 |-------|-------------------------------|------------------------------|
@@ -182,11 +216,12 @@ the credential file (`docker compose restart claude-a`).
 
 ## Known Container Issues
 
-### OAuth Fails Headless (GitHub #34917)
+### OAuth Fails Headless (GitHub #34917, #30369)
 
 - "Redirect URI not supported by client" error
-- Browser-based flow incompatible with headless Docker
-- **Fix**: Container OAuth works because the container forwards the OAuth URL to the host browser
+- Browser-based flow incompatible with headless Docker; localhost callback cannot cross Docker network boundary
+- **Fix (macOS)**: Keychain extraction via `scripts/claude-docker auth` — extracts host OAuth tokens and injects into container state dirs
+- **Fix (Linux/WSL2)**: Container-internal OAuth works because the container forwards the OAuth URL to the host browser
 
 ### OAuth Not Persisting (GitHub #22066, #1736)
 
@@ -198,6 +233,12 @@ the credential file (`docker compose restart claude-a`).
 
 - Anthropic Console auth broken in VS Code DevContainers
 - **Fix**: Use API key or container-internal Claude.ai OAuth with bind mount
+
+### NODE_PATH Required for Global npm Packages
+
+- Globally installed npm packages (e.g., `redis`) are not found by `require()` without `NODE_PATH`
+- **Root cause**: Node.js does not search `/usr/local/lib/node_modules` by default
+- **Fix**: Set `NODE_PATH=/usr/local/lib/node_modules` in the Dockerfile `ENV` line
 
 ### Installation Hangs at Root (/)
 

--- a/docs/software-design-specification.md
+++ b/docs/software-design-specification.md
@@ -110,7 +110,9 @@ RUN npm install -g redis \
     && npm cache clean --force
 
 # SRS-5.1.5: Memory heap limit
-ENV NODE_OPTIONS=--max-old-space-size=4096
+# NODE_PATH: Allow require() to find globally installed npm packages (e.g. redis)
+ENV NODE_OPTIONS=--max-old-space-size=4096 \
+    NODE_PATH=/usr/local/lib/node_modules
 
 # SRS-5.1.7: Run as non-root user
 # Why: node user (UID 1000) comes pre-created in node:20-slim
@@ -457,6 +459,7 @@ volumes:
 - Redis healthcheck ensures workers don't start before Redis is ready
 - Each worker has its own account state and node_modules volume
 - No port exposure to host — all communication via internal bridge network
+- Each worker service includes a `WORKER_PERSONA` env var containing the full persona system prompt (Sentinel for worker-1, Reviewer for worker-2, Profiler for worker-3). This is read by `worker-server.js` and prepended as a `[Role]` section in `buildEnrichedPrompt()`
 
 ---
 
@@ -626,6 +629,7 @@ const { createClient } = require('redis');                   // SRS-8.2.11
 const WORKER_PORT = parseInt(process.env.WORKER_PORT, 10) || 9000; // SRS-8.2.1
 const REDIS_URL   = process.env.REDIS_URL || 'redis://redis:6379';
 const WORKER_NAME = process.env.WORKER_NAME || `worker-${process.pid}`;
+const WORKER_PERSONA = process.env.WORKER_PERSONA || '';      // SRS-8.7.1
 const MAX_BUFFER  = 10 * 1024 * 1024;                       // 10 MB
 const REDIS_RETRY_LIMIT    = 3;                              // SRS-8.2.15
 const REDIS_RETRY_DELAY_MS = 2000;
@@ -690,6 +694,13 @@ async function readPriorFindings() {                         // SRS-8.2.4
  */
 function buildEnrichedPrompt(context, priorFindings, taskPrompt) {
   const sections = [];
+
+  // [Role] section — injected from WORKER_PERSONA env var (SRS-8.7.1)
+  if (WORKER_PERSONA) {
+    sections.push('[Role]');
+    sections.push(WORKER_PERSONA);
+    sections.push('');
+  }
 
   // [Project Context] section
   const ctxEntries = Object.entries(context);
@@ -1063,7 +1074,8 @@ main();
 ### 5.4 scripts/manager-helpers.sh (Phase 5)
 
 Bash helper functions sourced by the manager to dispatch tasks and query state.
-Reference: SRS-8.3.1~5.
+Reference: SRS-8.3.1~5, SRS-8.7.2.
+12 functions total.
 
 ```bash
 #!/usr/bin/env bash
@@ -1434,9 +1446,19 @@ chronological `ls` sorting. Max 50 sessions; oldest auto-pruned on save (SRS-8.5
 | `restore_session` | 8.5.4 | `<id\|latest>` | HSET context:shared, RPUSH findings:all, RPUSH findings:{cat} | Read context.json + findings.json |
 | `list_sessions` | 8.5.5 | none | none | Read index.json |
 | `show_session` | 8.5.6 | `<id>` | none | Read session.json + context.json + findings.json |
+| `run_analysis` | 8.7.2 | `<prompt> [timeout]` | clear_findings, LLEN findings:all, LLEN findings:{cat} | Read personas.json; auto-calls save_session |
 
 All functions use `ARCHIVE_DIR` env var (default `/archive`) and `_require_redis`
 guard for Redis-dependent operations. `save_session` is Redis-read-only (SRS-8.5.14).
+
+**`run_analysis`** (SRS-8.7.2): Loads worker personas from `/scripts/personas.json`,
+wraps the user prompt with each persona's role instructions, dispatches all workers
+in parallel, collects results, prints a categorized summary (security, quality,
+performance), and auto-saves the session via `save_session`.
+
+**Implementation note**: `save_session` generates session IDs using `od` instead of
+`xxd` for session hex generation (`head -c4 /dev/urandom | od -An -tx1 | tr -d ' \n'`),
+since `xxd` is not available in the `node:20-slim` base image.
 
 #### 5.6.4 Docker Compose Change
 
@@ -1472,11 +1494,56 @@ fields silently (SRS-8.5.7).
 | **index.json** | Fast listing without scanning session directories |
 | **Host bind mount** | Survives `docker compose down -v` (named volumes are deleted) |
 
+### 5.7 scripts/claude-docker (CLI Wrapper)
+
+Unified host-side CLI wrapper that auto-detects compose overlay files and
+provides short subcommands for common operations.
+
+**Key functions:**
+
+| Function | Purpose |
+|----------|---------|
+| `cmd_usage()` | Token usage report via `ccusage`; merges session data from all account state dirs |
+| `cmd_analyze()` | Multi-persona project analysis; delegates to `run_analysis` inside manager container |
+| `get_keychain_credentials()` | Extracts OAuth tokens from macOS Keychain via `security find-generic-password -s "Claude Code-credentials" -w` |
+| `inject_credentials()` | Writes credential JSON to a service's bind-mounted state directory on the host |
+| `build_merged_config_dir()` | Creates a temp directory with symlinks to all account project dirs for `ccusage` aggregation |
+| `list_account_dirs()` | Enumerates `~/.claude-state/account-*` directories |
+
+**Authentication rewrite**: The `cmd_auth` subcommand was rewritten from
+container-internal OAuth (`claude auth login` inside the container) to macOS
+Keychain extraction. On macOS, `get_keychain_credentials()` reads the host's
+OAuth tokens from the system Keychain, and `inject_credentials()` writes them
+to each service's bind-mounted `~/.claude-state/account-*/` directory as
+`.credentials.json`. This bypasses the container OAuth boundary problem
+(localhost callback fails across the Docker network boundary; see GitHub #34917,
+#30369). On non-macOS platforms, the command falls back to prompting the user
+to authenticate on the host first or use API keys.
+
 ---
 
 ## 6. Operational Flows
 
 ### 6.1 First Run — Path A (Subscription)
+
+**macOS (Keychain extraction):**
+
+```
+Host                                    Docker
+─────                                   ──────
+1. claude auth login                    (authenticate on host — tokens saved to macOS Keychain)
+2. mkdir -p ~/.claude-state/account-{a,b}
+3. cp .env.example .env
+   └─ Set PROJECT_DIR only (no API keys)
+4.                                      docker compose build
+5.                                      docker compose up -d
+6. scripts/claude-docker auth           (extracts Keychain credentials → writes .credentials.json
+                                         to each bind-mounted state dir)
+7.                                      docker compose exec claude-a claude
+   └─ Claude Code starts with injected OAuth tokens ✓
+```
+
+**Linux / WSL2 (container-internal OAuth):**
 
 ```
 Host                                    Docker
@@ -1486,11 +1553,10 @@ Host                                    Docker
    └─ Set PROJECT_DIR only (no API keys)
 3.                                      docker compose build
 4.                                      docker compose up -d
-5.                                      docker compose exec claude-a npm install
-6.                                      docker compose exec claude-b npm install
-7.                                      docker compose exec claude-a claude
+5.                                      docker compose exec claude-a claude auth login
    └─ Claude Code initiates OAuth → browser opens
    └─ .credentials.json created in bind-mounted state dir ✓
+6.                                      docker compose exec claude-a claude
 ```
 
 ### 6.2 First Run — Path B (Console API Key)
@@ -1550,9 +1616,10 @@ Container won't start
 
 Claude Code won't authenticate
 ├── Path A (OAuth)
-│   ├── "No credentials" → Re-run claude auth login INSIDE the container
-│   ├── "Token expired" → Re-run claude auth login INSIDE the container; restart container
-│   └── "Redirect URI error" → Ensure container can reach OAuth callback URL
+│   ├── macOS → Run: scripts/claude-docker auth (extracts Keychain → injects to state dirs)
+│   ├── "No credentials" → Linux/WSL2: re-run claude auth login INSIDE the container
+│   ├── "Token expired" → Re-run auth (Keychain or container-internal); restart container
+│   └── "Redirect URI error" → Use Keychain extraction on macOS; container OAuth on Linux
 └── Path B (API key)
     ├── "Invalid API key" → Check .env; ensure no quotes around key value
     └── "API key not found" → Check variable name matches compose: CLAUDE_API_KEY_A
@@ -1578,8 +1645,10 @@ Host                                    Docker
                                           -f docker-compose.orchestration.yml build
 4.                                      docker compose -f docker-compose.yml \
                                           -f docker-compose.orchestration.yml up -d
-5. Authenticate each account inside containers (Path A only):
-                                        docker compose exec manager claude auth login
+5. Authenticate (Path A only):
+   macOS:                               scripts/claude-docker auth
+   └─ Extracts Keychain credentials → writes .credentials.json to all state dirs
+   Linux/WSL2:                          docker compose exec manager claude auth login
                                         docker compose exec worker-1 claude auth login
                                         docker compose exec worker-2 claude auth login
                                         docker compose exec worker-3 claude auth login
@@ -1594,6 +1663,27 @@ Host                                    Docker
    dispatch_task worker-3 "analyze API routes"
 10. get_findings
     └─ Returns combined findings from all workers
+```
+
+### 6.7 Analyze Flow (Multi-Persona)
+
+```
+Host                                    Docker (manager)             Docker (workers)
+─────                                   ────────────────             ────────────────
+1. scripts/claude-docker analyze \
+     "Review this codebase"
+                                        2. source manager-helpers.sh
+                                           run_analysis "..."
+                                           ├─ Load /scripts/personas.json
+                                           ├─ clear_findings
+                                           ├─ dispatch_task worker-1   ──→  3a. [Sentinel] security analysis
+                                           ├─ dispatch_task worker-2   ──→  3b. [Reviewer] quality analysis
+                                           └─ dispatch_task worker-3   ──→  3c. [Profiler] performance analysis
+                                                                            (each writes findings to Redis)
+                                        4. Collect results from Redis
+                                           ├─ Print categorized summary
+                                           └─ save_session (auto-archive)
+5. View summary output
 ```
 
 ---
@@ -1645,7 +1735,7 @@ Host                                    Docker
 | `scripts/init-firewall.sh` | 4 | SRS-7.3 |
 | `scripts/personas.json` | 7 | Worker persona definitions (Sentinel, Reviewer, Profiler) |
 | `CLAUDE.md` | 7 | Manager auto-orchestration instructions |
-| `scripts/claude-docker` | — | Utility: CLI wrapper (includes usage tracking via ccusage, analyze command) |
+| `scripts/claude-docker` | — | Utility: CLI wrapper (Keychain auth, usage tracking via ccusage, analyze command) |
 | `scripts/install.sh` | — | Utility: project installer |
 | `scripts/remove.sh` | — | Utility: project uninstaller |
 | `scripts/test-orchestration.sh` | 5 | SRS-8.4.1~5 |

--- a/docs/software-requirements-specification.md
+++ b/docs/software-requirements-specification.md
@@ -22,15 +22,15 @@ document.
 
 The system consists of: one Docker image, N containers, host-side state
 directories, and orchestration via Docker Compose. It supports Linux,
-macOS, and Windows (WSL2), two authentication paths (OAuth subscription
-and Console API key), and two source-sharing tiers (shared bind mount
-and git worktree).
+macOS, and Windows (WSL2), three authentication paths (host-side Keychain
+extraction on macOS, container-internal OAuth on Linux/WSL2, and Console
+API key), and two source-sharing tiers (shared bind mount and git worktree).
 
 ### 1.3 Definitions
 
 | Term | Definition |
 |------|-----------|
-| Path A | Container-internal OAuth authentication for subscription accounts (Pro/Max/Team) |
+| Path A | Subscription OAuth authentication (Pro/Max/Team): host-side Keychain extraction on macOS, container-internal OAuth on Linux/WSL2 |
 | Path B | `ANTHROPIC_API_KEY` environment variable for Console accounts |
 | Tier A | Both containers share a single bind-mounted project directory |
 | Tier B | Each container mounts a separate git worktree from the same repository |
@@ -233,6 +233,7 @@ SHALL be provided with placeholder values and no real credentials.
 | SRS-5.1.10 | Final image size SHALL be under 1 GB. |
 | SRS-5.1.11 | *(Phase 5)* Dockerfile SHALL install `redis-tools` package via apt-get for `redis-cli` availability. Not required until Phase 5 orchestration is implemented. |
 | SRS-5.1.12 | *(Phase 5)* Dockerfile SHALL install `redis` npm package (v4.6+) globally for worker-server.js. Not required until Phase 5 orchestration is implemented. |
+| SRS-5.1.13 | Dockerfile SHALL set `NODE_PATH=/usr/local/lib/node_modules` so that globally installed npm packages (e.g., `redis`) are resolvable by `require()` in scripts. |
 
 ### SRS-5.2 Container Orchestration (docker-compose.yml)
 
@@ -253,6 +254,22 @@ SHALL be provided with placeholder values and no real credentials.
 ### SRS-5.3 Authentication Subsystem
 
 **SRS-5.3.1 (Path A — Subscription OAuth)**:
+
+**SRS-5.3.1a (macOS — Host-side Keychain Extraction)**:
+Container-internal OAuth fails on macOS Docker (GitHub #34917). The primary
+macOS method is host-side Keychain extraction.
+1. User SHALL create state directories on the host (`~/.claude-state/account-X/`).
+2. Container SHALL bind-mount the state directory to `/home/node/.claude`.
+3. User SHALL run `scripts/claude-docker auth` on the host.
+4. `get_keychain_credentials()` SHALL extract OAuth tokens from the macOS Keychain
+   (service: `claude.ai`, account: `oauth_credentials`).
+5. `inject_credentials()` SHALL write `.credentials.json` into the bind-mounted
+   state directory with mode `0600`.
+6. Credentials SHALL persist across container restarts via the host bind mount.
+7. Token refresh SHALL occur automatically via `refreshToken` inside the container.
+8. On token expiry beyond refresh, user SHALL re-run `scripts/claude-docker auth`.
+
+**SRS-5.3.1b (Linux/WSL2 — Container-internal OAuth)**:
 1. User SHALL create state directories on the host (`~/.claude-state/account-X/`).
 2. Container SHALL bind-mount the state directory to `/home/node/.claude`.
 3. On first `claude` launch inside the container, Claude Code SHALL initiate OAuth flow.
@@ -474,6 +491,32 @@ is identical; only `.env` values and optional compose overrides differ.
 | SRS-8.5.14 | SHALL | `save_session` SHALL NOT modify Redis state (read-only Redis operations during save) |
 | SRS-8.5.15 | SHALL | The archive directory SHALL persist across `docker compose down -v` because it is a host bind mount, not a Docker named volume |
 
+### 8.6 Orchestration UX (Phase 7)
+
+| Spec | Priority | Requirement |
+|------|----------|-------------|
+| SRS-8.6.1 | SHALL | `personas.json` SHALL define worker personas with fields: `name` (string), `role` (string), `worker` (string, e.g., `worker-1`), `icon` (string, emoji), `system` (string, system prompt), `category` (string, e.g., `security`, `quality`, `performance`) |
+| SRS-8.6.2 | SHALL | `WORKER_PERSONA` environment variable SHALL be injected into each worker's prompt context by `buildEnrichedPrompt()` during dispatch. The persona system prompt SHALL be prepended to the user-provided prompt. |
+| SRS-8.6.3 | SHALL | `run_analysis()` SHALL dispatch tasks to all workers in parallel with persona wrapping. Each worker receives its persona's system prompt concatenated with the user prompt and accumulated shared context. |
+| SRS-8.6.4 | SHALL | `scripts/claude-docker analyze "<prompt>"` CLI subcommand SHALL invoke `run_analysis` inside the manager container, print a categorized summary grouped by persona category, and save the session to cold storage. |
+| SRS-8.6.5 | SHOULD | Manager `CLAUDE.md` SHALL define trigger keywords (`analyze`, `audit`, `review`, `inspect`, `scan`, `security check`, `code quality`, `performance review`, `production readiness`, `health check`) that auto-invoke `run_analysis` when detected in user input. |
+
+### 8.7 Usage Tracking (Phase 7)
+
+| Spec | Priority | Requirement |
+|------|----------|-------------|
+| SRS-8.7.1 | SHALL | `scripts/claude-docker usage` subcommand SHALL aggregate token usage data from all container state directories and the host Claude config directory |
+| SRS-8.7.2 | SHALL | Usage aggregation SHALL use `ccusage` tool with symlink merge to unify per-account usage data into a single report |
+| SRS-8.7.3 | SHOULD | Usage report SHALL include per-account breakdown and total across all accounts (container + host) |
+
+### 8.8 Known Issues and Errata
+
+| ID | Description | Affected Spec | Fix |
+|----|-------------|---------------|-----|
+| ERRATA-1 | `xxd` is not available in `node:20-slim`; scripts using `xxd` for hex encoding SHALL use `od` instead (`od -An -tx1`) | SRS-8.3 | Replace `xxd` calls with `od -An -tx1` in manager-helpers.sh |
+| ERRATA-2 | `NODE_PATH=/usr/local/lib/node_modules` is required for globally installed npm packages to be resolvable by `require()` in worker-server.js | SRS-5.1.12 | Added SRS-5.1.13 |
+| ERRATA-3 | `((counter++))` returns exit code 1 when counter is 0 under `set -e`, causing script termination | SRS-8.3.5 | Use `counter=$((counter + 1))` instead of `((counter++))` in shell scripts |
+
 ---
 
 ## 9. Constraints and Assumptions
@@ -502,10 +545,10 @@ Each SRS functional section traces back to PRD Goals and Functional Requirements
 
 | SRS Section | Specs | PRD FR | PRD Goal | Phase |
 |-------------|-------|--------|----------|-------|
-| 5.1 Image Build | SRS-5.1.1–10 | FR-1–5 | G1, G5 | 1 |
+| 5.1 Image Build | SRS-5.1.1–10, 5.1.13 | FR-1–5 | G1, G5 | 1 |
 | 5.1 Image Build (Phase 5 additions) | SRS-5.1.11–12 | — | G9 | 5 |
 | 5.2 Container Orchestration | SRS-5.2.1–11 | FR-6, FR-9, FR-10, FR-12 | G2, G3, G5 | 2, 3 |
-| 5.3 Authentication | SRS-5.3.1–3 | FR-7, FR-8 | G2, G7 | 2 |
+| 5.3 Authentication | SRS-5.3.1a–b, 5.3.2–3 | FR-7, FR-8 | G2, G7 | 2 |
 | 5.4 Source Sharing | SRS-5.4.1–3 | FR-10–13 | G3, G4 | 3 |
 | 5.5 Scaling | SRS-5.5 | — | G8 | 2, 3 |
 | 6.1 Linux Adaptation | SRS-6.1.1–5 | — | G6 | 2 |
@@ -514,6 +557,8 @@ Each SRS functional section traces back to PRD Goals and Functional Requirements
 | 7.3 Security | SRS-7.3 | FR-14 | G5 | 4 |
 | 8.1–8.4 Orchestration | SRS-8.1.1–9, SRS-8.2.1–16, SRS-8.3.1–7, SRS-8.4.1–5 | FR-18–24 | G9, G10 | 5 |
 | 8.5 Cold Memory | SRS-8.5.1–15 | FR-25–29 | G10 | 6 |
+| 8.6 Orchestration UX | SRS-8.6.1–5 | FR-30–32 | G9 | 7 |
+| 8.7 Usage Tracking | SRS-8.7.1–3 | FR-33 | — | 7 |
 
 ### 10.2 Downstream Verification (PRD FR → SRS → Test)
 
@@ -528,7 +573,7 @@ a test procedure.
 | FR-4 (WORKDIR not /) | SRS-5.1.6 | `docker inspect` image; verify `WorkingDir` is not `/` |
 | FR-5 (.dockerignore) | SRS-5.1.9 | Build image; verify `.git` and `node_modules` not in image layers |
 | FR-6 (separate CLAUDE_CONFIG_DIR) | SRS-5.2.5, 5.2.7 | Create distinct files in each state dir on host; verify visibility in respective containers only |
-| FR-7 (Path A OAuth) | SRS-5.3.1 | Start container; run `claude auth login` inside container; complete OAuth in host browser; verify `claude auth status` succeeds inside container |
+| FR-7 (Path A OAuth) | SRS-5.3.1a–b | macOS: run `scripts/claude-docker auth`; verify `.credentials.json` created in state dir; verify `claude auth status` succeeds inside container. Linux/WSL2: run `claude auth login` inside container; complete OAuth in host browser; verify `claude auth status` succeeds inside container. |
 | FR-8 (Path B API key) | SRS-5.3.2 | Set `CLAUDE_API_KEY_A` in `.env`; start container; verify `claude auth status` shows API key auth |
 | FR-9 (.env.example) | SRS-4.5 | Verify `.env.example` exists with placeholder values; verify `.env` in `.gitignore` |
 | FR-10 (Tier A bind mount) | SRS-5.4.1 | Create test file on host in `PROJECT_DIR`; verify visible in both containers at `/workspace/` |
@@ -555,3 +600,8 @@ a test procedure.
 | FR-27 (session listing) | SRS-8.5.5 | Save 3 sessions; call `list_sessions`; verify all 3 appear with correct counts |
 | FR-28 (session pruning) | SRS-8.5.8 | Save 52 sessions; verify only 50 remain in index and on disk |
 | FR-29 (backward compat) | SRS-8.5.10 | Start orchestration without archive mount; verify all existing functions work |
+| FR-30 (worker personas) | SRS-8.6.1–2 | Verify `personas.json` is valid JSON with required fields; verify `WORKER_PERSONA` present in worker prompt context |
+| FR-31 (CLI analyze) | SRS-8.6.3–4 | Run `scripts/claude-docker analyze "test prompt"`; verify 3 workers dispatched; verify categorized summary output |
+| FR-32 (manager auto-orchestration) | SRS-8.6.5 | Send "analyze this project" to manager; verify `run_analysis` invoked automatically |
+| FR-33 (usage tracking) | SRS-8.7.1–3 | Run `scripts/claude-docker usage`; verify output includes per-account and total token data |
+| — (NODE_PATH) | SRS-5.1.13 | `docker compose exec worker-1 node -e "console.log(require.resolve('redis'))"` succeeds |


### PR DESCRIPTION
## Summary
- Update all 7 documentation files to match actual implementation
- Replace container-internal OAuth references with macOS Keychain extraction
- Add Phase 7 Orchestration UX specs (personas, analyze, CLAUDE.md)
- Add usage tracking specifications (ccusage integration)
- Document technical fixes (NODE_PATH, xxd→od, set -e errata)

## Files changed (7)
| File | Key Updates |
|------|-------------|
| README.md | Auth instructions split by platform (macOS/Linux), troubleshooting updated |
| architecture.md | Auth strategy rewritten, Phase 7 personas section, usage tracking section |
| product-requirements-document.md | FR-30~33 (Phase 7), traceability matrix, SC-14~16 |
| software-requirements-specification.md | SRS-5.3.1a/b (auth), SRS-8.6 (orchestration UX), SRS-8.7 (usage), SRS-8.8 (errata) |
| software-design-specification.md | Section 5.7 (claude-docker functions), section 6.7 (analyze flow), NODE_PATH |
| claude-code-container.md | Keychain extraction method, updated known issues #34917/#30369 |
| cross-platform.md | Platform-specific auth comparison table |

## Test plan
- [ ] All markdown renders correctly on GitHub
- [ ] No broken internal links
- [ ] Auth instructions match `scripts/claude-docker auth` behavior
- [ ] SRS/SDS traceability references are consistent