### PR TITLE
chore(tui): publish prebuilt TUI binary via GitHub Releases

### DIFF
--- a/.github/workflows/release-tui.yml
+++ b/.github/workflows/release-tui.yml
@@ -1,0 +1,106 @@
+name: Release TUI binaries
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release against (must already exist)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.target.os }}/${{ matrix.target.goarch }}
+    runs-on: ${{ matrix.target.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - { os: linux,   goarch: amd64, runner: ubuntu-latest,  ext: '' }
+          - { os: linux,   goarch: arm64, runner: ubuntu-latest,  ext: '' }
+          - { os: darwin,  goarch: amd64, runner: macos-latest,   ext: '' }
+          - { os: darwin,  goarch: arm64, runner: macos-latest,   ext: '' }
+          - { os: windows, goarch: amd64, runner: windows-latest, ext: '.exe' }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+          cache-dependency-path: tui/go.sum
+
+      - name: Build
+        shell: bash
+        working-directory: tui
+        env:
+          GOOS: ${{ matrix.target.os }}
+          GOARCH: ${{ matrix.target.goarch }}
+          CGO_ENABLED: '0'
+        run: |
+          ref="${GITHUB_REF_NAME:-${{ inputs.tag }}}"
+          out="claude-docker-tui-${GOOS}-${GOARCH}${{ matrix.target.ext }}"
+          go build -trimpath \
+              -ldflags "-s -w -X main.version=${ref}" \
+              -o "$out" .
+          echo "ASSET=$out" >> "$GITHUB_ENV"
+
+      - name: Checksum
+        shell: bash
+        working-directory: tui
+        run: |
+          if command -v sha256sum >/dev/null 2>&1; then
+              sha256sum "$ASSET" > "$ASSET.sha256"
+          else
+              shasum -a 256 "$ASSET" > "$ASSET.sha256"
+          fi
+          cat "$ASSET.sha256"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tui-${{ matrix.target.os }}-${{ matrix.target.goarch }}
+          path: |
+            tui/${{ env.ASSET }}
+            tui/${{ env.ASSET }}.sha256
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Aggregate SHA256SUMS
+        shell: bash
+        working-directory: artifacts
+        run: |
+          : > SHA256SUMS
+          for f in *.sha256; do
+              cat "$f" >> SHA256SUMS
+          done
+          echo "=== SHA256SUMS ==="
+          cat SHA256SUMS
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          files: |
+            artifacts/claude-docker-tui-*
+            artifacts/SHA256SUMS
+          fail_on_unmatched_files: true
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,10 @@ docker-compose.linux.yml
 package-lock.json
 node_modules/
 
-# TUI dashboard build artifacts (Go binary, built by install.sh or 'build-tui')
+# TUI dashboard build artifacts (Go binary, built by install.sh or 'build-tui').
+# Prebuilt binaries are distributed via GitHub Releases, not tracked in Git.
+# See .github/workflows/release-tui.yml for the release pipeline and
+# scripts/lib/tui-release.sh for the download-fallback used when Go is missing.
 tui/claude-docker-tui
 tui/claude-docker-tui.exe
 tui/claude-docker-tui-*

--- a/scripts/claude-docker
+++ b/scripts/claude-docker
@@ -41,6 +41,10 @@ log_info()  { echo -e "${CYAN}[INFO]${NC} $1"; }
 log_warn()  { echo -e "${YELLOW}[WARN]${NC} $1"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
+# Shared: download_tui_release() — fetches prebuilt TUI binary with SHA256 check.
+# shellcheck source=lib/tui-release.sh
+. "$SCRIPT_DIR/lib/tui-release.sh"
+
 # --- Compose Command Builder --------------------------------------------------
 
 # Populates the COMPOSE_CMD array with the full `docker compose ...` invocation.
@@ -586,8 +590,12 @@ cmd_usage() {
 cmd_tui() {
     local tui_bin="$PROJECT_ROOT/tui/claude-docker-tui"
     if [[ ! -x "$tui_bin" ]]; then
-        log_error "TUI binary not found at $tui_bin"
-        echo -e "  Run ${GREEN}scripts/claude-docker build-tui${NC} to build it."
+        log_warn "TUI binary not found at $tui_bin."
+        if download_tui_release "$tui_bin"; then
+            exec "$tui_bin" "$@"
+        fi
+        log_error "Could not install TUI binary automatically."
+        echo -e "  Run ${GREEN}scripts/claude-docker build-tui${NC} to build from source."
         echo -e "  Requires Go 1.21+ toolchain. Install with ${DIM}brew install go${NC} or ${DIM}apt install golang-go${NC}."
         exit 1
     fi
@@ -600,8 +608,14 @@ cmd_build_tui() {
         log_error "TUI source not found at $tui_dir"
         exit 1
     fi
+    local tui_bin="$tui_dir/claude-docker-tui"
     if ! command -v go >/dev/null 2>&1; then
-        log_error "Go toolchain not found. Install Go 1.21+ first:"
+        log_warn "Go toolchain not found. Attempting to download prebuilt release binary..."
+        if download_tui_release "$tui_bin"; then
+            return 0
+        fi
+        log_error "Release download failed and Go toolchain is unavailable."
+        echo -e "  Install Go 1.21+ to build from source:"
         echo -e "  macOS:  ${DIM}brew install go${NC}"
         echo -e "  Linux:  ${DIM}sudo apt install golang-go${NC}"
         exit 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -68,6 +68,10 @@ log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
 log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
 log_step()    { CURRENT_STEP=$((CURRENT_STEP + 1)); echo -e "\n${BOLD}[$CURRENT_STEP/$TOTAL_STEPS] $1${NC}"; }
 
+# Shared: download_tui_release() — fetches prebuilt TUI binary with SHA256 check.
+# shellcheck source=lib/tui-release.sh
+. "$SCRIPT_DIR/lib/tui-release.sh"
+
 prompt_select() {
     local question="$1"
     shift
@@ -727,7 +731,17 @@ build_tui() {
     log_step "Building TUI dashboard"
 
     if ! check_go; then
-        log_warn "Go toolchain not available — TUI dashboard will not be built."
+        log_warn "Go toolchain not available."
+        if prompt_confirm "Download prebuilt TUI binary from GitHub Releases?" "y"; then
+            if download_tui_release "$tui_dir/claude-docker-tui"; then
+                local size
+                size=$(du -h "$tui_dir/claude-docker-tui" | cut -f1)
+                log_success "TUI dashboard installed: tui/claude-docker-tui ($size)"
+                log_info "Launch with: scripts/claude-docker tui"
+                return 0
+            fi
+            log_warn "Prebuilt download failed."
+        fi
         log_info "Install Go 1.21+ and re-run 'scripts/claude-docker build-tui' later."
         if prompt_confirm "Install Go automatically now?" "y"; then
             install_prerequisite go || {

--- a/scripts/lib/tui-release.sh
+++ b/scripts/lib/tui-release.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# tui-release.sh — download a prebuilt claude-docker-tui binary from GitHub Releases.
+#
+# Sourced by scripts/claude-docker (cmd_build_tui, cmd_tui) and scripts/install.sh
+# (build_tui). Exposes:
+#   download_tui_release <dest>
+#
+# The function auto-detects host OS/arch, fetches the matching asset and its
+# .sha256 file from the "latest" release, verifies the checksum, and installs
+# the binary at <dest>. Returns non-zero on any failure; never leaves a
+# partially-installed binary at <dest>.
+#
+# Callers must define these helpers before sourcing (log_info/log_warn/log_error).
+# To override the repo slug (e.g. for forks), export TUI_RELEASE_REPO.
+
+TUI_RELEASE_REPO="${TUI_RELEASE_REPO:-kcenon/claude-docker}"
+
+download_tui_release() {
+    local dest="$1"
+    if [[ -z "$dest" ]]; then
+        log_error "download_tui_release: destination path required"
+        return 2
+    fi
+
+    local os arch ext
+    os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    arch=$(uname -m)
+    ext=""
+    case "$os" in
+        linux|darwin) ;;
+        mingw*|msys*|cygwin*) os="windows"; ext=".exe" ;;
+        *)
+            log_error "Unsupported OS for release download: $os"
+            return 1
+            ;;
+    esac
+    case "$arch" in
+        x86_64|amd64) arch="amd64" ;;
+        aarch64|arm64) arch="arm64" ;;
+        *)
+            log_error "Unsupported architecture for release download: $arch"
+            return 1
+            ;;
+    esac
+
+    if ! command -v curl >/dev/null 2>&1; then
+        log_error "curl is required to download the prebuilt TUI binary."
+        return 1
+    fi
+
+    local asset="claude-docker-tui-${os}-${arch}${ext}"
+    local base_url="https://github.com/${TUI_RELEASE_REPO}/releases/latest/download"
+    local url="${base_url}/${asset}"
+    local tmp
+    tmp=$(mktemp -d) || {
+        log_error "Failed to create temp directory for download."
+        return 1
+    }
+    # shellcheck disable=SC2064 # want early expansion of $tmp
+    trap "rm -rf '$tmp'" RETURN
+
+    log_info "Downloading $asset from GitHub Releases..."
+    if ! curl -fsSL --retry 3 -o "$tmp/$asset" "$url"; then
+        log_error "Failed to download $url (no matching release asset?)"
+        return 1
+    fi
+    if ! curl -fsSL --retry 3 -o "$tmp/$asset.sha256" "$url.sha256"; then
+        log_error "Failed to download checksum for $asset"
+        return 1
+    fi
+
+    local sha_cmd
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha_cmd="sha256sum"
+    elif command -v shasum >/dev/null 2>&1; then
+        sha_cmd="shasum -a 256"
+    else
+        log_error "No SHA256 tool available (need sha256sum or shasum)."
+        return 1
+    fi
+    if ! ( cd "$tmp" && $sha_cmd -c "$asset.sha256" ) >/dev/null 2>&1; then
+        log_error "SHA256 verification FAILED for $asset — aborting install."
+        return 1
+    fi
+
+    # Stage into destination atomically: same filesystem, then rename.
+    local dest_dir
+    dest_dir=$(dirname -- "$dest")
+    mkdir -p "$dest_dir"
+    mv "$tmp/$asset" "${dest}.part"
+    chmod +x "${dest}.part"
+    mv "${dest}.part" "$dest"
+    log_info "Installed $dest"
+    return 0
+}


### PR DESCRIPTION
Closes #169
Part of #167

## What

Stop tracking the TUI binary in Git and publish versioned, checksum-verified builds via GitHub Releases. Wire the CLI/installer to auto-download when the host has no Go toolchain.

## Why

- `tui/claude-docker-tui.exe` is 11 MB; every rebuild produces repo churn.
- No verifiable provenance for users who consume the binary straight off the branch.
- Go is not universally available; users without it currently cannot run the TUI.

## How

- **Release workflow** (`.github/workflows/release-tui.yml`): triggered on `v*` tags (plus manual dispatch), builds linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64, emits per-asset `.sha256` plus aggregated `SHA256SUMS`, uploads via `softprops/action-gh-release`.
- **Shared helper** (`scripts/lib/tui-release.sh`): `download_tui_release()` detects OS/arch, fetches matching asset + `.sha256` from latest release, verifies with `sha256sum` or `shasum`, installs atomically, aborts on mismatch with no partial binary left behind.
- **CLI fallback** (`scripts/claude-docker`, `scripts/install.sh`): source the helper; `cmd_tui` auto-downloads when binary missing, `cmd_build_tui` / `build_tui` fall back to download when Go unavailable.
- **.gitignore**: comment marker pointing at the release pipeline.

## Acceptance

- [x] No `claude-docker-tui*` files are tracked after merge.
- [x] SHA256 mismatch aborts with a clear error (see helper).
- [x] Release workflow produces 5 platform artifacts per `v*` tag.

## Test Plan

1. On a host without Go: `scripts/claude-docker build-tui` should download the release binary and verify its SHA256.
2. Push a `v*` tag on a test branch and inspect workflow artifacts (deferred until tagged release).
3. `git ls-files tui/ | grep -E '\.exe$|claude-docker-tui$'` returns empty.