### PR TITLE
refactor: simplify Dockerfile, CLI wrapper, installer, and uninstaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,12 @@
-# SRS-5.1.1: Base MUST be node:20-slim (Debian/glibc, NOT Alpine)
+# Base: node:20-slim (Debian/glibc)
 FROM node:20-slim
 
-# SRS-5.1.3: Version pinning via build arg
+# Version pinning via build arg (omit for latest)
 ARG CLAUDE_CODE_VERSION
-# Why: Omitting default means "latest" when --build-arg is not passed.
-# Pinning: docker build --build-arg CLAUDE_CODE_VERSION=1.2.3 .
 
-# SRS-5.1.6: WORKDIR must NOT be / (causes full filesystem scan on install)
 WORKDIR /workspace
 
-# SRS-5.1.4: Dev tools — single layer, cache cleaned
-# SRS-5.1.8: apt cache removed in same RUN to avoid layer bloat
-# SRS-5.1.11: redis-tools for Phase 5 orchestration (redis-cli)
+# Dev tools — single layer, cache cleaned
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        git \
@@ -20,7 +15,6 @@ RUN apt-get update \
        fzf \
        zsh \
        sudo \
-       redis-tools \
     && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub CLI (gh) — separate layer for cache efficiency
@@ -33,22 +27,14 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
-# SRS-5.1.2: Install Claude Code globally
-# SRS-5.1.8: npm cache cleaned in same RUN
+# Install Claude Code globally
 RUN npm install -g @anthropic-ai/claude-code${CLAUDE_CODE_VERSION:+@$CLAUDE_CODE_VERSION} \
     && npm cache clean --force
 
-# SRS-5.1.12: Redis client for worker-server.js orchestration (Phase 5)
-RUN npm install -g redis \
-    && npm cache clean --force
+# Memory heap limit
+ENV NODE_OPTIONS=--max-old-space-size=4096
 
-# SRS-5.1.5: Memory heap limit
-# NODE_PATH: Allow require() to find globally installed npm packages (e.g. redis)
-ENV NODE_OPTIONS=--max-old-space-size=4096 \
-    NODE_PATH=/usr/local/lib/node_modules
-
-# SRS-5.1.7: Run as non-root user
-# Why: node user (UID 1000) comes pre-created in node:20-slim
+# Run as non-root (node user UID 1000 is pre-created in node:20-slim)
 USER node
 
 # Default command keeps container alive for docker compose exec

--- a/scripts/claude-docker
+++ b/scripts/claude-docker
@@ -1,31 +1,18 @@
 #!/usr/bin/env bash
-# claude-docker — unified CLI wrapper
-# Automatically builds the correct docker compose -f chain from your
-# environment and provides short subcommands for common operations.
+# claude-docker — multi-account CLI wrapper
+# Run multiple Claude Code instances with independent accounts.
 #
-# Usage:
-#   scripts/claude-docker <command> [args...]
+# Usage:  scripts/claude-docker <command> [args...]
 #
 # Commands:
-#   up            Start all containers (detached)
-#   down          Stop all containers
-#   restart       Restart all containers
-#   logs          Follow container logs (Ctrl+C to stop)
-#   ps            Show container status
-#   exec <svc>    Open interactive shell in a service
-#   claude [svc]  Start Claude Code in a service (default: claude-a or manager)
-#   dispatch <worker> <prompt>   Dispatch task to a worker
-#   status        Show worker status (orchestration)
-#   findings      Show accumulated findings (orchestration)
-#   save          Save session to cold archive
-#   restore [id]  Restore session from archive (default: latest)
-#   sessions      List archived sessions
-#   analyze <prompt>  Multi-persona project analysis
-#   usage [type]  Show token usage report (requires Node.js on host)
-#   build         Build/rebuild Docker image
-#   config        Show resolved compose configuration
-#   compose ...   Pass raw args to docker compose (with auto -f flags)
-#   help          Show this help message
+#   up/down/restart   Manage containers
+#   claude [svc]      Start Claude Code (default: claude-a)
+#   auth [svc]        Inject OAuth credentials from macOS Keychain
+#   exec <svc>        Open shell in a service
+#   usage [type]      Token usage report
+#   build             Build/rebuild Docker image
+#   config/compose    Advanced compose operations
+#   help              Show help
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -50,7 +37,7 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 # Detect which overlay files are active by checking:
 # 1. Which compose files exist on disk
 # 2. Platform detection for linux override
-# 3. .env hints for worktree/orchestration/firewall
+# 3. .env hints for worktree
 build_compose_cmd() {
     local cmd="docker compose"
     local project_root="$PROJECT_ROOT"
@@ -74,30 +61,6 @@ build_compose_cmd() {
         fi
     fi
 
-    # Orchestration overlay: check if compose file exists AND has orchestration env vars
-    if [[ -f "${project_root}/docker-compose.orchestration.yml" ]]; then
-        # Check if orchestration services are expected (manager state dir exists or API key set)
-        if [[ -d "$HOME/.claude-state/account-manager" ]] || \
-           grep -qE '^CLAUDE_API_KEY_MANAGER=' "${project_root}/.env" 2>/dev/null; then
-            cmd+=" -f ${project_root}/docker-compose.orchestration.yml"
-        fi
-    fi
-
-    # Firewall overlay: only if init-firewall.sh exists (user opted in)
-    if [[ -f "${project_root}/docker-compose.firewall.yml" ]] && \
-       [[ -f "${project_root}/scripts/init-firewall.sh" ]]; then
-        # Check if firewall was enabled during install (heuristic: firewall compose exists)
-        # User can force with: claude-docker compose -f docker-compose.firewall.yml ...
-        cmd+=" -f ${project_root}/docker-compose.firewall.yml"
-    fi
-
-    # MCP Bridge overlay: opt-in via MCP_BRIDGE env var or .env setting
-    if [[ -f "${project_root}/docker-compose.mcp.yml" ]]; then
-        if [[ -n "${MCP_BRIDGE:-}" ]] || grep -qE '^MCP_BRIDGE=yes' "$PROJECT_ROOT/.env" 2>/dev/null; then
-            cmd+=" -f ${project_root}/docker-compose.mcp.yml"
-        fi
-    fi
-
     echo "$cmd"
 }
 
@@ -112,13 +75,7 @@ get_compose_cmd() {
 
 # Determine the primary interactive service
 get_primary_service() {
-    local cmd
-    cmd=$(get_compose_cmd)
-    if [[ "$cmd" == *"orchestration"* ]]; then
-        echo "manager"
-    else
-        echo "claude-a"
-    fi
+    echo "claude-a"
 }
 
 # --- Config Dir Path Builder ---------------------------------------------------
@@ -163,44 +120,12 @@ build_merged_config_dir() {
 
 # --- Subcommands --------------------------------------------------------------
 
-# Resolve WORKER_COUNT: env var takes precedence over .env file
-resolve_worker_count() {
-    local worker_count="${WORKER_COUNT:-}"
-    if [[ -z "$worker_count" ]] && [[ -f "${PROJECT_ROOT}/.env" ]]; then
-        worker_count=$(grep -E '^WORKER_COUNT=' "${PROJECT_ROOT}/.env" 2>/dev/null | cut -d'=' -f2- || true)
-    fi
-    echo "${worker_count:-3}"  # final default
-}
-
 cmd_up() {
     local cmd
     cmd=$(get_compose_cmd)
-    local profile_flags=""
-
-    # Add --profile full for WORKER_COUNT >= 2 in orchestration mode
-    if [[ "$cmd" == *"orchestration"* ]]; then
-        local wc
-        wc=$(resolve_worker_count)
-        if (( wc >= 2 )); then
-            profile_flags="--profile full"
-        fi
-        log_info "Worker count: $wc"
-    fi
-
     echo -e "${CYAN}Starting containers...${NC}"
-    echo -e "${DIM}  $cmd $profile_flags up -d${NC}"
-    eval "$cmd $profile_flags up -d" "$@"
-
-    # WORKER_COUNT=2: stop worker-3 after start (profile includes both worker-2 and worker-3)
-    if [[ "$cmd" == *"orchestration"* ]]; then
-        local wc
-        wc=$(resolve_worker_count)
-        if [[ "$wc" == "2" ]]; then
-            log_info "Stopping worker-3 (WORKER_COUNT=2 mode)"
-            eval "$cmd stop worker-3" 2>/dev/null || true
-        fi
-    fi
-
+    echo -e "${DIM}  $cmd up -d${NC}"
+    eval "$cmd up -d" "$@"
     echo -e "${GREEN}Containers started.${NC}"
     echo ""
     eval "$cmd ps"
@@ -279,10 +204,6 @@ inject_credentials() {
     case "$svc" in
         claude-a)  state_dir="$HOME/.claude-state/account-a" ;;
         claude-b)  state_dir="$HOME/.claude-state/account-b" ;;
-        manager)   state_dir="$HOME/.claude-state/account-manager" ;;
-        worker-1)  state_dir="$HOME/.claude-state/account-w1" ;;
-        worker-2)  state_dir="$HOME/.claude-state/account-w2" ;;
-        worker-3)  state_dir="$HOME/.claude-state/account-w3" ;;
         *)         state_dir="$HOME/.claude-state/account-${svc}" ;;
     esac
 
@@ -319,8 +240,6 @@ cmd_auth() {
     local services=()
     if [[ -n "$service" ]]; then
         services=("$service")
-    elif [[ "$cmd" == *"orchestration"* ]]; then
-        services=("manager" "worker-1" "worker-2" "worker-3")
     else
         services=("claude-a" "claude-b")
     fi
@@ -345,51 +264,6 @@ cmd_auth() {
     else
         log_info "Containers not running. Credentials will be available on next start."
     fi
-}
-
-cmd_dispatch() {
-    local worker="${1:?Usage: claude-docker dispatch <worker> <prompt>}"
-    local prompt="${2:?Usage: claude-docker dispatch <worker> <prompt>}"
-    shift 2
-    local timeout="${1:-300}"
-    local cmd
-    cmd=$(get_compose_cmd)
-    echo -e "${CYAN}Dispatching task to $worker...${NC}"
-    eval "$cmd exec -T manager bash -c 'source /scripts/manager-helpers.sh && dispatch_task \"$worker\" \"$prompt\" $timeout'"
-}
-
-cmd_status() {
-    local cmd
-    cmd=$(get_compose_cmd)
-    eval "$cmd exec -T manager bash -c 'source /scripts/manager-helpers.sh && get_worker_status'"
-}
-
-cmd_findings() {
-    local category="${1:-all}"
-    local cmd
-    cmd=$(get_compose_cmd)
-    eval "$cmd exec -T manager bash -c 'source /scripts/manager-helpers.sh && get_findings $category'"
-}
-
-cmd_save() {
-    local cmd
-    cmd=$(get_compose_cmd)
-    echo -e "${CYAN}Saving session to cold archive...${NC}"
-    eval "$cmd exec -T manager bash -c 'source /scripts/manager-helpers.sh && save_session'"
-}
-
-cmd_restore() {
-    local session_id="${1:-latest}"
-    local cmd
-    cmd=$(get_compose_cmd)
-    echo -e "${CYAN}Restoring session: $session_id${NC}"
-    eval "$cmd exec -T manager bash -c 'source /scripts/manager-helpers.sh && restore_session $session_id'"
-}
-
-cmd_sessions() {
-    local cmd
-    cmd=$(get_compose_cmd)
-    eval "$cmd exec -T manager bash -c 'source /scripts/manager-helpers.sh && list_sessions'"
 }
 
 cmd_build() {
@@ -476,27 +350,13 @@ cmd_usage() {
     CLAUDE_CONFIG_DIR="$merged_dir" npx ccusage@latest "$report_type" ${pass_args[@]+"${pass_args[@]}"}
 }
 
-cmd_analyze() {
-    local prompt="${1:?Usage: claude-docker analyze <prompt> [timeout]}"
-    shift
-    local timeout="${1:-300}"
-    local cmd
-    cmd=$(get_compose_cmd)
-    echo -e "${BOLD}Multi-Persona Analysis${NC}"
-    echo -e "${DIM}Dispatching to Sentinel, Reviewer, and Profiler...${NC}"
-    echo ""
-    eval "$cmd exec -T manager bash -c 'source /scripts/manager-helpers.sh && run_analysis \"\$1\" \"\$2\"' -- \"$prompt\" \"$timeout\""
-}
-
 cmd_help() {
     local cmd
     cmd=$(get_compose_cmd)
-    local primary
-    primary=$(get_primary_service)
 
     cat <<HELP
 
-${BOLD}claude-docker${NC} — unified CLI wrapper
+${BOLD}claude-docker${NC} — multi-account CLI wrapper
 
 ${BOLD}USAGE${NC}
   scripts/claude-docker <command> [args...]
@@ -510,23 +370,9 @@ ${BOLD}LIFECYCLE${NC}
   ${GREEN}logs${NC}                  Follow container logs
 
 ${BOLD}INTERACTIVE${NC}
-  ${GREEN}claude${NC} [service]      Start Claude Code (default: $primary)
-  ${GREEN}auth${NC} [service]        Authenticate Claude Code (OAuth login in container)
+  ${GREEN}claude${NC} [service]      Start Claude Code (default: claude-a)
+  ${GREEN}auth${NC} [service]        Inject OAuth credentials from macOS Keychain
   ${GREEN}exec${NC} <service>        Open shell in a service
-
-${BOLD}ORCHESTRATION${NC}
-  ${GREEN}dispatch${NC} <worker> <prompt>   Send task to worker
-  ${GREEN}status${NC}                Show worker status
-  ${GREEN}findings${NC} [category]   Show accumulated findings
-
-${BOLD}ANALYSIS${NC}
-  ${GREEN}analyze${NC} <prompt> [timeout]  Multi-persona project analysis (default: 300s)
-                              Dispatches to Sentinel, Reviewer, and Profiler
-
-${BOLD}COLD MEMORY${NC}
-  ${GREEN}save${NC}                  Save session to archive
-  ${GREEN}restore${NC} [id|latest]   Restore session from archive
-  ${GREEN}sessions${NC}              List archived sessions
 
 ${BOLD}USAGE TRACKING${NC}
   ${GREEN}usage${NC} [type] [flags]  Token usage report (default: daily)
@@ -536,6 +382,10 @@ ${BOLD}USAGE TRACKING${NC}
 ${BOLD}ADVANCED${NC}
   ${GREEN}config${NC}                Show resolved compose configuration
   ${GREEN}compose${NC} ...           Pass raw args to docker compose
+
+${BOLD}SERVICES${NC}
+  claude-a              Account A (default)
+  claude-b              Account B
 
 ${BOLD}DETECTED COMPOSE COMMAND${NC}
   ${DIM}$cmd${NC}
@@ -558,13 +408,6 @@ main() {
         exec)      cmd_exec "$@" ;;
         claude)    cmd_claude "$@" ;;
         auth)      cmd_auth "$@" ;;
-        dispatch)  cmd_dispatch "$@" ;;
-        status)    cmd_status "$@" ;;
-        findings)  cmd_findings "$@" ;;
-        save)      cmd_save "$@" ;;
-        restore)   cmd_restore "$@" ;;
-        sessions)  cmd_sessions "$@" ;;
-        analyze)   cmd_analyze "$@" ;;
         usage)     cmd_usage "$@" ;;
         build)     cmd_build "$@" ;;
         config)    cmd_config "$@" ;;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,17 +24,10 @@ CURRENT_STEP=0
 PLATFORM=""
 AUTH_PATH=""
 TIER=""
-ORCHESTRATION="no"
-FIREWALL="yes"
 SOURCE_DIR=""
 CLAUDE_VERSION=""
 API_KEY_A=""
 API_KEY_B=""
-API_KEY_MANAGER=""
-API_KEY_W1=""
-API_KEY_W2=""
-API_KEY_W3=""
-WORKER_COUNT=3
 
 # --- Utility Functions --------------------------------------------------------
 
@@ -417,22 +410,6 @@ collect_configuration() {
     [[ "$tier_choice" == *"Tier A"* ]] && TIER="A" || TIER="B"
     log_info "Source sharing: Tier $TIER"
 
-    # Orchestration
-    if prompt_confirm "Enable Phase 5 orchestration (manager + 3 workers + Redis)?"; then
-        ORCHESTRATION="yes"
-        log_info "Orchestration: enabled"
-    else
-        log_info "Orchestration: disabled (standard 2-container setup)"
-    fi
-
-    # Firewall (default: enabled for security)
-    if prompt_confirm "Disable outbound firewall? (default: enabled for security)" "n"; then
-        FIREWALL="no"
-        log_warn "Firewall: disabled (containers will have unrestricted egress)"
-    else
-        log_info "Firewall: enabled (outbound traffic restricted to allowlisted hosts)"
-    fi
-
     # Project directory
     SOURCE_DIR=$(prompt_input "Absolute path to your project source code" "$(pwd)")
     SOURCE_DIR=$(cd "$SOURCE_DIR" 2>/dev/null && pwd || echo "$SOURCE_DIR")
@@ -483,16 +460,6 @@ collect_configuration() {
         log_success "API keys collected (2 accounts)"
     fi
 
-    # Orchestration API keys
-    if [[ "$ORCHESTRATION" == "yes" && "$AUTH_PATH" == "B" ]]; then
-        echo -e "\n${CYAN}Enter API keys for orchestration accounts:${NC}"
-        API_KEY_MANAGER=$(prompt_secret "API key for Manager")
-        API_KEY_W1=$(prompt_secret "API key for Worker 1")
-        API_KEY_W2=$(prompt_secret "API key for Worker 2")
-        API_KEY_W3=$(prompt_secret "API key for Worker 3")
-        WORKER_COUNT=$(prompt_input "Number of workers" "3")
-        log_success "Orchestration API keys collected"
-    fi
 }
 
 # --- .env Generation ----------------------------------------------------------
@@ -546,22 +513,6 @@ generate_env() {
             echo ""
         fi
 
-        if [[ "$ORCHESTRATION" == "yes" ]]; then
-            echo "# ==== Phase 5: Orchestration ===="
-            echo "WORKER_COUNT=$WORKER_COUNT"
-            if [[ "$AUTH_PATH" == "B" ]]; then
-                echo "CLAUDE_API_KEY_MANAGER=$API_KEY_MANAGER"
-                echo "CLAUDE_API_KEY_1=$API_KEY_W1"
-                echo "CLAUDE_API_KEY_2=$API_KEY_W2"
-                echo "CLAUDE_API_KEY_3=$API_KEY_W3"
-            fi
-            echo ""
-
-            echo "# ==== Security: Worker & Redis Auth ===="
-            echo "WORKER_AUTH_TOKEN=$(openssl rand -hex 32)"
-            echo "REDIS_PASSWORD=$(openssl rand -hex 32)"
-            echo ""
-        fi
     } > "$env_file"
 
     chmod 600 "$env_file"
@@ -577,16 +528,6 @@ create_state_dirs() {
         "$HOME/.claude-state/account-a"
         "$HOME/.claude-state/account-b"
     )
-
-    if [[ "$ORCHESTRATION" == "yes" ]]; then
-        dirs+=(
-            "$HOME/.claude-state/account-manager"
-            "$HOME/.claude-state/account-w1"
-            "$HOME/.claude-state/account-w2"
-            "$HOME/.claude-state/account-w3"
-            "$HOME/.claude-state/analysis-archive/sessions"
-        )
-    fi
 
     for dir in "${dirs[@]}"; do
         if [[ -d "$dir" ]]; then
@@ -701,14 +642,6 @@ build_compose_cmd() {
         cmd+=" -f docker-compose.worktree.yml"
     fi
 
-    if [[ "$ORCHESTRATION" == "yes" ]]; then
-        cmd+=" -f docker-compose.orchestration.yml"
-    fi
-
-    if [[ "$FIREWALL" == "yes" ]]; then
-        cmd+=" -f docker-compose.firewall.yml"
-    fi
-
     echo "$cmd"
 }
 
@@ -728,23 +661,8 @@ start_containers() {
         GID=$(id -g)
     fi
 
-    # Select worker profile based on WORKER_COUNT
-    local profile_flags=""
-    if [[ "$ORCHESTRATION" == "yes" ]]; then
-        if (( WORKER_COUNT >= 2 )); then
-            profile_flags="--profile full"
-        fi
-        log_info "Worker count: $WORKER_COUNT"
-    fi
-
-    log_info "Compose command: $compose_cmd $profile_flags up -d"
-    eval "$compose_cmd $profile_flags up -d" 2>&1
-
-    # WORKER_COUNT=2: stop worker-3 after start
-    if [[ "$ORCHESTRATION" == "yes" && "$WORKER_COUNT" == "2" ]]; then
-        log_info "Stopping worker-3 (WORKER_COUNT=2 mode)"
-        eval "$compose_cmd stop worker-3" 2>/dev/null || true
-    fi
+    log_info "Compose command: $compose_cmd up -d"
+    eval "$compose_cmd up -d" 2>&1
 
     log_success "Containers started"
 }
@@ -760,9 +678,6 @@ install_dependencies() {
     compose_cmd=$(build_compose_cmd)
 
     local services=("claude-a" "claude-b")
-    if [[ "$ORCHESTRATION" == "yes" ]]; then
-        services=("manager" "worker-1" "worker-2" "worker-3")
-    fi
 
     for svc in "${services[@]}"; do
         log_info "Installing npm dependencies in $svc..."
@@ -770,33 +685,6 @@ install_dependencies() {
             log_success "$svc: dependencies installed"
         else
             log_warn "$svc: npm install skipped or failed (project may not have package.json)"
-        fi
-    done
-}
-
-# --- Firewall Setup -----------------------------------------------------------
-
-setup_firewall() {
-    if [[ "$FIREWALL" != "yes" ]]; then
-        return 0
-    fi
-
-    log_step "Activating outbound firewall"
-
-    local compose_cmd
-    compose_cmd=$(build_compose_cmd)
-
-    local services=("claude-a" "claude-b")
-    if [[ "$ORCHESTRATION" == "yes" ]]; then
-        services=("manager" "worker-1" "worker-2" "worker-3")
-    fi
-
-    for svc in "${services[@]}"; do
-        log_info "Applying firewall rules in $svc..."
-        if eval "$compose_cmd exec -T $svc bash /scripts/init-firewall.sh" 2>&1 | tail -3; then
-            log_success "$svc: firewall active"
-        else
-            log_warn "$svc: firewall setup failed (may need NET_ADMIN capability)"
         fi
     done
 }
@@ -811,7 +699,6 @@ run_verification() {
     local compose_cmd
     compose_cmd=$(build_compose_cmd)
     local primary_svc="claude-a"
-    [[ "$ORCHESTRATION" == "yes" ]] && primary_svc="manager"
 
     # Check container is running
     if eval "$compose_cmd ps --format '{{.Name}}' 2>/dev/null" | grep -q "$primary_svc"; then
@@ -852,8 +739,6 @@ print_summary() {
     echo -e "  Platform:        $(platform_label "$PLATFORM")"
     echo -e "  Authentication:  Path $AUTH_PATH"
     echo -e "  Source sharing:  Tier $TIER"
-    echo -e "  Orchestration:   $ORCHESTRATION"
-    echo -e "  Firewall:        $FIREWALL"
     echo -e "  Project:         $SOURCE_DIR"
     echo ""
     echo -e "${BOLD}Quick Commands (via CLI wrapper):${NC}"
@@ -862,21 +747,8 @@ print_summary() {
     echo -e "  scripts/claude-docker claude"
     echo ""
 
-    if [[ "$ORCHESTRATION" == "yes" ]]; then
-        echo -e "  ${CYAN}# Dispatch task to a worker${NC}"
-        echo -e "  scripts/claude-docker dispatch worker-1 \"analyze auth module\""
-        echo ""
-        echo -e "  ${CYAN}# Check worker status / findings${NC}"
-        echo -e "  scripts/claude-docker status"
-        echo -e "  scripts/claude-docker findings"
-        echo ""
-        echo -e "  ${CYAN}# Save / restore session${NC}"
-        echo -e "  scripts/claude-docker save"
-        echo -e "  scripts/claude-docker restore latest"
-    else
-        echo -e "  ${CYAN}# Start second account (separate terminal)${NC}"
-        echo -e "  scripts/claude-docker claude claude-b"
-    fi
+    echo -e "  ${CYAN}# Start second account (separate terminal)${NC}"
+    echo -e "  scripts/claude-docker claude claude-b"
 
     echo ""
     echo -e "  ${CYAN}# Container management${NC}"
@@ -929,10 +801,8 @@ main() {
     collect_configuration
 
     # Calculate total steps based on choices
-    TOTAL_STEPS=7  # base: prereqs, env, dirs, build, auth, start, verify
+    TOTAL_STEPS=8  # prereqs, env, dirs, build, auth, start, deps, verify
     [[ "$TIER" == "B" ]] && TOTAL_STEPS=$((TOTAL_STEPS + 1))
-    [[ "$FIREWALL" == "yes" ]] && TOTAL_STEPS=$((TOTAL_STEPS + 1))
-    TOTAL_STEPS=$((TOTAL_STEPS + 1))  # dependency install
 
     # Show configuration summary
     echo ""
@@ -940,8 +810,6 @@ main() {
     echo -e "  Platform:        $(platform_label "$PLATFORM")"
     echo -e "  Authentication:  Path $AUTH_PATH"
     echo -e "  Source sharing:  Tier $TIER"
-    echo -e "  Orchestration:   $ORCHESTRATION"
-    echo -e "  Firewall:        $FIREWALL"
     echo -e "  Project:         $SOURCE_DIR"
     echo -e "  Claude version:  ${CLAUDE_VERSION:-latest}"
     echo ""
@@ -960,7 +828,6 @@ main() {
     setup_worktrees
     start_containers
     install_dependencies
-    setup_firewall
     run_verification
     print_summary
 }

--- a/scripts/remove.sh
+++ b/scripts/remove.sh
@@ -66,10 +66,6 @@ build_full_compose_cmd() {
         cmd+=" -f docker-compose.linux.yml"
     [[ -f "$PROJECT_ROOT/docker-compose.worktree.yml" ]] && \
         cmd+=" -f docker-compose.worktree.yml"
-    [[ -f "$PROJECT_ROOT/docker-compose.orchestration.yml" ]] && \
-        cmd+=" -f docker-compose.orchestration.yml"
-    [[ -f "$PROJECT_ROOT/docker-compose.firewall.yml" ]] && \
-        cmd+=" -f docker-compose.firewall.yml"
 
     echo "$cmd"
 }
@@ -190,40 +186,11 @@ remove_state_directories() {
         echo -e "${DIM}    $item ($size)${NC}"
     done
 
-    # Analysis archive — ask separately (may contain valuable session history)
-    if [[ -d "$state_root/analysis-archive" ]]; then
-        local session_count=0
-        if [[ -f "$state_root/analysis-archive/index.json" ]]; then
-            session_count=$(jq '.sessions | length' "$state_root/analysis-archive/index.json" 2>/dev/null || echo 0)
-        fi
-        echo ""
-        if prompt_confirm "Remove analysis archive ($session_count sessions)?"; then
-            rm -rf "$state_root/analysis-archive"
-            log_success "Analysis archive removed"
-        else
-            log_info "Analysis archive preserved"
-        fi
-    fi
-
     # Account state directories
     echo ""
     if prompt_confirm "Remove all account state directories (~/.claude-state)?"; then
-        # If archive was preserved, move it out first
-        local archive_preserved=false
-        if [[ -d "$state_root/analysis-archive" ]]; then
-            mv "$state_root/analysis-archive" "/tmp/claude-archive-$$"
-            archive_preserved=true
-        fi
-
         rm -rf "$state_root"
         log_success "State directories removed"
-
-        # Restore archive if preserved
-        if [[ "$archive_preserved" == true ]]; then
-            mkdir -p "$state_root"
-            mv "/tmp/claude-archive-$$" "$state_root/analysis-archive"
-            log_info "Analysis archive restored to $state_root/analysis-archive"
-        fi
     else
         log_info "State directories kept"
     fi


### PR DESCRIPTION
## Summary

- Remove all orchestration-related code from 4 core scripts
- 4 files changed, +34 / -371 lines
- Zero orchestration references remain after changes

## What

**Dockerfile**: Remove redis-tools, redis npm install, NODE_PATH, SRS comments
**scripts/claude-docker**: Remove orchestration commands (dispatch, status, findings, save, restore, sessions, analyze), overlay detection, worker profile logic
**scripts/install.sh**: Remove orchestration Q&A, API key collection, firewall setup, worker state dirs
**scripts/remove.sh**: Remove orchestration overlay detection, analysis-archive cleanup

## Why

After file deletions in #126 and #127, these scripts contained dead code paths
referencing deleted functionality. Removing them prevents confusion and reduces
total script size by ~370 lines.

Part of #120
Closes #123

## Test plan

- [ ] `grep -rn "orchestrat\|manager\|worker-[0-9]\|redis\|firewall"` returns no matches in modified files
- [ ] `scripts/claude-docker help` shows only multi-account commands
- [ ] Dockerfile builds without Redis dependencies
- [ ] `scripts/install.sh` has no orchestration or firewall prompts