### PR TITLE
feat: forward host GitHub CLI auth to containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,18 @@ scripts/claude-docker exec claude-a claude auth login
 scripts/claude-docker exec claude-a claude auth status
 ```
 
+**GitHub CLI (`gh`)** is automatically available inside containers. The host's
+`~/.config/gh/` is bind-mounted read-only, so `gh` commands use the host's
+GitHub session without separate authentication.
+
+```bash
+# Verify gh auth inside container
+scripts/claude-docker exec claude-a gh auth status
+
+# Use gh normally
+scripts/claude-docker exec claude-a gh pr list
+```
+
 ### Running Commands Inside Containers
 
 ```bash
@@ -291,6 +303,7 @@ All state is preserved across container restarts via Docker volume mounts:
 | Credentials | `~/.claude-state/account-a/.credentials.json` | `/home/node/.claude/.credentials.json` |
 | Memory | `~/.claude-state/account-a/projects/*/memory/` | `/home/node/.claude/projects/*/memory/` |
 | Settings | `~/.claude-state/account-a/settings.json` | `/home/node/.claude/settings.json` |
+| GitHub CLI auth | `~/.config/gh/` | `/home/node/.config/gh/` (read-only) |
 | node_modules | Named volume `node_modules_a` | `/workspace/node_modules/` |
 | Project files | `${PROJECT_DIR}` bind mount | `/workspace/` |
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - ${PROJECT_DIR}:/workspace
       - ${HOME}/.claude-state/account-a:/home/node/.claude
+      - ${HOME}/.config/gh:/home/node/.config/gh:ro
       - node_modules_a:/workspace/node_modules
     environment:
       - CLAUDE_CONFIG_DIR=/home/node/.claude
@@ -38,6 +39,7 @@ services:
     volumes:
       - ${PROJECT_DIR}:/workspace
       - ${HOME}/.claude-state/account-b:/home/node/.claude
+      - ${HOME}/.config/gh:/home/node/.config/gh:ro
       - node_modules_b:/workspace/node_modules
     environment:
       - CLAUDE_CONFIG_DIR=/home/node/.claude

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -20,17 +20,6 @@ if [ -n "$REPO_DIR" ] && [ -d "$REPO_DIR/.git" ]; then
     done
 fi
 
-echo "=== Preserving analysis archive ==="
-if [ -d "${HOME}/.claude-state/analysis-archive" ]; then
-    read -p "Remove analysis archive (~/.claude-state/analysis-archive)? (y/N) " confirm_archive
-    if [ "$confirm_archive" = "y" ] || [ "$confirm_archive" = "Y" ]; then
-        rm -rf "${HOME}/.claude-state/analysis-archive"
-        echo "  Analysis archive removed."
-    else
-        echo "  Analysis archive preserved."
-    fi
-fi
-
 echo "=== Removing state directories ==="
 read -p "Remove ~/.claude-state/*? (y/N) " confirm
 if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then

--- a/scripts/remove.sh
+++ b/scripts/remove.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Complete removal script for claude-docker
 # Reverses everything install.sh set up: containers, volumes, images,
-# worktrees, state directories, archive, .env, and optionally host tools.
+# worktrees, state directories, .env, and optionally host tools.
 set -euo pipefail
 
 # --- Constants & Colors -------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add read-only bind mount of host's `~/.config/gh/` into containers
- `gh` commands inside containers automatically use the host's GitHub session
- Also cleans up stale analysis-archive reference from previous refactoring

## What

**docker-compose.yml**: Add `${HOME}/.config/gh:/home/node/.config/gh:ro` volume to both `claude-a` and `claude-b` services. The `:ro` flag ensures containers cannot modify the host's gh configuration.

**README.md**: Document gh auth forwarding in Authentication section and add GitHub CLI auth row to the State and Memory Persistence table.

**scripts/cleanup.sh**: Remove stale analysis-archive block (leftover from orchestration removal).

**scripts/remove.sh**: Remove stale "archive" from header comment.

## Why

Containers have `gh` installed but previously required separate authentication. Since all containers share the same GitHub user (unlike Claude Code accounts), the host's gh credentials can be safely shared read-only.

Closes #131

## Test plan

- [ ] `docker compose exec claude-a gh auth status` succeeds without container-internal login
- [ ] `docker compose exec claude-b gh auth status` succeeds
- [ ] Host `~/.config/gh/` is mounted read-only (container cannot modify)
- [ ] No stale "analysis-archive" references remain in codebase