### PR TITLE
security(dockerfile): pin Node base image by sha256 digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 # Base: node:20.18.1-slim (Debian/glibc)
-# Pinned to a specific patch version for reproducible builds. To bump:
+# Pinned to a specific patch version AND content digest so rebuilds are
+# byte-for-byte reproducible and any upstream repush of the tag is caught
+# at build time as a digest mismatch. To bump:
 #   1. Check <https://hub.docker.com/_/node/tags?name=slim> for the latest 20.x LTS
-#   2. Update the tag below
-#   3. Optionally capture the digest:
-#      docker pull node:20.18.1-slim \
-#        && docker inspect --format='{{index .RepoDigests 0}}' node:20.18.1-slim
+#   2. Capture the digest on a trusted host (REQUIRED, not optional):
+#        docker pull node:<new-version>-slim \
+#          && docker inspect --format='{{index .RepoDigests 0}}' node:<new-version>-slim
+#   3. Update BOTH the tag and the @sha256: suffix in the FROM line below
 #   4. Rebuild: docker compose build --no-cache
-FROM node:20.18.1-slim
+FROM node:20.18.1-slim@sha256:b2c8e0eb8a6aeeae33b2711f8f516003e27ee45804e270468d937b3214f2f0cc
 
 # Version pinning via build arg (omit for latest)
 ARG CLAUDE_CODE_VERSION

--- a/README.md
+++ b/README.md
@@ -445,18 +445,20 @@ Requirements section below uses `limits` to size Docker Desktop memory;
 
 ## Bumping the Base Image
 
-The `Dockerfile` pins the Node base image to a specific patch version for
-reproducible builds. To bump:
+The `Dockerfile` pins the Node base image to a specific patch version **and
+content digest** so rebuilds are byte-for-byte reproducible and any upstream
+repush of the tag is caught at build time as a digest mismatch. To bump:
 
 1. Check <https://hub.docker.com/_/node/tags?name=slim> for the latest 20.x LTS
-2. Update the `FROM` line in `Dockerfile`
-3. Update the `image:` tag in `docker-compose.yml` to today's date
-   (`claude-code-base:YYYY.MM.DD`) so old containers cannot reference the new build
-4. Optionally capture the digest for future verification:
+2. Capture the digest on a trusted host (**required**, not optional):
    ```bash
-   docker pull node:20.x.y-slim
-   docker inspect --format='{{index .RepoDigests 0}}' node:20.x.y-slim
+   docker pull node:<new-version>-slim
+   docker inspect --format='{{index .RepoDigests 0}}' node:<new-version>-slim
    ```
+3. Update the `FROM` line in `Dockerfile` — **both** the tag and the
+   `@sha256:` suffix must be updated together
+4. Update the `image:` tag in `docker-compose.yml` to today's date
+   (`claude-code-base:YYYY.MM.DD`) so old containers cannot reference the new build
 5. Rebuild everything from scratch: `docker compose build --no-cache`
 6. Check the build log for the `[build] GitHub CLI keyring fingerprint:` line
    and confirm it matches prior builds (unexpected changes may indicate an


### PR DESCRIPTION
Closes #171
Part of #167

## Summary

Pin the Dockerfile base image to `node:20.18.1-slim@sha256:b2c8e0eb...` so any future repush of the `20.18.1-slim` tag is caught as a digest mismatch at build time.

## How

- `Dockerfile:11` — FROM line now carries the digest captured via `docker inspect --format='{{index .RepoDigests 0}}' node:20.18.1-slim` on 2026-04-17.
- `Dockerfile:1-10` — bump procedure reworded so digest capture is required, not optional, and tag+digest must move together.
- `README.md` "Bumping the Base Image" — same wording change.

## Acceptance

- [x] `grep -n '^FROM' Dockerfile` shows `@sha256:`.
- [x] `docker manifest inspect` against the pinned digest succeeds (registry still has this manifest).
- [x] README treats digest capture as required.
- [ ] `docker compose build --no-cache` — deferred to local reviewer / CI (manifest-level verification performed here).

## Test Plan

1. `docker compose build --no-cache` from a clean cache should succeed with the pinned digest.
2. Manually corrupt one hex character of the digest in the Dockerfile; rebuild should fail with `manifest unknown` before any RUN step executes.