### PR TITLE
ci: add shellcheck, hadolint, PSScriptAnalyzer, compose validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ludeeus/action-shellcheck@master
+        env:
+          # SC1091: sourced files are resolved at runtime, not checkable in lint
+          SHELLCHECK_OPTS: -e SC1091
+        with:
+          scandir: "./scripts"
+          severity: warning
+
+  hadolint:
+    name: Hadolint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+          failure-threshold: warning
+
+  psanalyzer:
+    name: PSScriptAnalyzer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
+      - name: Run analyzer
+        shell: pwsh
+        run: |
+          $results = Invoke-ScriptAnalyzer -Path scripts -Recurse -Severity Warning,Error
+          if ($results) {
+            $results | Format-Table -AutoSize
+            exit 1
+          }
+
+  compose-validate:
+    name: Compose validate (${{ matrix.fixture }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        fixture: [minimal, tier-b, n5, with-special-chars]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Stage fixture
+        run: cp tests/env_fixtures/${{ matrix.fixture }}.env .env
+      - name: Generate compose
+        run: bash scripts/generate-compose.sh
+      - name: Validate compose
+        run: docker compose config > /dev/null

--- a/tests/env_fixtures/README.md
+++ b/tests/env_fixtures/README.md
@@ -1,0 +1,29 @@
+# Compose validation fixtures
+
+Used by `.github/workflows/ci.yml` `compose-validate` matrix. Each `*.env` file
+is copied to the repo root as `.env`, then `scripts/generate-compose.sh` and
+`docker compose config` run against it.
+
+| Fixture | Exercises |
+|---------|-----------|
+| `minimal.env` | Default 2-account Tier A setup without API keys |
+| `tier-b.env` | Worktree paths (`PROJECT_DIR_A/B`, `CONTAINER_PROJECT_DIR_A/B`) |
+| `n5.env` | `NUM_ACCOUNTS=5` scaling path (claude-a..claude-e) |
+
+`with-special-chars.env` (values containing `#`, `=`, quotes, whitespace) is
+added by #170 alongside the unified `.env` parser.
+
+## Running locally
+
+```bash
+cd claude-docker
+cp tests/env_fixtures/n5.env .env
+bash scripts/generate-compose.sh
+docker compose config > /dev/null && echo OK
+```
+
+Clean up afterwards so the fixture `.env` does not leak into day-to-day runs:
+
+```bash
+git checkout -- .env 2>/dev/null || rm .env
+```

--- a/tests/env_fixtures/minimal.env
+++ b/tests/env_fixtures/minimal.env
@@ -1,2 +1,8 @@
+# Fixture: minimal — default 2-account Tier A setup without API keys.
+# Used by .github/workflows/ci.yml compose-validate matrix AND by
+# tests/test_parse_env.sh / .ps1 for parser assertions.
 NUM_ACCOUNTS=2
+HOME=/tmp/claude-test
+PROJECT_DIR=/tmp/claude-test/project
+CONTAINER_PROJECT_DIR=/project
 IMAGE_TAG=latest

--- a/tests/env_fixtures/n5.env
+++ b/tests/env_fixtures/n5.env
@@ -1,0 +1,7 @@
+# Fixture: n5 — 5-account scaling verification (claude-a..claude-e).
+# Used by .github/workflows/ci.yml compose-validate matrix.
+NUM_ACCOUNTS=5
+HOME=/tmp/claude-test
+PROJECT_DIR=/tmp/claude-test/project
+CONTAINER_PROJECT_DIR=/project
+IMAGE_TAG=ci-test

--- a/tests/env_fixtures/tier-b.env
+++ b/tests/env_fixtures/tier-b.env
@@ -1,0 +1,11 @@
+# Fixture: tier-b — worktree setup with PROJECT_DIR_A/B populated.
+# Used by .github/workflows/ci.yml compose-validate matrix.
+NUM_ACCOUNTS=2
+HOME=/tmp/claude-test
+PROJECT_DIR=/tmp/claude-test/project
+CONTAINER_PROJECT_DIR=/project
+IMAGE_TAG=ci-test
+PROJECT_DIR_A=/tmp/claude-test/project-a
+PROJECT_DIR_B=/tmp/claude-test/project-b
+CONTAINER_PROJECT_DIR_A=/project-a
+CONTAINER_PROJECT_DIR_B=/project-b

--- a/tests/env_fixtures/with-special-chars.env
+++ b/tests/env_fixtures/with-special-chars.env
@@ -1,0 +1,12 @@
+# Fixture: with-special-chars — exercises the unified parser (#170) from
+# the compose-validate job: spaces, inline comments, quoted values, and
+# values containing '='. Combined with docker compose config, this catches
+# any regression where the parser embeds comment text or quotes into a
+# value that the compose engine then rejects.
+NUM_ACCOUNTS=2
+HOME=/tmp/claude-test
+PROJECT_DIR=/tmp/claude test/project  # path with a space and inline comment
+CONTAINER_PROJECT_DIR=/project
+IMAGE_TAG="ci-test"
+GH_TOKEN=gho_fake123  # inline comment must be stripped
+EXTRA="foo=bar=baz"


### PR DESCRIPTION
Closes #175
Part of #167

## Summary

Add `.github/workflows/ci.yml` with four jobs — shellcheck, hadolint, PSScriptAnalyzer, and a compose-validate matrix — to catch the regressions this repo has already shipped (sed portability, CRLF, broken compose files).

## Jobs

| Job | Scope | Threshold |
|-----|-------|-----------|
| shellcheck | `scripts/` (SC1091 excluded) | warning |
| hadolint | `Dockerfile` | warning |
| psanalyzer | `scripts/` recurse | Warning, Error |
| compose-validate | matrix: minimal / tier-b / n5 / with-special-chars | fail-fast: false |

Shared `concurrency` group cancels superseded runs on the same ref to limit CI minutes.

## Fixtures (`tests/env_fixtures/`)

- `minimal.env` — expanded from #170's parser fixture so `docker compose config` has HOME / PROJECT_DIR.
- `tier-b.env` — `PROJECT_DIR_A/B` worktree paths.
- `n5.env` — `NUM_ACCOUNTS=5` scaling.
- `with-special-chars.env` — exercises the #170 parser under values containing spaces, inline comments, quotes, and `=`.
- `README.md` — documents the matrix and a local-run recipe.

## Branching policy note

Per `.claude/rules/workflow/branching-strategy.md`, CI runs only on PRs targeting `main`. This PR targets `develop`, so the workflow first executes on the next develop → main release PR. If lint rules flag existing warnings at that point, they should be fixed in-flight — all four jobs are configured with `warning`-level thresholds, not `error`-only.

## Acceptance

- [x] Four jobs declared in one workflow file.
- [x] All four fixtures present.
- [x] Parser tests (#170) still pass 21/21 after expanding `minimal.env`.
- [x] `yaml.safe_load` parses `ci.yml` without error.
- [ ] Jobs actually execute — deferred until the develop → main release PR because of the branching policy above.

## Test Plan

1. Wait for next develop → main release PR. All 7 checks (1 shellcheck + 1 hadolint + 1 psanalyzer + 4 compose-validate) should appear and pass.
2. If any job fails, open a follow-up PR with the specific fix (do not relax thresholds unless justified).
3. Manual local sanity already performed: `bash -n` on all touched scripts, fixture files parse through `parse_env.sh` helpers, YAML validates via `python -c 'import yaml'`.