### PR TITLE
fix(compose): omit ANTHROPIC_API_KEY env var when empty for Path A users

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,14 @@ scripts/claude-docker exec claude-a claude auth status
 If container-internal OAuth fails on macOS due to Docker network boundary
 limitations, switch to Path B (API keys) in `.env`.
 
+> **Switching between Path A and Path B**: After editing `CLAUDE_API_KEY_*`
+> in `.env`, re-run `scripts/generate-compose.sh` (or `.ps1`) and
+> `docker compose up -d` so the generated compose files reflect the new
+> state. `ANTHROPIC_API_KEY` is only injected into a container when the
+> matching `CLAUDE_API_KEY_<LETTER>` is set at generate time — emitting
+> it with an empty string would otherwise make the SDK ignore the
+> `.credentials.json` from OAuth.
+
 **GitHub CLI (`gh`)** is automatically available inside containers. The host's
 `~/.config/gh/` is bind-mounted read-only, so `gh` commands use the host's
 GitHub session without separate authentication.

--- a/scripts/generate-compose.ps1
+++ b/scripts/generate-compose.ps1
@@ -112,7 +112,15 @@ function New-BaseCompose {
         [void]$sb.AppendLine('      - CLAUDE_CONFIG_DIR=/home/node/.claude')
         [void]$sb.AppendLine('      - CLAUDE_CONFIG_SOURCE=${CLAUDE_CONFIG_SOURCE:-}')
         [void]$sb.AppendLine('      - NODE_OPTIONS=--max-old-space-size=4096')
-        [void]$sb.AppendLine("      - ANTHROPIC_API_KEY=`${CLAUDE_API_KEY_${upper}:-}")
+        # Only emit ANTHROPIC_API_KEY when CLAUDE_API_KEY_<LETTER> is set at
+        # generate time. Path A (OAuth) users have no value; emitting
+        # ANTHROPIC_API_KEY= with an empty string makes the SDK prefer the
+        # empty env var over .credentials.json in the mounted state dir.
+        $keyVarName = "CLAUDE_API_KEY_${upper}"
+        $keyValue = [Environment]::GetEnvironmentVariable($keyVarName)
+        if (-not [string]::IsNullOrEmpty($keyValue)) {
+            [void]$sb.AppendLine("      - ANTHROPIC_API_KEY=`${CLAUDE_API_KEY_${upper}}")
+        }
         [void]$sb.AppendLine('      - GH_TOKEN=${GH_TOKEN:-}')
         [void]$sb.AppendLine('      - GIT_USER_NAME=${GIT_USER_NAME:-}')
         [void]$sb.AppendLine('      - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}')

--- a/scripts/generate-compose.sh
+++ b/scripts/generate-compose.sh
@@ -91,7 +91,14 @@ generate_base() {
             echo "      - CLAUDE_CONFIG_DIR=/home/node/.claude"
             echo "      - CLAUDE_CONFIG_SOURCE=\${CLAUDE_CONFIG_SOURCE:-}"
             echo "      - NODE_OPTIONS=--max-old-space-size=4096"
-            echo "      - ANTHROPIC_API_KEY=\${CLAUDE_API_KEY_${upper}:-}"
+            # Only emit ANTHROPIC_API_KEY when CLAUDE_API_KEY_<LETTER> is
+            # set at generate time. Path A (OAuth) users have no value;
+            # emitting ANTHROPIC_API_KEY= with an empty string makes the
+            # SDK prefer the empty env var over .credentials.json.
+            local key_var="CLAUDE_API_KEY_${upper}"
+            if [[ -n "${!key_var:-}" ]]; then
+                echo "      - ANTHROPIC_API_KEY=\${CLAUDE_API_KEY_${upper}}"
+            fi
             echo "      - GH_TOKEN=\${GH_TOKEN:-}"
             echo "      - GIT_USER_NAME=\${GIT_USER_NAME:-}"
             echo "      - GIT_USER_EMAIL=\${GIT_USER_EMAIL:-}"


### PR DESCRIPTION
Closes #181
Part of #167

## Summary

Generated compose files previously always contained `- ANTHROPIC_API_KEY=\${CLAUDE_API_KEY_A:-}`. Under Path A (OAuth) that evaluates to an empty string, which makes the Anthropic SDK prefer the env var over `.credentials.json` and then fail with "no auth". Fix: move the empty-check to generate time so the line is only emitted when a key is actually configured.

## How

- `scripts/generate-compose.sh`: wrap the `ANTHROPIC_API_KEY` line in an `if [[ -n "${!key_var:-}" ]]` guard using indirect expansion on `CLAUDE_API_KEY_<LETTER>`. Works because `load_env_file` (from #170) exports those keys into the generator's shell.
- `scripts/generate-compose.ps1`: same guard via `[Environment]::GetEnvironmentVariable`.
- `README.md` Authentication section: document that switching Path A ↔ Path B requires re-running `generate-compose.sh` (move from runtime check to generate-time check).

## Acceptance

- [x] With no `CLAUDE_API_KEY_*` in env, generated `docker-compose.yml` contains zero `ANTHROPIC_API_KEY` lines (verified locally).
- [x] With `CLAUDE_API_KEY_A=sk-ant-test`, exactly one line appears, scoped to `claude-a` (verified locally).
- [x] README instructs re-running the generator after `.env` changes.

## Test Plan

```bash
unset CLAUDE_API_KEY_A CLAUDE_API_KEY_B
NUM_ACCOUNTS=2 HOME=/tmp/t IMAGE_TAG=t PROJECT_DIR=/tmp/p \
  CONTAINER_PROJECT_DIR=/project bash scripts/generate-compose.sh
grep -c ANTHROPIC docker-compose.yml   # → 0

CLAUDE_API_KEY_A=sk-ant-test NUM_ACCOUNTS=2 HOME=/tmp/t IMAGE_TAG=t \
  PROJECT_DIR=/tmp/p CONTAINER_PROJECT_DIR=/project \
  bash scripts/generate-compose.sh
grep -c ANTHROPIC docker-compose.yml   # → 1
```