### PR TITLE
docs: rewrite README for multi-account focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,14 +341,15 @@ Ensure `PROJECT_DIR` points to a WSL2 filesystem path (`/home/...`),
 
 | Instances | Docker RAM | Host RAM (Linux / macOS / Windows) |
 |:---------:|:----------:|:----------------------------------:|
-| 2 | 4 GB | 8 / 8 / 8 GB |
-| 3 | 6 GB | 10 / 10 / 10 GB |
-| 4 | 8 GB | 12 / 12 / 12 GB |
+| 2 | 8 GB | 12 / 12 / 12 GB |
+| 3 | 12 GB | 16 / 16 / 16 GB |
+| 4 | 16 GB | 20 / 20 / 20 GB |
 
 ## Project Structure
 
 ```
 claude-docker/
++-- .dockerignore                      Docker build context exclusions
 +-- Dockerfile                         Base image
 +-- docker-compose.yml                 Base config (Tier A)
 +-- docker-compose.linux.yml           Linux override


### PR DESCRIPTION
## Summary

- Rewrite README.md for multi-account focus, removing all orchestration documentation
- Net -260 lines (636 -> ~372 lines)

## What

### Removed sections
- Orchestration (Multi-Agent): dispatch, status, findings commands
- Analysis (Multi-Persona): Sentinel/Reviewer/Profiler personas
- MCP Bridge (Native Tool Integration): 8-tool reference
- Session Archive (Cold Memory): save/restore/sessions commands
- Documentation section (links to deleted docs/)

### Updated sections
- Features list: multi-account only
- Quick reference table: matches actual CLI commands
- Compose overrides table: only 3 overlays (base, linux, worktree)
- Resource requirements: corrected for 4G-per-container limits
- Project structure: reflects current file layout including .dockerignore

### Added sections
- State and Memory Persistence: volume mount table

## Why

README documented a system that no longer exists after #126, #127, #128.
Focused README reduces cognitive load and accurately describes capabilities.

Part of #120
Closes #124

## Test plan

- [ ] No references to orchestration, firewall, MCP, cold memory
- [ ] CLI commands match `scripts/claude-docker help` output
- [ ] Project structure matches actual files
- [ ] Resource requirements reflect compose limits (4G per container)