### PR TITLE
feat(mcp): add .mcp.json for Claude Code auto-discovery

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,21 @@
+{
+  "mcpServers": {
+    "claude-docker": {
+      "command": "node",
+      "args": ["scripts/mcp-bridge-server.js"],
+      "env": {
+        "REDIS_HOST": "127.0.0.1",
+        "REDIS_PORT": "6379",
+        "REDIS_PASSWORD": "${REDIS_PASSWORD}",
+        "ARCHIVE_DIR": "${HOME}/.claude-state/analysis-archive",
+        "DOCKER_COMPOSE_DIR": "${PWD}",
+        "CLAUDE_API_KEY_MANAGER": "${CLAUDE_API_KEY_MANAGER}",
+        "CLAUDE_API_KEY_A": "${CLAUDE_API_KEY_A}",
+        "CLAUDE_API_KEY_B": "${CLAUDE_API_KEY_B}",
+        "CLAUDE_API_KEY_1": "${CLAUDE_API_KEY_1}",
+        "CLAUDE_API_KEY_2": "${CLAUDE_API_KEY_2}",
+        "CLAUDE_API_KEY_3": "${CLAUDE_API_KEY_3}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add .mcp.json at project root for Claude Code MCP auto-discovery
- References all env vars needed by the MCP bridge server
- No secrets hardcoded — all values use ${VAR} substitution

## Related Issues
Closes #110
Part of #107

## Test Plan
- [ ] Claude Code discovers claude-docker MCP server when in project directory
- [ ] /mcp command shows claude-docker tools
- [ ] No actual secrets in .mcp.json file