### PR TITLE
feat(tui): docker rebuild + gh-auth + macOS bash 3.2 compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,25 +93,14 @@ Choose your authentication path:
 
 **Path A -- Subscription accounts (Pro / Max / Team):**
 
-macOS:
+Authenticate inside each container after starting:
 ```bash
-# 1. Authenticate on host (one-time, opens browser)
-claude auth login
-
-# 2. Inject credentials into all containers
-scripts/claude-docker auth
-```
-
-Linux / WSL2:
-```bash
-# Authenticate inside each container after starting
 scripts/claude-docker claude claude-a
 # Inside container: claude auth login
 ```
 
-Note: On macOS, container-internal OAuth fails due to Docker network
-boundary limitations. The `auth` command extracts tokens from macOS
-Keychain instead.
+Note: Container-internal OAuth may fail on macOS due to Docker network
+boundary limitations. If it does, use Path B (API keys) below.
 
 **Path B -- Console API keys:**
 
@@ -159,7 +148,6 @@ scripts/claude-docker help       # Show all available commands
 | | `ps` | Show container status |
 | | `logs` | Follow container logs |
 | **Interactive** | `claude [service]` | Start Claude Code (default: claude-a) |
-| | `auth [service]` | Inject OAuth credentials from macOS Keychain |
 | | `exec <service>` | Open shell in a container |
 | **Usage Tracking** | `usage [type] [flags]` | Token usage report |
 | **Advanced** | `config` | Show resolved compose configuration |
@@ -200,29 +188,20 @@ history, settings, memory, and credentials.
 
 ### Authentication
 
-On macOS, `scripts/claude-docker auth` extracts OAuth credentials from the
-host's macOS Keychain and injects them into each container's state directory.
-Host-side authentication (`claude auth login`) must be completed first.
-
-On Windows (native), `.\scripts\claude-docker.ps1 auth` copies credentials
-from the host's `~/.claude/.credentials.json` into each container's state
-directory. Authenticate on the host first with `claude auth login`.
-
-On Linux/WSL2, authenticate directly inside containers.
+Authenticate directly inside each container. Each container keeps its own
+credentials in its bind-mounted state directory, so you run this once per
+account.
 
 ```bash
-# macOS: extract from Keychain -> inject to all containers
-scripts/claude-docker auth
-
-# macOS: inject to specific container only
-scripts/claude-docker auth claude-a
-
-# Linux/WSL2: authenticate inside container
+# Authenticate inside a specific container
 scripts/claude-docker exec claude-a claude auth login
 
 # Check status in any container
 scripts/claude-docker exec claude-a claude auth status
 ```
+
+If container-internal OAuth fails on macOS due to Docker network boundary
+limitations, switch to Path B (API keys) in `.env`.
 
 **GitHub CLI (`gh`)** is automatically available inside containers. The host's
 `~/.config/gh/` is bind-mounted read-only, so `gh` commands use the host's
@@ -401,13 +380,6 @@ The `scripts/claude-docker` CLI auto-detects which overlays to apply.
 
 **"Authentication expired" inside container:**
 
-macOS:
-```bash
-claude auth login              # Re-authenticate on host
-scripts/claude-docker auth     # Re-inject to containers
-```
-
-Linux/WSL2:
 ```bash
 scripts/claude-docker exec claude-a claude auth login
 ```

--- a/scripts/claude-docker
+++ b/scripts/claude-docker
@@ -7,7 +7,6 @@
 # Commands:
 #   up/down/restart   Manage containers
 #   claude [svc]      Start Claude Code (default: claude-a)
-#   auth [svc]        Inject OAuth credentials from macOS Keychain
 #   exec <svc>        Open shell in a service
 #   usage [type]      Token usage report
 #   build             Build/rebuild Docker image
@@ -307,82 +306,6 @@ verify_container_gh_auth() {
         echo -e "    ${DIM}git push/pull and gh commands may fail.${NC}"
         echo -e "    Fix: ${DIM}scripts/claude-docker gh-auth${NC}"
         return 1
-    fi
-}
-
-# Extract OAuth credentials from macOS Keychain (host-side).
-# Returns JSON string or empty on failure.
-get_keychain_credentials() {
-    if [[ "$(uname -s)" != "Darwin" ]]; then
-        return 1
-    fi
-    security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null
-}
-
-# Inject credentials JSON into a container's state directory on the host.
-inject_credentials() {
-    local svc="$1"
-    local creds="$2"
-
-    # Map service name to host state directory (claude-X -> account-X)
-    local suffix="${svc#claude-}"
-    local state_dir="$HOME/.claude-state/account-${suffix}"
-
-    if [[ ! -d "$state_dir" ]]; then
-        mkdir -p "$state_dir"
-        chmod 700 "$state_dir"
-    fi
-
-    echo "$creds" > "$state_dir/.credentials.json"
-    chmod 600 "$state_dir/.credentials.json"
-}
-
-cmd_auth() {
-    local service="${1:-}"
-    ensure_compose_cmd
-
-    # On macOS, extract credentials from Keychain (host-side auth)
-    local creds=""
-    creds=$(get_keychain_credentials) || true
-
-    if [[ -z "$creds" ]]; then
-        # Not macOS or no credentials in Keychain
-        echo -e "${YELLOW}No credentials found in macOS Keychain.${NC}"
-        echo -e "Authenticate on the host first, then re-run this command:"
-        echo -e "  ${DIM}claude auth login${NC}"
-        echo -e ""
-        echo -e "Or set API keys in .env (Path B):"
-        echo -e "  ${DIM}CLAUDE_API_KEY_A=sk-ant-...${NC}"
-        exit 1
-    fi
-
-    # Determine which services to authenticate
-    local services=()
-    if [[ -n "$service" ]]; then
-        services=("$service")
-    else
-        read -ra services <<< "$(get_service_names)"
-    fi
-
-    echo -e "${BOLD}Injecting credentials from macOS Keychain${NC}"
-    echo ""
-
-    for svc in "${services[@]}"; do
-        inject_credentials "$svc" "$creds"
-        echo -e "  ${GREEN}*${NC} $svc — credentials written"
-    done
-
-    echo ""
-
-    # Verify: check auth status in first running container
-    local first_svc="${services[0]}"
-    local cid
-    cid=$(get_container_id "$first_svc")
-    if [[ -n "$cid" ]]; then
-        echo -e "${DIM}Verifying ($first_svc):${NC}"
-        docker exec "$cid" claude auth status 2>&1 || true
-    else
-        log_info "Containers not running. Credentials will be available on next start."
     fi
 }
 
@@ -719,7 +642,6 @@ ${BOLD}LIFECYCLE${NC}
 ${BOLD}INTERACTIVE${NC}
   ${GREEN}claude${NC} [service]      Start Claude Code (default: claude-a)
   ${GREEN}tui${NC}                   Launch multi-account dashboard TUI
-  ${GREEN}auth${NC} [service]        Inject Claude OAuth credentials from macOS Keychain
   ${GREEN}gh-auth${NC}               Inject GitHub token from host gh CLI into containers
   ${GREEN}exec${NC} <service>        Open shell in a service
 
@@ -744,7 +666,7 @@ HELP
     for idx in "${!svc_names[@]}"; do
         local svc="${svc_names[$idx]}"
         local suffix="${svc#claude-}"
-        local label="Account ${suffix^^}"
+        local label="Account $(printf '%s' "$suffix" | tr '[:lower:]' '[:upper:]')"
         if [[ "$idx" -eq 0 ]]; then
             label="$label (default)"
         fi
@@ -773,7 +695,6 @@ main() {
         ps)        cmd_ps "$@" ;;
         exec)      cmd_exec "$@" ;;
         claude)    cmd_claude "$@" ;;
-        auth)      cmd_auth "$@" ;;
         gh-auth)   cmd_gh_auth "$@" ;;
         usage)     cmd_usage "$@" ;;
         build)     cmd_build "$@" ;;

--- a/scripts/claude-docker.ps1
+++ b/scripts/claude-docker.ps1
@@ -132,58 +132,6 @@ function Invoke-Claude {
     Invoke-Compose -ProjectRoot $ProjectRoot exec $service claude
 }
 
-function Invoke-Auth {
-    $service = if ($Arguments.Count -gt 0) { $Arguments[0] } else { '' }
-
-    # On Windows, look for file-based credentials from host Claude installation
-    $credFile = Join-Path $env:USERPROFILE '.claude\.credentials.json'
-    $creds = ''
-
-    if (Test-Path $credFile) {
-        $creds = Get-Content $credFile -Raw
-    }
-
-    if (-not $creds) {
-        Write-LogWarn 'No credentials found at ~/.claude/.credentials.json'
-        Write-Host 'Authenticate on the host first, then re-run this command:'
-        Write-Host '  claude auth login' -ForegroundColor DarkGray
-        Write-Host ''
-        Write-Host 'Or set API keys in .env (Path B):'
-        Write-Host '  CLAUDE_API_KEY_A=sk-ant-...' -ForegroundColor DarkGray
-        exit 1
-    }
-
-    # Determine which services to authenticate
-    $services = if ($service) { @($service) } else { @(Get-ServiceNames -ProjectRoot $ProjectRoot) }
-
-    Write-Host 'Injecting credentials from host' -ForegroundColor White
-
-    foreach ($svc in $services) {
-        $suffix = $svc -replace '^claude-', ''
-        $stateDir = Join-Path $env:USERPROFILE ".claude-state\account-$suffix"
-
-        if (-not (Test-Path $stateDir)) {
-            New-Item -ItemType Directory -Path $stateDir -Force | Out-Null
-        }
-
-        $destCred = Join-Path $stateDir '.credentials.json'
-        [System.IO.File]::WriteAllText($destCred, $creds, [System.Text.UTF8Encoding]::new($false))
-        Write-Host "  * $svc - credentials written" -ForegroundColor Green
-    }
-
-    Write-Host ''
-
-    # Verify in first running container
-    $cid = Get-ContainerId -ProjectRoot $ProjectRoot -Service $services[0]
-    if ($cid) {
-        Write-Host "Verifying ($($services[0])):" -ForegroundColor DarkGray
-        & docker exec $cid claude auth status 2>&1
-    }
-    else {
-        Write-LogInfo 'Containers not running. Credentials will be available on next start.'
-    }
-}
-
 function Invoke-GhAuth {
     if (-not (Test-Command 'gh')) {
         Write-LogError 'gh CLI not found on host.'
@@ -529,7 +477,6 @@ function Show-Help {
     Write-Host ''
     Write-Host 'INTERACTIVE' -ForegroundColor White
     Write-Host '  claude [service]      ' -ForegroundColor Green -NoNewline; Write-Host 'Start Claude Code (default: claude-a)'
-    Write-Host '  auth [service]        ' -ForegroundColor Green -NoNewline; Write-Host 'Inject Claude credentials from host'
     Write-Host '  gh-auth               ' -ForegroundColor Green -NoNewline; Write-Host 'Inject GitHub token from host gh CLI'
     Write-Host '  exec <service>        ' -ForegroundColor Green -NoNewline; Write-Host 'Open shell in a service'
     Write-Host ''
@@ -624,7 +571,6 @@ switch ($Command) {
     'claude'     { Invoke-Claude }
     'tui'        { Invoke-Tui }
     'dashboard'  { Invoke-Tui }
-    'auth'       { Invoke-Auth }
     'gh-auth'    { Invoke-GhAuth }
     'usage'      { Invoke-Usage }
     'build'      { Invoke-Build }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -514,7 +514,8 @@ collect_configuration() {
         for i in $(seq 1 "$NUM_ACCOUNTS"); do
             local letter
             letter=$(printf "\\$(printf '%03o' $((96 + i)))")
-            local upper="${letter^^}"
+            local upper
+            upper=$(printf '%s' "$letter" | tr '[:lower:]' '[:upper:]')
             API_KEYS+=("$(prompt_secret "API key for Account $upper (sk-ant-...)")")
         done
 
@@ -571,7 +572,8 @@ generate_env() {
             for i in $(seq 1 "$NUM_ACCOUNTS"); do
                 local letter
                 letter=$(printf "\\$(printf '%03o' $((96 + i)))")
-                local upper="${letter^^}"
+                local upper
+                upper=$(printf '%s' "$letter" | tr '[:lower:]' '[:upper:]')
                 echo "CLAUDE_API_KEY_${upper}=${API_KEYS[$((i-1))]}"
             done
             echo ""
@@ -583,7 +585,8 @@ generate_env() {
             for i in $(seq 1 "$NUM_ACCOUNTS"); do
                 local letter
                 letter=$(printf "\\$(printf '%03o' $((96 + i)))")
-                local upper="${letter^^}"
+                local upper
+                upper=$(printf '%s' "$letter" | tr '[:lower:]' '[:upper:]')
                 echo "PROJECT_DIR_${upper}="
                 echo "CONTAINER_PROJECT_DIR_${upper}=/project-${letter}"
             done

--- a/scripts/setup-worktrees.sh
+++ b/scripts/setup-worktrees.sh
@@ -39,7 +39,7 @@ for i in "${!BRANCHES[@]}"; do
 
     git branch "$branch" 2>/dev/null || true
     git worktree add "$worktree" "$branch"
-    echo "  ${letter^^}: $worktree (branch: $branch)"
+    echo "  $(printf '%s' "$letter" | tr '[:lower:]' '[:upper:]'): $worktree (branch: $branch)"
 done
 
 echo ""
@@ -47,6 +47,6 @@ echo "Add to .env:"
 for i in "${!BRANCHES[@]}"; do
     idx=$((i + 1))
     letter=$(index_to_letter "$idx")
-    upper="${letter^^}"
+    upper=$(printf '%s' "$letter" | tr '[:lower:]' '[:upper:]')
     echo "  PROJECT_DIR_${upper}=${REPO_DIR%/}-${letter}"
 done

--- a/scripts/test-concurrent-git.sh
+++ b/scripts/test-concurrent-git.sh
@@ -18,6 +18,12 @@ index_to_letter() {
     printf "\\$(printf '%03o' $((96 + $1)))"
 }
 
+# Uppercase a single-letter string. Portable replacement for bash 4+ ${var^^}
+# (macOS ships bash 3.2 which does not support the ^^ expansion).
+to_upper() {
+    printf '%s' "$1" | tr '[:lower:]' '[:upper:]'
+}
+
 # Cleanup on exit
 cleanup() {
     echo "=== Cleaning up ==="
@@ -55,7 +61,7 @@ echo "=== Starting containers with worktree override ==="
 export PROJECT_DIR="$REPO_DIR"
 for i in $(seq 1 "$NUM_TEST_ACCOUNTS"); do
     letter=$(index_to_letter "$i")
-    upper="${letter^^}"
+    upper=$(to_upper "$letter")
     export "PROJECT_DIR_${upper}=${REPO_DIR}-${letter}"
 done
 
@@ -67,7 +73,7 @@ echo "=== Running parallel commits ==="
 PIDS=()
 for i in $(seq 1 "$NUM_TEST_ACCOUNTS"); do
     letter=$(index_to_letter "$i")
-    upper="${letter^^}"
+    upper=$(to_upper "$letter")
     svc="claude-${letter}"
 
     docker compose -f "$PROJECT_DIR/docker-compose.yml" \
@@ -99,7 +105,7 @@ echo "=== Verifying results ==="
 
 for i in $(seq 1 "$NUM_TEST_ACCOUNTS"); do
     letter=$(index_to_letter "$i")
-    upper="${letter^^}"
+    upper=$(to_upper "$letter")
     worktree="${REPO_DIR}-${letter}"
 
     # Check worktree has 5 commits from its agent
@@ -112,8 +118,7 @@ for i in $(seq 1 "$NUM_TEST_ACCOUNTS"); do
     # Check no cross-contamination from other agents
     for j in $(seq 1 "$NUM_TEST_ACCOUNTS"); do
         if [ "$j" -eq "$i" ]; then continue; fi
-        other_upper="$(index_to_letter "$j")"
-        other_upper="${other_upper^^}"
+        other_upper=$(to_upper "$(index_to_letter "$j")")
         cross=$(cd "$worktree" && git log --oneline --author="Agent ${other_upper}" | wc -l | tr -d ' ')
         if [ "$cross" -ne 0 ]; then
             echo "FAIL: Cross-contamination from Agent ${other_upper} in worktree-${letter}"
@@ -133,7 +138,7 @@ echo ""
 echo "=== ALL TESTS PASSED ==="
 for i in $(seq 1 "$NUM_TEST_ACCOUNTS"); do
     letter=$(index_to_letter "$i")
-    upper="${letter^^}"
+    upper=$(to_upper "$letter")
     echo "  Worktree ${upper}: 5 commits from Agent ${upper} (no cross-contamination)"
 done
 echo "  Repository integrity: OK"

--- a/tui/internal/auth/gh_token.go
+++ b/tui/internal/auth/gh_token.go
@@ -1,0 +1,38 @@
+package auth
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// HostGHToken returns the GitHub token from the host's gh CLI.
+// Two-step verification (status → token) gives clearer error messages
+// than relying on `gh auth token` exit codes alone.
+func HostGHToken() (string, error) {
+	if _, err := exec.LookPath("gh"); err != nil {
+		return "", fmt.Errorf("gh CLI not found on host (install via https://cli.github.com)")
+	}
+
+	var stderr bytes.Buffer
+	check := exec.Command("gh", "auth", "status")
+	check.Stderr = &stderr
+	if err := check.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("gh not authenticated: %s", msg)
+	}
+
+	out, err := exec.Command("gh", "auth", "token").Output()
+	if err != nil {
+		return "", fmt.Errorf("gh auth token: %w", err)
+	}
+	token := strings.TrimSpace(string(out))
+	if token == "" {
+		return "", fmt.Errorf("gh returned empty token")
+	}
+	return token, nil
+}

--- a/tui/internal/config/env.go
+++ b/tui/internal/config/env.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -79,6 +80,53 @@ func (e *Env) Set(key, value string) {
 	}
 	e.index[key] = len(e.entries)
 	e.entries = append(e.entries, entry{key: key, value: value, raw: key + "=" + value})
+}
+
+// Save writes the env file back to disk, preserving order/comments.
+// Uses atomic rename + 0600 permissions because the file holds secrets.
+func (e *Env) Save() error {
+	if e.path == "" {
+		return fmt.Errorf("env path not set")
+	}
+	dir := filepath.Dir(e.path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("mkdir: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".env.tmp-*")
+	if err != nil {
+		return fmt.Errorf("create tmp: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	w := bufio.NewWriter(tmp)
+	for _, ent := range e.entries {
+		if ent.key != "" {
+			if _, err := fmt.Fprintf(w, "%s=%s\n", ent.key, ent.value); err != nil {
+				tmp.Close()
+				return fmt.Errorf("write: %w", err)
+			}
+		} else {
+			if _, err := fmt.Fprintln(w, ent.raw); err != nil {
+				tmp.Close()
+				return fmt.Errorf("write: %w", err)
+			}
+		}
+	}
+	if err := w.Flush(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("flush: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close: %w", err)
+	}
+	if err := os.Chmod(tmpName, 0600); err != nil {
+		return fmt.Errorf("chmod: %w", err)
+	}
+	if err := os.Rename(tmpName, e.path); err != nil {
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
 }
 
 // NumAccounts returns the NUM_ACCOUNTS value from .env (default 1).

--- a/tui/internal/docker/client.go
+++ b/tui/internal/docker/client.go
@@ -94,6 +94,45 @@ func (c *Client) ExecArgs(service string, cmd ...string) (string, []string) {
 	return "docker", args
 }
 
+// BuildArgs returns (bin, args) for `docker compose build`.
+// When noCache is true, passes --no-cache to force a full rebuild.
+func (c *Client) BuildArgs(noCache bool) (string, []string) {
+	args := append(BuildComposeArgs(c.projectRoot, c.env), "build")
+	if noCache {
+		args = append(args, "--no-cache")
+	}
+	return "docker", args
+}
+
+// UpRecreateArgs returns (bin, args) for `docker compose up -d --force-recreate`.
+// Used after image rebuild or .env change so containers pick up new config.
+func (c *Client) UpRecreateArgs() (string, []string) {
+	args := append(BuildComposeArgs(c.projectRoot, c.env), "up", "-d", "--force-recreate")
+	return "docker", args
+}
+
+// RestartArgs returns (bin, args) for restarting a single service.
+// service must be a name produced by ServiceNames() (e.g. "claude-a").
+func (c *Client) RestartArgs(service string) (string, []string) {
+	args := append(BuildComposeArgs(c.projectRoot, c.env), "restart", service)
+	return "docker", args
+}
+
+// HasRunningContainers returns true if any compose service is currently up.
+// Used by gh-auth flow to decide whether a recreate is needed.
+func (c *Client) HasRunningContainers() bool {
+	infos, err := c.PS()
+	if err != nil {
+		return false
+	}
+	for _, ci := range infos {
+		if strings.EqualFold(ci.State, "running") {
+			return true
+		}
+	}
+	return false
+}
+
 // ServiceNames returns the expected service names based on NUM_ACCOUNTS.
 func (c *Client) ServiceNames() []string {
 	n := 1

--- a/tui/internal/ui/app.go
+++ b/tui/internal/ui/app.go
@@ -34,7 +34,7 @@ func NewApp(version, projectRoot string, env *config.Env, client *docker.Client)
 		env:         env,
 		client:      client,
 		manager:     mgr,
-		dashboard:   dashboard.New(mgr, client),
+		dashboard:   dashboard.New(mgr, client, env),
 	}
 }
 

--- a/tui/internal/ui/dashboard/model.go
+++ b/tui/internal/ui/dashboard/model.go
@@ -10,14 +10,45 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/kcenon/claude-docker/tui/internal/account"
+	"github.com/kcenon/claude-docker/tui/internal/auth"
+	"github.com/kcenon/claude-docker/tui/internal/config"
 	"github.com/kcenon/claude-docker/tui/internal/docker"
 	"github.com/kcenon/claude-docker/tui/internal/ui/components"
 )
+
+// opKind identifies which multi-stage operation is in flight, so callbacks
+// returning from tea.ExecProcess know what to do next.
+type opKind int
+
+const (
+	opNone opKind = iota
+	opUp
+	opDown
+	opBuild
+	opBuildNoCache
+	opUpdateBuild   // step 1 of update chain
+	opUpdateRecreate // step 2 of update chain
+	opRestart
+	opGHAuthRecreate
+)
+
+// statusLevel controls toast color.
+type statusLevel int
+
+const (
+	statusInfo statusLevel = iota
+	statusOK
+	statusErr
+)
+
+// statusTTL is how long a toast stays on screen before auto-clearing.
+const statusTTL = 5 * time.Second
 
 // Model is the dashboard bubbletea model.
 type Model struct {
 	manager       *account.Manager
 	client        *docker.Client
+	env           *config.Env
 	accounts      []account.Account
 	cursor        int
 	width         int
@@ -29,13 +60,21 @@ type Model struct {
 	retryCount    int       // number of auto-retries since TUI started
 	lastRefreshAt time.Time // time of last refresh completion
 	nextRetryAt   time.Time // scheduled time for next auto-retry (zero = no retry pending)
+
+	// Action state (Docker rebuild / gh-auth / restart).
+	busy         bool        // true while a background op is running
+	showHelp     bool        // ? toggles a key-map overlay
+	statusText   string      // last toast message
+	statusLevel  statusLevel // toast color
+	statusExpiry time.Time   // when the toast should disappear
 }
 
 // New creates a new dashboard model.
-func New(mgr *account.Manager, client *docker.Client) Model {
+func New(mgr *account.Manager, client *docker.Client, env *config.Env) Model {
 	return Model{
 		manager: mgr,
 		client:  client,
+		env:     env,
 		loading: true,
 	}
 }
@@ -48,6 +87,24 @@ type accountsLoadedMsg struct {
 type sessionFinishedMsg struct{ err error }
 
 type uiTickMsg struct{} // 1-second tick drives both countdown display AND scheduled retry
+
+// dockerOpDoneMsg arrives after a tea.ExecProcess handoff returns.
+// kind lets the reducer decide whether to chain to the next stage
+// (e.g. build → recreate during `U` update).
+type dockerOpDoneMsg struct {
+	kind opKind
+	err  error
+}
+
+// ghAuthAppliedMsg is emitted after the gh-token write step completes.
+// recreateNeeded = true triggers a follow-up `up -d --force-recreate` handoff.
+type ghAuthAppliedMsg struct {
+	err            error
+	recreateNeeded bool
+}
+
+// statusExpiredMsg clears any stale toast once its TTL has passed.
+type statusExpiredMsg struct{}
 
 // Init starts the initial data load.
 // Clears any stale API cooldowns so the first refresh attempts the API fresh.
@@ -135,7 +192,74 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		// After Claude session ends, refresh account list
 		return m, m.Refresh()
 
+	case dockerOpDoneMsg:
+		m.busy = false
+		switch msg.kind {
+		case opUp:
+			m = m.toast(opResultText("Up", msg.err), levelOf(msg.err))
+		case opDown:
+			m = m.toast(opResultText("Down", msg.err), levelOf(msg.err))
+		case opBuild:
+			m = m.toast(opResultText("Build", msg.err), levelOf(msg.err))
+		case opBuildNoCache:
+			m = m.toast(opResultText("Rebuild (no-cache)", msg.err), levelOf(msg.err))
+		case opRestart:
+			m = m.toast(opResultText("Restart", msg.err), levelOf(msg.err))
+		case opUpdateBuild:
+			if msg.err != nil {
+				m = m.toast(opResultText("Update (build)", msg.err), statusErr)
+				return m, m.toastExpireCmd()
+			}
+			// Chain into recreate stage.
+			m.busy = true
+			bin, args := m.client.UpRecreateArgs()
+			cmd := exec.Command(bin, args...)
+			return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
+				return dockerOpDoneMsg{kind: opUpdateRecreate, err: err}
+			})
+		case opUpdateRecreate:
+			m = m.toast(opResultText("Update", msg.err), levelOf(msg.err))
+		case opGHAuthRecreate:
+			m = m.toast(opResultText("GitHub auth + recreate", msg.err), levelOf(msg.err))
+		}
+		return m, tea.Batch(m.Refresh(), m.toastExpireCmd())
+
+	case ghAuthAppliedMsg:
+		if msg.err != nil {
+			m.busy = false
+			m = m.toast("gh-auth: "+msg.err.Error(), statusErr)
+			return m, m.toastExpireCmd()
+		}
+		if !msg.recreateNeeded {
+			m.busy = false
+			m = m.toast("GitHub token written to .env (no running containers)", statusOK)
+			return m, tea.Batch(m.Refresh(), m.toastExpireCmd())
+		}
+		// Containers are running — recreate them so the new GH_TOKEN takes effect.
+		bin, args := m.client.UpRecreateArgs()
+		cmd := exec.Command(bin, args...)
+		return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
+			return dockerOpDoneMsg{kind: opGHAuthRecreate, err: err}
+		})
+
+	case statusExpiredMsg:
+		if !m.statusExpiry.IsZero() && !time.Now().Before(m.statusExpiry) {
+			m.statusText = ""
+			m.statusExpiry = time.Time{}
+		}
+		return m, nil
+
 	case tea.KeyMsg:
+		// When a background/blocking op is in flight, ignore everything except quit.
+		if m.busy {
+			return m, nil
+		}
+		// Help overlay is modal: any key other than quit closes it.
+		if m.showHelp {
+			m.showHelp = false
+			return m, nil
+		}
+
 		switch msg.String() {
 		case "j", "down":
 			if m.cursor < len(m.accounts)-1 {
@@ -158,23 +282,21 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				}
 			}
 		case "u":
+			m.busy = true
+			m = m.toast("Starting containers (docker compose up -d)...", statusInfo)
 			client := m.client
-			return m, tea.Batch(
-				func() tea.Msg {
-					client.Up()
-					return nil
-				},
-				m.Refresh(),
-			)
+			return m, func() tea.Msg {
+				err := client.Up()
+				return dockerOpDoneMsg{kind: opUp, err: err}
+			}
 		case "d":
+			m.busy = true
+			m = m.toast("Stopping containers (docker compose down)...", statusInfo)
 			client := m.client
-			return m, tea.Batch(
-				func() tea.Msg {
-					client.Down()
-					return nil
-				},
-				m.Refresh(),
-			)
+			return m, func() tea.Msg {
+				err := client.Down()
+				return dockerOpDoneMsg{kind: opDown, err: err}
+			}
 		case "r":
 			if m.refreshing {
 				return m, nil // already refreshing, ignore
@@ -183,10 +305,109 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			m.refreshing = true
 			m.retryCount++ // manual refresh counts as a retry
 			return m, m.Refresh()
+
+		case "b":
+			m.busy = true
+			bin, args := m.client.BuildArgs(false)
+			cmd := exec.Command(bin, args...)
+			return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
+				return dockerOpDoneMsg{kind: opBuild, err: err}
+			})
+
+		case "B":
+			m.busy = true
+			bin, args := m.client.BuildArgs(true)
+			cmd := exec.Command(bin, args...)
+			return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
+				return dockerOpDoneMsg{kind: opBuildNoCache, err: err}
+			})
+
+		case "U":
+			// Two-stage chain: build --no-cache → up -d --force-recreate.
+			m.busy = true
+			bin, args := m.client.BuildArgs(true)
+			cmd := exec.Command(bin, args...)
+			return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
+				return dockerOpDoneMsg{kind: opUpdateBuild, err: err}
+			})
+
+		case "R":
+			if m.cursor >= len(m.accounts) {
+				return m, nil
+			}
+			svc := m.accounts[m.cursor].ServiceName
+			m.busy = true
+			bin, args := m.client.RestartArgs(svc)
+			cmd := exec.Command(bin, args...)
+			return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
+				return dockerOpDoneMsg{kind: opRestart, err: err}
+			})
+
+		case "g":
+			return m.startGHAuth()
+
+		case "?":
+			m.showHelp = true
+			return m, nil
 		}
 	}
 
 	return m, nil
+}
+
+// startGHAuth reads the host gh token, writes it to .env, and — if any
+// container is running — queues a recreate handoff so containers pick up
+// the new GH_TOKEN. Synchronous .env write is fine (no blocking I/O beyond
+// a single file); the slow container restart is done via tea.ExecProcess.
+func (m Model) startGHAuth() (Model, tea.Cmd) {
+	if m.env == nil {
+		m = m.toast("gh-auth: .env not loaded", statusErr)
+		return m, m.toastExpireCmd()
+	}
+	m.busy = true
+	client := m.client
+	env := m.env
+	return m, func() tea.Msg {
+		token, err := auth.HostGHToken()
+		if err != nil {
+			return ghAuthAppliedMsg{err: err}
+		}
+		env.Set("GH_TOKEN", token)
+		if err := env.Save(); err != nil {
+			return ghAuthAppliedMsg{err: fmt.Errorf("write .env: %w", err)}
+		}
+		return ghAuthAppliedMsg{recreateNeeded: client.HasRunningContainers()}
+	}
+}
+
+// toast returns a copy of the model with a transient status message set.
+// Callers should chain toastExpireCmd() so the message auto-clears.
+func (m Model) toast(text string, level statusLevel) Model {
+	m.statusText = text
+	m.statusLevel = level
+	m.statusExpiry = time.Now().Add(statusTTL)
+	return m
+}
+
+// toastExpireCmd schedules a statusExpiredMsg after statusTTL.
+func (m Model) toastExpireCmd() tea.Cmd {
+	return tea.Tick(statusTTL, func(time.Time) tea.Msg {
+		return statusExpiredMsg{}
+	})
+}
+
+func levelOf(err error) statusLevel {
+	if err != nil {
+		return statusErr
+	}
+	return statusOK
+}
+
+func opResultText(name string, err error) string {
+	if err != nil {
+		return fmt.Sprintf("%s failed: %v", name, err)
+	}
+	return name + " completed"
 }
 
 // View renders the dashboard.
@@ -201,6 +422,10 @@ func (m Model) View() string {
 		return "  No accounts configured. Run the installer to set up accounts."
 	}
 
+	if m.showHelp {
+		return renderHelp()
+	}
+
 	var b strings.Builder
 
 	b.WriteString(renderAccountTable(m.accounts, m.cursor, m.width))
@@ -213,11 +438,29 @@ func (m Model) View() string {
 		}
 	}
 
+	actionsText := fmt.Sprintf(
+		"  [u] Up  [d] Down  [r] Refresh  [Enter] Attach  [?] Keys  (%d/%d running)",
+		runningCount, len(m.accounts))
+	if m.busy {
+		actionsText = "  Busy... (keys disabled; see status below)"
+	}
 	actions := lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280")).
-		Render(fmt.Sprintf(
-			"  [u] Up all  [d] Down all  [r] Refresh  [Enter] Attach  (%d/%d running)",
-			runningCount, len(m.accounts)))
+		Render(actionsText)
 	b.WriteString(actions)
+
+	if m.statusText != "" {
+		var color lipgloss.Color
+		switch m.statusLevel {
+		case statusOK:
+			color = lipgloss.Color("#22C55E")
+		case statusErr:
+			color = lipgloss.Color("#EF4444")
+		default:
+			color = lipgloss.Color("#06B6D4")
+		}
+		toast := lipgloss.NewStyle().Foreground(color).Render("  " + m.statusText)
+		b.WriteString("\n" + toast)
+	}
 
 
 	// API retry status: visible when any account is rate-limited or currently refreshing
@@ -388,4 +631,34 @@ func min(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// renderHelp shows the key-map overlay (dismissed by any key).
+func renderHelp() string {
+	title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#06B6D4")).
+		Render("  Keybindings")
+	key := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#E5E7EB"))
+	desc := lipgloss.NewStyle().Foreground(lipgloss.Color("#9CA3AF"))
+
+	rows := [][2]string{
+		{"j / k", "Move cursor down / up"},
+		{"Enter / c", "Attach to selected account's claude session"},
+		{"r", "Refresh dashboard"},
+		{"u / d", "docker compose up -d / down (all)"},
+		{"b", "docker compose build (cached)"},
+		{"B", "docker compose build --no-cache"},
+		{"U", "Full update: rebuild --no-cache + force-recreate"},
+		{"R", "Restart the selected container"},
+		{"g", "Inject host gh token into .env (+ recreate)"},
+		{"?", "Toggle this help"},
+		{"q / Ctrl+C", "Quit"},
+	}
+
+	var b strings.Builder
+	b.WriteString(title + "\n\n")
+	for _, row := range rows {
+		b.WriteString("  " + key.Render(padPlain(row[0], 12)) + "  " + desc.Render(row[1]) + "\n")
+	}
+	b.WriteString("\n" + desc.Render("  Press any key to close."))
+	return b.String()
 }

--- a/tui/main.go
+++ b/tui/main.go
@@ -34,10 +34,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	env, err := config.LoadEnv(filepath.Join(projectRoot, ".env"))
+	envPath := filepath.Join(projectRoot, ".env")
+	env, err := config.LoadEnv(envPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: cannot load .env: %v\n", err)
-		env = config.NewEmptyEnv(projectRoot)
+		env = config.NewEmptyEnv(envPath)
 	}
 
 	composeClient := docker.NewClient(projectRoot, env)


### PR DESCRIPTION
## What

Three logical changes bundled into one PR:

1. **TUI: docker rebuild + gh-auth + responsive lifecycle ops** (`feat/tui`)
   New keybindings on the dashboard: `b` build, `B` build --no-cache, `U` full update (rebuild + force-recreate chain), `R` restart selected container, `g` inject host gh token into `.env` (+ recreate), `?` help overlay. Adds a toast status system, a busy guard, and an `env.Save()` that writes `.env` back via atomic rename + 0600 permissions. Also rewires `u` / `d` so Refresh runs after the op completes instead of racing with it in parallel.
2. **Remove host credential injection into containers** (`refactor/cli`)
   Drops `cmd_auth` (bash) and `Invoke-Auth` (PowerShell), the macOS Keychain / Windows credentials helpers, and related README sections. Users now authenticate inside containers (`scripts/claude-docker exec <svc> claude auth login`) or use Path B API keys.
3. **macOS bash 3.2 compatibility for installer scripts** (`fix/scripts`)
   `${var^^}` (bash 4+) is rewritten to `printf '%s' "$var" | tr '[:lower:]' '[:upper:]'` (POSIX). Affects `install.sh`, `setup-worktrees.sh`, `claude-docker`, and `test-concurrent-git.sh`. This was blocking installer step `[2/10] Generating .env configuration` on default macOS bash.

## Why

- The TUI previously only exposed up/down/refresh/attach. Rebuilding an image, refreshing a GitHub token, or restarting a single container required dropping back to the bash CLI. The new keys close that parity gap.
- `u` / `d` felt like the TUI was hung on slow first-time starts because Refresh ran in parallel with the docker op via `tea.Batch`, so the dashboard showed stale state for the entire duration. Switching to the same `dockerOpDoneMsg` state machine used by `b` / `B` / `U` / `R` gives immediate progress feedback and an automatic refresh on completion.
- Pulling Claude OAuth credentials off the host and writing them into per-container state directories was a trust boundary the project no longer wants to maintain. Container-internal `claude auth login` (or Path B API keys) is sufficient.
- macOS ships bash 3.2 due to GPLv3, and `${var^^}` aborts with `bad substitution` there. The installer was unrunnable on a clean macOS until the substitution syntax was replaced.

## How

### TUI internals
- New `opKind` enum (`opUp` / `opDown` / `opBuild` / `opBuildNoCache` / `opUpdateBuild` / `opUpdateRecreate` / `opRestart` / `opGHAuthRecreate`) drives the completion handler.
- Long-running ops (build, update, restart) hand off to `tea.ExecProcess` so docker's native progress output stays intact. `u` / `d` / `g` run in goroutines and surface results via toast.
- `internal/auth/gh_token.go` reads the host `gh auth token` (status check first for clearer errors).
- `Env.Save` writes via `os.CreateTemp` + `Chmod 0600` + atomic `Rename` so a crashed write never leaves a half-baked `.env`.

### Removed surface area
- `scripts/claude-docker`: deletes `get_keychain_credentials`, `inject_credentials`, `cmd_auth`, the `auth)` dispatcher case, the `auth [service]` help line, and the header comment.
- `scripts/claude-docker.ps1`: deletes `Invoke-Auth`, the `'auth' { ... }` switch arm, and the help line.
- `README.md`: rewrites the macOS authentication section, removes the table row for `auth`, simplifies the "Authentication expired" troubleshooting.

### bash 3.2 compatibility
- `install.sh`: 3 sites converted inline.
- `setup-worktrees.sh`: 2 sites converted inline.
- `scripts/claude-docker`: 1 site converted inline.
- `test-concurrent-git.sh`: 5 sites; introduces a `to_upper` helper to keep the call sites readable.

No other bash 4+ features (`declare -A`, `mapfile`, globstar, `;&`) are used in the affected scripts.

## Test plan

- [ ] `cd tui && go build` succeeds.
- [ ] `tui/claude-docker-tui --version` prints version.
- [ ] In the TUI: `b` and `B` hand off to docker compose build and return cleanly.
- [ ] `U` chains build --no-cache then force-recreate; toast shows final result.
- [ ] `R` restarts the container under the cursor.
- [ ] `g` writes `GH_TOKEN` into `.env` (verify file permissions are 0600) and triggers a recreate when containers are running.
- [ ] `?` shows the help overlay; any key dismisses it.
- [ ] `u` / `d` show "Starting/Stopping containers..." toast immediately, then auto-refresh on completion (no more apparent hang).
- [ ] `bash -n scripts/install.sh scripts/setup-worktrees.sh scripts/claude-docker scripts/test-concurrent-git.sh` clean.
- [ ] Fresh `scripts/install.sh` run on macOS reaches step `[2/10] Generating .env configuration` without `bad substitution`.
- [ ] `scripts/claude-docker --help` no longer lists `auth`.
- [ ] `grep -rn 'cmd_auth\|inject_credentials\|get_keychain_credentials\|Invoke-Auth' scripts/` returns no matches.
