### PR TITLE
docs(mcp): add MCP bridge setup guide and usage documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,3 +68,31 @@ source /scripts/manager-helpers.sh
 list_sessions
 restore_session latest
 ```
+
+## MCP Bridge Tools
+
+When running as a **host-side Claude Code session** (not inside a container),
+the MCP bridge provides the same orchestration capabilities as native tools.
+Use these tools instead of shell commands when available:
+
+| Instead of | Use MCP tool |
+|------------|-------------|
+| `scripts/claude-docker dispatch worker-1 "prompt"` | `dispatch(worker: "worker-1", prompt: "...")` |
+| `scripts/claude-docker analyze "prompt"` | `analyze(prompt: "...")` |
+| `scripts/claude-docker findings security` | `findings(category: "security")` |
+| `scripts/claude-docker status` | `status()` |
+| `scripts/claude-docker sessions` | `sessions()` |
+
+### When to Use `delegate`
+
+Use `delegate` to run a prompt on a different account:
+
+- **Cross-account review**: "Get account B's perspective on this code"
+- **Model comparison**: Specify a different model via the `model` parameter
+- **Workload distribution**: Offload expensive analysis to a dedicated account
+
+### When to Use `analyze` vs `dispatch`
+
+- **`analyze`**: Full three-persona parallel analysis. Use for broad reviews.
+- **`dispatch`**: Single-worker targeted task. Use when you know which persona
+  is needed (e.g., security-only check goes to `worker-1`).

--- a/README.md
+++ b/README.md
@@ -342,6 +342,48 @@ When using `scripts/claude-docker claude` to enter the manager, the manager
 Claude Code reads `CLAUDE.md` and can automatically orchestrate analysis
 when you ask it to analyze, audit, or review code.
 
+### MCP Bridge (Native Tool Integration)
+
+Access all orchestration features directly from a Claude Code session
+without switching terminals. The MCP bridge exposes 8 tools via the
+Model Context Protocol.
+
+**Setup:**
+
+```bash
+# 1. Enable Redis host access
+echo "MCP_BRIDGE=yes" >> .env
+
+# 2. Install Node.js dependencies
+npm install
+
+# 3. Restart containers
+scripts/claude-docker up
+```
+
+Start Claude Code from the project directory -- the `.mcp.json` config
+is auto-discovered.
+
+**Available tools:**
+
+| Tool | Description |
+|------|-------------|
+| `delegate` | Run a prompt on a specified account (supports model selection) |
+| `analyze` | Multi-persona parallel analysis (security, quality, performance) |
+| `dispatch` | Send a task to a specific worker |
+| `accounts` | List configured accounts and routing status |
+| `findings` | Query analysis findings (live or archived) |
+| `sessions` | List archived analysis sessions |
+| `status` | Show worker health and activity |
+| `budget` | Token usage information |
+
+API key accounts route via the Anthropic SDK (fast, supports model
+selection). OAuth accounts route via `docker exec`. API key accounts
+fall back to `docker exec` automatically if the SDK call fails.
+
+For detailed tool schemas, input/output examples, and troubleshooting,
+see [MCP Bridge Reference](docs/mcp-bridge.md).
+
 ### Session Archive (Cold Memory)
 
 Save and restore orchestration sessions across container restarts:
@@ -469,6 +511,7 @@ Override files separate platform and feature concerns from the base compose:
 | `docker-compose.worktree.yml` | Per-container worktree paths | Tier B only |
 | `docker-compose.firewall.yml` | Outbound network whitelist | Security hardening |
 | `docker-compose.orchestration.yml` | Manager-worker with Redis | Multi-agent orchestration |
+| `docker-compose.mcp.yml` | Redis host port for MCP bridge | `MCP_BRIDGE=yes` in `.env` |
 
 Combine with `-f` (or let `scripts/claude-docker` detect them automatically):
 
@@ -541,6 +584,9 @@ claude-docker/
 +-- docker-compose.worktree.yml        Tier B override
 +-- docker-compose.firewall.yml        Firewall override
 +-- docker-compose.orchestration.yml  Manager-worker orchestration
++-- docker-compose.mcp.yml            MCP bridge Redis overlay
++-- .mcp.json                          MCP server auto-discovery
++-- package.json                       MCP bridge dependencies
 +-- .env.example                       Environment template
 +-- .gitignore
 +-- .gitattributes                     LF line endings
@@ -554,6 +600,7 @@ claude-docker/
 |   +-- personas.json                 Worker persona definitions
 |   +-- cleanup.sh                    Full cleanup
 |   +-- install.sh                    Interactive setup script
+|   +-- mcp-bridge-server.js           MCP bridge server (stdio)
 |   +-- claude-docker                  Unified CLI wrapper
 |   +-- remove.sh                     Complete removal script
 +-- docs/
@@ -564,6 +611,7 @@ claude-docker/
     +-- cross-platform.md
     +-- threat-model.md                STRIDE threat analysis
     +-- key-rotation.md                Secret rotation procedures
+    +-- mcp-bridge.md                  MCP bridge architecture and tool reference
     +-- software-verification-plan.md  Verification procedures (SVP)
     +-- reference/                     Platform-specific references
 ```
@@ -579,6 +627,7 @@ claude-docker/
 | [Cross-Platform](docs/cross-platform.md) | Linux / macOS / Windows comparison and templates |
 | [Threat Model](docs/threat-model.md) | STRIDE threat analysis, controls, residual risks |
 | [Key Rotation](docs/key-rotation.md) | Procedures for rotating secrets and OAuth tokens |
+| [MCP Bridge](docs/mcp-bridge.md) | Architecture, 8-tool reference, smart routing, troubleshooting |
 | [SVP](docs/software-verification-plan.md) | Verification procedures for all SRS requirements |
 
 ## License

--- a/docs/mcp-bridge.md
+++ b/docs/mcp-bridge.md
@@ -1,0 +1,522 @@
+# MCP Bridge -- Architecture and Tool Reference
+
+The MCP (Model Context Protocol) Bridge exposes Docker orchestration
+functionality as native tools within a Claude Code session. Instead of
+switching terminals to run `scripts/claude-docker dispatch` or `docker exec`,
+you invoke tools directly from the conversation.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────┐
+│ Claude Code (host session)                       │
+│  ├─ Native tools (Read, Edit, Bash, Agent, ...)  │
+│  └─ MCP: claude-docker                           │
+│       ├─ delegate(account, prompt, model)         │
+│       ├─ analyze(prompt, timeout)                 │
+│       ├─ dispatch(worker, prompt, timeout)        │
+│       ├─ accounts()                               │
+│       ├─ findings(category?, sessionId?)          │
+│       ├─ sessions()                               │
+│       ├─ status(worker?)                          │
+│       └─ budget()                                 │
+└──────────────────┬───────────────────────────────┘
+                   │ stdio
+┌──────────────────┴───────────────────────────────┐
+│ mcp-bridge-server.js (host process, Node.js)     │
+│  ├─ Anthropic SDK (api-key accounts)             │
+│  ├─ docker exec (OAuth accounts)                 │
+│  ├─ Redis client (findings, worker status)       │
+│  └─ Filesystem (session archives)                │
+└──────────────────┬───────────────────────────────┘
+          ┌────────┴────────┐
+          │ Docker layer    │
+          │ ├─ Redis        │
+          │ ├─ Manager      │
+          │ ├─ Worker 1-3   │
+          │ └─ claude-a/b   │
+          └─────────────────┘
+```
+
+### How It Works
+
+1. Claude Code starts `mcp-bridge-server.js` as a child process (stdio transport).
+2. The server reads account credentials from environment variables and
+   `~/.claude-state/` OAuth files at startup.
+3. Tool calls route through one of two paths:
+   - **SDK path** -- API key accounts call the Anthropic API directly from the host.
+   - **Docker path** -- OAuth accounts execute `docker exec <container> claude -p`.
+4. Redis queries (findings, status) connect to `127.0.0.1:6379`, which requires
+   the MCP overlay (`docker-compose.mcp.yml`) to be active.
+
+### Smart Routing
+
+The `delegate` tool uses smart routing to pick the fastest execution path:
+
+| Account Type | Primary Path | Fallback |
+|--------------|-------------|----------|
+| API key | Anthropic SDK (supports model selection) | `docker exec` |
+| OAuth | `docker exec` only | -- |
+
+If the SDK call fails (rate limit, network error), API key accounts
+automatically fall back to `docker exec` on the account's container.
+
+## Prerequisites
+
+- Docker containers running (`scripts/claude-docker up`)
+- Orchestration enabled (Redis + workers in `docker-compose.orchestration.yml`)
+- `MCP_BRIDGE=yes` in `.env` (exposes Redis on `127.0.0.1:6379`)
+- Node.js dependencies installed (`npm install` in project root)
+- At least one account configured (API key in `.env` or OAuth in `~/.claude-state/`)
+
+## Setup
+
+### 1. Enable the MCP overlay
+
+Add to `.env`:
+
+```bash
+MCP_BRIDGE=yes
+```
+
+This activates `docker-compose.mcp.yml`, which exposes Redis on
+`127.0.0.1:6379` (localhost only -- not accessible from the network).
+
+### 2. Install dependencies
+
+```bash
+cd /path/to/claude-docker
+npm install
+```
+
+### 3. Restart containers
+
+```bash
+scripts/claude-docker down
+scripts/claude-docker up
+```
+
+### 4. Verify
+
+Start Claude Code from the project directory. The `.mcp.json` file is
+auto-discovered, and the MCP tools appear in the tool list.
+
+```bash
+claude
+# Inside Claude Code:
+# /mcp   -- should show "claude-docker" server with 8 tools
+```
+
+## Tool Reference
+
+### delegate
+
+Run a prompt on a specified account.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `account` | string | yes | Account name: `manager`, `a`, `b`, `worker-1`, `worker-2`, `worker-3` |
+| `prompt` | string | yes | Prompt to send |
+| `model` | string | no | Model ID (default: `claude-sonnet-4-20250514`). Only effective for API key accounts via SDK path. |
+
+**Example input:**
+
+```json
+{
+  "account": "b",
+  "prompt": "Review this function for security issues:\n\nfunction login(user, pass) { ... }",
+  "model": "claude-sonnet-4-20250514"
+}
+```
+
+**Example output:**
+
+```text
+The function has several security concerns:
+1. Password is not hashed before comparison...
+```
+
+**Routing behavior:**
+- API key account: tries Anthropic SDK first (honors `model`), falls back to `docker exec`.
+- OAuth account: always uses `docker exec` (ignores `model`).
+
+---
+
+### analyze
+
+Run multi-persona parallel analysis across all three worker personas
+(Sentinel, Reviewer, Profiler).
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `prompt` | string | yes | Analysis prompt |
+| `timeout` | number | no | Timeout in seconds, 1-3600 (default: 300) |
+
+**Example input:**
+
+```json
+{
+  "prompt": "Evaluate production readiness of the authentication module",
+  "timeout": 600
+}
+```
+
+**Example output:**
+
+```text
+=== Analysis Results ===
+Time elapsed: 45s
+
+[SECURITY] Sentinel found 3 issues:
+  - HIGH: JWT secret stored in plaintext config
+  - MEDIUM: No rate limiting on login endpoint
+  - LOW: Session token entropy below recommended 128 bits
+
+[QUALITY] Reviewer found 2 issues:
+  - MEDIUM: Duplicate validation logic in login/register
+  - LOW: Dead code in legacy auth adapter
+
+[PERFORMANCE] Profiler found 1 issue:
+  - MEDIUM: Synchronous bcrypt in request handler blocks event loop
+```
+
+**Notes:**
+- Executes via `docker exec` into the manager container, which calls
+  `run_analysis()` from `manager-helpers.sh`.
+- The manager dispatches to all three workers in parallel.
+- Results are stored in Redis and saved to cold storage automatically.
+
+---
+
+### dispatch
+
+Send a task to a specific worker.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `worker` | string | yes | Worker name: `worker-1`, `worker-2`, `worker-3` |
+| `prompt` | string | yes | Task prompt |
+| `timeout` | number | no | Timeout in seconds, 1-3600 (default: 300) |
+
+**Example input:**
+
+```json
+{
+  "worker": "worker-1",
+  "prompt": "Check the /scripts directory for hardcoded secrets or credentials"
+}
+```
+
+**Example output:**
+
+```json
+{
+  "taskId": "t_abc123",
+  "status": "dispatched",
+  "output": "Task dispatched to worker-1..."
+}
+```
+
+**Worker personas:**
+
+| Worker | Persona | Focus Area |
+|--------|---------|------------|
+| `worker-1` | Sentinel (Security Analyst) | Vulnerabilities, secrets, injection, auth |
+| `worker-2` | Reviewer (Code Quality Engineer) | Dead code, duplication, SOLID, complexity |
+| `worker-3` | Profiler (Performance Engineer) | N+1 queries, blocking I/O, memory, bundle size |
+
+---
+
+### accounts
+
+List all configured accounts and their routing status.
+
+**Parameters:** None.
+
+**Example output:**
+
+```json
+[
+  {
+    "name": "manager",
+    "type": "configured",
+    "routing": "sdk",
+    "status": "running"
+  },
+  {
+    "name": "a",
+    "type": "configured",
+    "routing": "docker-exec",
+    "status": "running"
+  },
+  {
+    "name": "worker-1",
+    "type": "configured",
+    "routing": "sdk",
+    "status": "running"
+  }
+]
+```
+
+**Fields:**
+- `routing: "sdk"` -- API key configured, calls go via Anthropic SDK.
+- `routing: "docker-exec"` -- OAuth credentials only, calls go via `docker exec`.
+- `status` -- `running` if the container appears in `docker compose ps`, otherwise `stopped`.
+
+---
+
+### findings
+
+Query analysis findings from live Redis or an archived session.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `category` | string | no | Filter: `security`, `quality`, `performance` |
+| `sessionId` | string | no | Load from archive instead of live Redis |
+
+**Example input (live):**
+
+```json
+{
+  "category": "security"
+}
+```
+
+**Example input (archived):**
+
+```json
+{
+  "sessionId": "20260328T143000Z_a1b2c3d4"
+}
+```
+
+**Example output:**
+
+```json
+[
+  {
+    "category": "security",
+    "severity": "HIGH",
+    "title": "JWT secret in plaintext",
+    "details": "Config file contains unhashed JWT signing key..."
+  }
+]
+```
+
+**Notes:**
+- Without `sessionId`, reads from Redis key `findings:{category}` (or `findings:all`).
+- With `sessionId`, reads from `~/.claude-state/analysis-archive/sessions/{id}/findings.json`.
+- Session IDs are validated against path traversal.
+
+---
+
+### sessions
+
+List archived analysis sessions.
+
+**Parameters:** None.
+
+**Example output:**
+
+```json
+[
+  {
+    "id": "20260328T143000Z_a1b2c3d4",
+    "timestamp": "2026-03-28T14:35:00Z",
+    "findingsCount": 6,
+    "categories": ["security", "quality", "performance"]
+  },
+  {
+    "id": "20260327T090000Z_e5f6g7h8",
+    "timestamp": "2026-03-27T09:12:00Z",
+    "findingsCount": 4,
+    "categories": ["security", "quality"]
+  }
+]
+```
+
+**Notes:**
+- Reads from `~/.claude-state/analysis-archive/sessions/index.json`
+  (or `~/.claude-state/analysis-archive/index.json` as fallback).
+- Maximum 50 sessions retained; oldest pruned automatically.
+
+---
+
+### status
+
+Show worker health and activity status from Redis.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `worker` | string | no | Specific worker (omit for all three) |
+
+**Example input:**
+
+```json
+{
+  "worker": "worker-1"
+}
+```
+
+**Example output:**
+
+```json
+[
+  {
+    "name": "worker-1",
+    "state": "idle",
+    "lastTask": "Check auth module for SQL injection",
+    "timestamp": "2026-03-28T14:30:00Z"
+  }
+]
+```
+
+**States:**
+- `idle` -- Worker is ready for new tasks.
+- `busy` -- Worker is currently processing a task.
+- `offline` -- No status key found in Redis (worker container may be stopped).
+
+**Notes:**
+- Reads from Redis key `worker:{name}:status` which stores JSON with 60s TTL.
+- Workers update this key periodically while running.
+
+---
+
+### budget
+
+Token usage summary.
+
+**Parameters:** None.
+
+**Example output:**
+
+```json
+{
+  "message": "Use 'scripts/claude-docker usage' for detailed tracking"
+}
+```
+
+**Notes:**
+- Currently a pointer to the host-side `usage` subcommand (powered by ccusage).
+- Future enhancement: direct API-based token tracking per account.
+
+## Environment Variables
+
+The `.mcp.json` file passes these variables to the bridge server:
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `REDIS_HOST` | Redis hostname | `127.0.0.1` |
+| `REDIS_PORT` | Redis port | `6379` |
+| `REDIS_PASSWORD` | Redis authentication password | (empty) |
+| `ARCHIVE_DIR` | Session archive directory | `~/.claude-state/analysis-archive` |
+| `DOCKER_COMPOSE_DIR` | Project root for compose commands | `$PWD` |
+| `CLAUDE_API_KEY_MANAGER` | API key for manager account | -- |
+| `CLAUDE_API_KEY_A` | API key for account A | -- |
+| `CLAUDE_API_KEY_B` | API key for account B | -- |
+| `CLAUDE_API_KEY_1` | API key for worker-1 | -- |
+| `CLAUDE_API_KEY_2` | API key for worker-2 | -- |
+| `CLAUDE_API_KEY_3` | API key for worker-3 | -- |
+
+API key variables are optional. Accounts without an API key fall back to OAuth
+credential detection in `~/.claude-state/<account>/`.
+
+## Security
+
+- **Redis binding**: `docker-compose.mcp.yml` binds Redis to `127.0.0.1` only.
+  External hosts cannot reach port 6379.
+- **Opt-in activation**: The MCP overlay is only loaded when `MCP_BRIDGE=yes`
+  is set in `.env`. Redis is not exposed by default.
+- **Timeout validation**: All timeout parameters are parsed with `parseInt()`
+  and clamped to 1-3600 seconds.
+- **Path traversal protection**: The `findings` tool validates `sessionId`
+  using `path.resolve()` + `startsWith()` to prevent directory escape.
+- **Shell injection prevention**: All subprocess calls use `execFile` (not
+  `exec`), which does not spawn a shell.
+- **API key isolation**: Keys are passed via environment variables, never
+  logged or included in error messages.
+
+## Troubleshooting
+
+### MCP server not detected
+
+Verify `.mcp.json` exists in the project root and contains the
+`claude-docker` entry. Restart Claude Code after adding the file.
+
+```bash
+# Check the file
+cat .mcp.json
+```
+
+### "Redis connection refused"
+
+The MCP overlay is not active. Verify:
+
+```bash
+# Check .env has MCP_BRIDGE=yes
+grep MCP_BRIDGE .env
+
+# Verify Redis port is exposed
+docker compose ps redis
+docker compose port redis 6379
+```
+
+If Redis is running but the port is not mapped, restart with the overlay:
+
+```bash
+scripts/claude-docker down
+echo "MCP_BRIDGE=yes" >> .env
+scripts/claude-docker up
+```
+
+### "Unknown account: ..."
+
+The account has no API key and no OAuth credentials. Check:
+
+```bash
+# API key configured?
+grep CLAUDE_API_KEY .env
+
+# OAuth credentials present?
+ls ~/.claude-state/account-*/. credentials.json
+```
+
+### delegate returns error for model selection
+
+Model selection only works for API key accounts (SDK path). OAuth accounts
+ignore the `model` parameter and use the default model configured in the
+container's Claude Code instance.
+
+### analyze times out
+
+Increase the timeout (default 300s). Large codebases may need 600-900s:
+
+```json
+{ "prompt": "full analysis", "timeout": 900 }
+```
+
+Also verify all worker containers are running:
+
+```bash
+scripts/claude-docker ps
+```
+
+### Stale worker status shows "offline"
+
+Worker status keys in Redis have a 60-second TTL. If a worker was recently
+restarted, wait for it to update its status. Check container health:
+
+```bash
+scripts/claude-docker ps
+scripts/claude-docker logs worker-1 --tail 20
+```


### PR DESCRIPTION
## What

### Summary
Adds comprehensive MCP bridge documentation: a new reference document, README updates, and CLAUDE.md guidance for using orchestration tools natively.

### Change Type
- [x] Documentation

## Why

### Related Issues
- Closes #112

### Motivation
The MCP bridge server (PRs #115-#117) introduced 8 tools but had no user-facing documentation. Users need a setup guide, tool reference with input/output examples, and troubleshooting help.

## Where

### Files Changed
| File | Change |
|------|--------|
| `docs/mcp-bridge.md` | New: architecture diagram, 8-tool reference with input/output examples, env vars, security notes, troubleshooting |
| `README.md` | Added MCP Bridge section (setup + tool table), MCP overlay in Compose Overrides table, new files in Project Structure |
| `CLAUDE.md` | Added MCP Bridge Tools section: when to use each tool, delegate vs analyze vs dispatch guidance |