### PR TITLE
feat(mcp): add unified token budget tracking across accounts

### DIFF
--- a/docs/mcp-bridge.md
+++ b/docs/mcp-bridge.md
@@ -394,7 +394,7 @@ Show worker health and activity status from Redis.
 
 ### budget
 
-Token usage summary.
+Token usage per account aggregated during the current MCP server session.
 
 **Parameters:** None.
 
@@ -402,13 +402,43 @@ Token usage summary.
 
 ```json
 {
-  "message": "Use 'scripts/claude-docker usage' for detailed tracking"
+  "accounts": [
+    {
+      "name": "manager",
+      "type": "configured",
+      "inputTokens": 12500,
+      "outputTokens": 8300,
+      "calls": 5
+    },
+    {
+      "name": "a",
+      "type": "configured",
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "calls": 0
+    },
+    {
+      "name": "worker-1",
+      "status": "unavailable"
+    }
+  ],
+  "total": {
+    "inputTokens": 12500,
+    "outputTokens": 8300
+  }
 }
 ```
 
+**Data sources:**
+- **API key accounts**: Token counts cached in-memory from each `delegate` SDK call.
+  The `calls` field shows how many delegate calls were made this session.
+  Accounts with no delegate calls yet show zero counts.
+- **OAuth accounts**: Queried via `docker exec <container> claude usage --json`.
+  If the container is stopped or the command fails, `status: "unavailable"` is returned.
+
 **Notes:**
-- Currently a pointer to the host-side `usage` subcommand (powered by ccusage).
-- Future enhancement: direct API-based token tracking per account.
+- Usage data resets when the MCP server restarts (session-level only).
+- For persistent historical tracking, use `scripts/claude-docker usage`.
 
 ## Environment Variables
 

--- a/scripts/mcp-bridge-server.js
+++ b/scripts/mcp-bridge-server.js
@@ -171,6 +171,23 @@ function resetAccountsRegistry() {
 }
 
 // ---------------------------------------------------------------------------
+// Token usage cache — session-level per-account aggregation from SDK calls
+// ---------------------------------------------------------------------------
+
+// { [accountName]: { inputTokens: number, outputTokens: number, calls: number } }
+const usageCache = {};
+
+function recordUsage(account, usage) {
+  if (!usage) return;
+  if (!usageCache[account]) {
+    usageCache[account] = { inputTokens: 0, outputTokens: 0, calls: 0 };
+  }
+  usageCache[account].inputTokens += usage.input_tokens || 0;
+  usageCache[account].outputTokens += usage.output_tokens || 0;
+  usageCache[account].calls += 1;
+}
+
+// ---------------------------------------------------------------------------
 // Tool definitions
 // ---------------------------------------------------------------------------
 
@@ -246,7 +263,7 @@ const TOOLS = [
   },
   {
     name: 'budget',
-    description: 'Token usage information',
+    description: 'Token usage per account (API key: session cache, OAuth: container query)',
     inputSchema: { type: 'object', properties: {} },
   },
 ];
@@ -262,10 +279,11 @@ async function delegateViaSDK(apiKey, prompt, model) {
     max_tokens: 4096,
     messages: [{ role: 'user', content: prompt }],
   });
-  return response.content
+  const text = response.content
     .filter((b) => b.type === 'text')
     .map((b) => b.text)
     .join('\n');
+  return { text, usage: response.usage };
 }
 
 async function delegateViaDocker(service, prompt) {
@@ -288,7 +306,9 @@ async function handleDelegate({ account, prompt, model }) {
   if (entry.type === 'api-key') {
     // Primary: Anthropic SDK (supports model selection)
     try {
-      return await delegateViaSDK(entry.apiKey, prompt, model);
+      const { text, usage } = await delegateViaSDK(entry.apiKey, prompt, model);
+      recordUsage(account, usage);
+      return text;
     } catch (sdkErr) {
       // Fallback: docker exec if SDK fails
       try {
@@ -432,10 +452,69 @@ async function handleStatus({ worker } = {}) {
   }
 }
 
-function handleBudget() {
-  return JSON.stringify({
-    message: "Use 'scripts/claude-docker usage' for detailed tracking",
-  });
+async function handleBudget() {
+  const registry = await getAccountsRegistry();
+  const accounts = [];
+  const total = { inputTokens: 0, outputTokens: 0 };
+
+  for (const [name, entry] of Object.entries(registry)) {
+    // API key accounts: use in-memory usage cache
+    if (entry.type === 'api-key' && usageCache[name]) {
+      const cached = usageCache[name];
+      accounts.push({
+        name,
+        type: 'configured',
+        inputTokens: cached.inputTokens,
+        outputTokens: cached.outputTokens,
+        calls: cached.calls,
+      });
+      total.inputTokens += cached.inputTokens;
+      total.outputTokens += cached.outputTokens;
+      continue;
+    }
+
+    // OAuth accounts: try docker exec claude usage
+    if (entry.type === 'oauth') {
+      try {
+        const composeName = await getComposeProjectName();
+        const container = `${composeName}-${entry.service}-1`;
+        const { stdout } = await run(
+          'docker', ['exec', '-T', container, 'claude', 'usage', '--json'],
+          { timeout: 15_000 },
+        );
+        const data = JSON.parse(stdout);
+        const input = data.inputTokens || data.input_tokens || 0;
+        const output = data.outputTokens || data.output_tokens || 0;
+        accounts.push({
+          name,
+          type: 'configured',
+          inputTokens: input,
+          outputTokens: output,
+        });
+        total.inputTokens += input;
+        total.outputTokens += output;
+      } catch {
+        accounts.push({ name, status: 'unavailable' });
+      }
+      continue;
+    }
+
+    // API key account with no cached usage yet
+    if (entry.type === 'api-key') {
+      accounts.push({
+        name,
+        type: 'configured',
+        inputTokens: 0,
+        outputTokens: 0,
+        calls: 0,
+      });
+      continue;
+    }
+
+    accounts.push({ name, status: 'unavailable' });
+  }
+
+  return JSON.stringify({ accounts, total }, null, 2);
 }
 
 // ---------------------------------------------------------------------------
@@ -479,7 +558,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         result = await handleStatus(args);
         break;
       case 'budget':
-        result = handleBudget();
+        result = await handleBudget();
         break;
       default:
         return {


### PR DESCRIPTION
## What

### Summary
Replaces the placeholder `handleBudget` with real per-account token usage tracking. API key accounts aggregate from SDK response headers cached in-memory; OAuth accounts query containers via `docker exec claude usage --json`.

### Change Type
- [x] Feature (new functionality)

## Why

### Related Issues
- Closes #113

### Motivation
The budget tool was a placeholder returning a static message. Users need actual token consumption data per account to manage costs across multiple Claude instances.

## Where

### Files Changed
| File | Change |
|------|--------|
| `scripts/mcp-bridge-server.js` | Added `usageCache` + `recordUsage()`, modified `delegateViaSDK` to return usage, replaced `handleBudget` placeholder with real aggregation |
| `docs/mcp-bridge.md` | Updated budget tool docs with new output format and data source explanation |

## How

### Implementation Details
1. **`usageCache`** (in-memory Map) — records `{ inputTokens, outputTokens, calls }` per account name
2. **`recordUsage(account, usage)`** — called after each successful `delegateViaSDK` call, accumulates `response.usage.input_tokens` / `output_tokens`
3. **`delegateViaSDK`** — now returns `{ text, usage }` instead of plain text; `handleDelegate` destructures and caches
4. **`handleBudget`** — iterates registry:
   - API key accounts: reads from `usageCache` (zero if no calls yet)
   - OAuth accounts: `docker exec <container> claude usage --json` with 15s timeout, falls back to `{ status: "unavailable" }`
5. Returns `{ accounts: [...], total: { inputTokens, outputTokens } }`

### Testing Approach
- SDK path: delegate call followed by budget call should show accumulated tokens
- OAuth path: budget call with running containers should return parsed usage
- Unavailable: stopped container returns `status: "unavailable"` gracefully