### PR TITLE
chore(install): rotate and lock-down .env backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,18 @@ platform `perl -i -pe`. If you still see stale `.env.tmp` files from a
 pre-fix install, delete them manually — they are not consumed by the
 current installer.
 
+**Stray `.env.backup.*` files from pre-rotation installs:**
+
+Current `install.sh` / `install.ps1` keep at most three `.env.backup.*`
+files and set them to `chmod 600` (owner-only) immediately after creation.
+If your working tree has leftover backups from before this change — often
+world-readable because they inherited umask — review and delete them:
+
+```bash
+ls -la .env.backup.*
+rm .env.backup.*   # or keep the newest by hand
+```
+
 **Container memory limit vs reservation:**
 
 `docker-compose.yml` sets `limits.memory: 4G` (hard cap — Docker will refuse

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -345,6 +345,19 @@ function Get-Configuration {
 
 # --- .env Generation ----------------------------------------------------------
 
+function Remove-StaleEnvBackups {
+    param(
+        [Parameter(Mandatory)][string]$EnvFile,
+        [int]$Keep = 3
+    )
+    $dir = Split-Path -Parent $EnvFile
+    $pattern = (Split-Path -Leaf $EnvFile) + '.backup.*'
+    Get-ChildItem -Path $dir -Filter $pattern -File -ErrorAction SilentlyContinue |
+        Sort-Object Name -Descending |
+        Select-Object -Skip $Keep |
+        Remove-Item -Force -ErrorAction SilentlyContinue
+}
+
 function New-EnvFile {
     Write-LogStep 'Generating .env configuration'
 
@@ -356,8 +369,11 @@ function New-EnvFile {
             return
         }
         $timestamp = Get-Date -Format 'yyyyMMddHHmmss'
-        Copy-Item $envFile "${envFile}.backup.${timestamp}"
-        Write-LogInfo 'Backed up existing .env'
+        $backup = "${envFile}.backup.${timestamp}"
+        Copy-Item $envFile $backup
+        & icacls $backup /inheritance:r /grant:r "${env:USERNAME}:(R,W)" 2>$null | Out-Null
+        Remove-StaleEnvBackups -EnvFile $envFile -Keep 3
+        Write-LogInfo "Backed up existing .env to $(Split-Path -Leaf $backup)"
     }
 
     $projectDir = ConvertTo-ForwardSlash -Path $Script:SourceDir

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -131,6 +131,22 @@ check_command() {
     command -v "$1" &>/dev/null
 }
 
+# Keep at most $keep newest ".env.backup.*" siblings of $env_file.
+# Sort is lexicographic by epoch suffix — monotonic for the foreseeable future.
+rotate_env_backups() {
+    local env_file="$1"
+    local keep="${2:-3}"
+    local dir base
+    dir=$(dirname -- "$env_file")
+    base=$(basename -- "$env_file")
+    find "$dir" -maxdepth 1 -type f -name "${base}.backup.*" 2>/dev/null \
+        | sort -r \
+        | tail -n +$((keep + 1)) \
+        | while IFS= read -r stale; do
+            rm -f -- "$stale"
+        done
+}
+
 # Measure filesystem I/O latency with a single write+read+delete cycle.
 # Returns latency in milliseconds.
 measure_io_latency() {
@@ -541,8 +557,11 @@ generate_env() {
             log_warn "Keeping existing .env. Some settings may not match your choices."
             return 0
         fi
-        cp "$env_file" "${env_file}.backup.$(date +%s)"
-        log_info "Backed up existing .env"
+        local backup="${env_file}.backup.$(date +%s)"
+        cp "$env_file" "$backup"
+        chmod 600 "$backup"
+        rotate_env_backups "$env_file" 3
+        log_info "Backed up existing .env to ${backup##*/}"
     fi
 
     {


### PR DESCRIPTION
## What

### Summary
Cap `.env.backup.*` retention to the 3 newest files and enforce `chmod 600`
(owner-only) on every backup created by `install.sh` / `install.ps1`.

### Change Type
- [x] Chore (configuration / tooling)

### Affected Components
- `scripts/install.sh` — new `rotate_env_backups()` helper + backup hardening
- `scripts/install.ps1` — new `Remove-StaleEnvBackups` + `icacls` lockdown
- `README.md` — troubleshooting entry for pre-rotation stray backups

## Why

Prior behavior let `.env.backup.*` accumulate without bound and inherit the
user's umask — `ls -la` on the working tree showed four world-readable
backups (`rwxrwxrwx`) even though `.env` itself ends up `chmod 600`. Since
backups contain the same secrets as `.env`, this is a silent secret-sprawl
risk.

### Related Issues
- Closes #168
- Part of #167 (Phase 7 — supply chain, parsing, and automation hardening)

## How

### Bash
```bash
rotate_env_backups() {
    local env_file="$1"
    local keep="${2:-3}"
    find "$(dirname "$env_file")" -maxdepth 1 -type f \
        -name "$(basename "$env_file").backup.*" 2>/dev/null \
        | sort -r | tail -n +$((keep + 1)) \
        | while IFS= read -r stale; do rm -f -- "$stale"; done
}
```
Called from `generate_env()` right after `cp` + `chmod 600` on the new
backup. Uses `find` instead of `ls` parsing (shellcheck-friendly).

### PowerShell
Mirrors bash with `Get-ChildItem | Sort-Object Name -Descending |
Select-Object -Skip $Keep | Remove-Item`. Backup ACL is tightened by
reusing the existing `icacls ... /grant:r "${env:USERNAME}:(R,W)"`
pattern already used for `.env` itself.

## Test Plan

### Automated smoke test (bash, passed locally)
```bash
for i in 1..10; do
    cp .env .env.backup.$epoch_i; chmod 600 ...; rotate_env_backups .env 3
done
# Result: 3 files remaining, all 600
```

### Manual verification on reviewer's side
1. Create a dummy `.env` and a few `.env.backup.*` with various timestamps.
2. Run `install.sh` (or `install.ps1`) and confirm overwrite path.
3. Verify:
   - [ ] `ls .env.backup.* | wc -l` ≤ 3
   - [ ] `stat -c '%a' .env.backup.<ts>` returns `600` (Linux)
   - [ ] PowerShell: backup ACL shows only the current user with R,W.

### Breaking Changes
None. Purely additive behavior on the backup path.