### PR TITLE
feat(compose): expose Redis port on localhost for MCP bridge access

### DIFF
--- a/docker-compose.orchestration.yml
+++ b/docker-compose.orchestration.yml
@@ -8,6 +8,8 @@ services:
     image: redis:7-alpine                                       # SRS-8.1.2
     env_file: .env
     command: ["sh", "-c", "redis-server --save 60 1 --loglevel notice --requirepass \"$REDIS_PASSWORD\" --maxmemory 200mb --maxmemory-policy allkeys-lru --appendonly yes --appendfsync everysec"]
+    ports:
+      - "127.0.0.1:6379:6379"
     volumes:
       - redis-data:/data                                        # SRS-8.1.3
     networks:


### PR DESCRIPTION
## Summary
- Add localhost-only port mapping (127.0.0.1:6379:6379) to Redis service in orchestration compose
- Enables MCP bridge server running on host to query Redis directly
- External access prevented by 127.0.0.1 binding

## Related Issues
Closes #108
Part of #107

## Test Plan
- [ ] Redis accessible from host at localhost:6379
- [ ] Redis NOT accessible from external network
- [ ] Password authentication still required
- [ ] Existing container-to-container Redis access unchanged