### PR TITLE
refactor(entrypoint): scope CRLF normalization and make it opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,10 +413,16 @@ Ensure `PROJECT_DIR` points to a WSL2 filesystem path (`/home/...`),
 **CRLF errors in container (`$'\r': command not found`):**
 
 This happens when a Windows editor saved a `.sh` file with CRLF line endings,
-overriding the `.gitattributes eol=lf` rule. The container entrypoint now
-normalizes CRLF under `/project` at startup, so this should auto-heal on
-container restart. If it persists, run `dos2unix` on the offending file or
-configure your editor to use LF for `.sh` files.
+overriding the `.gitattributes eol=lf` rule. Fix the underlying cause first
+(`git config core.autocrlf input`, add/fix `.gitattributes`, or have your
+editor save as LF for `.sh` files).
+
+If you cannot fix the host setup and need the container to auto-patch bind-
+mounted scripts, set `CLAUDE_NORMALIZE_CRLF=1` in `.env` and restart. This
+reinstates the former entrypoint sweep under `/project` with a bounded depth.
+**Warning**: this modifies host files via the bind mount, which can appear
+as unexpected `git status` diffs and conflict with host-side editors. It's
+off by default for that reason.
 
 **`${HOME}` not expanding in docker-compose.yml (Windows):**
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -204,19 +204,22 @@ if [ -n "${GIT_USER_EMAIL:-}" ] && [ -z "$(git config --global user.email 2>/dev
     git config --global user.email "$GIT_USER_EMAIL"
 fi
 
-# --- Bind-mounted project script CRLF normalization ---------------------------
-# Windows hosts (or editors with CRLF defaults) may introduce \r\n into shell
-# scripts bind-mounted under /project, even when .gitattributes enforces LF.
-# Strip CR characters in-place so bash does not trip over '\r: command not found'
-# when executing project-local scripts inside the container.
-# Best-effort: bounded depth to avoid scanning huge monorepos, errors suppressed
-# so the entrypoint never fails on read-only mounts or missing directories.
-if [ -d /project ]; then
+# --- Bind-mounted project script CRLF normalization (opt-in) -----------------
+# /project is a bind mount from the host. Rewriting files here mutates host
+# files, which can trigger editor "file changed" dialogs, show up as
+# unexpected diffs in `git status`, or race with concurrent host writes.
+# The sweep therefore runs only when the user explicitly opts in via
+# CLAUDE_NORMALIZE_CRLF=1 in .env (typical case: Windows hosts with
+# CRLF-default editors and no enforcing .gitattributes in the project repo).
+# Best-effort: bounded depth to avoid scanning huge monorepos, errors
+# suppressed so the entrypoint never fails on read-only mounts or missing
+# directories.
+if [ -d /project ] && [ "${CLAUDE_NORMALIZE_CRLF:-0}" = "1" ]; then
     sh_count=$(find /project -maxdepth 3 -name '*.sh' -type f 2>/dev/null | wc -l | tr -d ' ')
     if [ "${sh_count:-0}" -gt 0 ]; then
         find /project -maxdepth 3 -name '*.sh' -type f \
             -exec sed -i 's/\r$//' {} + 2>/dev/null || true
-        echo "[entrypoint] CRLF normalized in ${sh_count} shell script(s) under /project"
+        echo "[entrypoint] CRLF normalized in ${sh_count} shell script(s) under /project (opt-in)"
     fi
 fi
 

--- a/scripts/generate-compose.ps1
+++ b/scripts/generate-compose.ps1
@@ -111,6 +111,7 @@ function New-BaseCompose {
         [void]$sb.AppendLine('      - TERM=xterm-256color')
         [void]$sb.AppendLine('      - CLAUDE_CONFIG_DIR=/home/node/.claude')
         [void]$sb.AppendLine('      - CLAUDE_CONFIG_SOURCE=${CLAUDE_CONFIG_SOURCE:-}')
+        [void]$sb.AppendLine('      - CLAUDE_NORMALIZE_CRLF=${CLAUDE_NORMALIZE_CRLF:-}')
         [void]$sb.AppendLine('      - NODE_OPTIONS=--max-old-space-size=4096')
         # Only emit ANTHROPIC_API_KEY when CLAUDE_API_KEY_<LETTER> is set at
         # generate time. Path A (OAuth) users have no value; emitting

--- a/scripts/generate-compose.sh
+++ b/scripts/generate-compose.sh
@@ -90,6 +90,7 @@ generate_base() {
             echo "      - TERM=xterm-256color"
             echo "      - CLAUDE_CONFIG_DIR=/home/node/.claude"
             echo "      - CLAUDE_CONFIG_SOURCE=\${CLAUDE_CONFIG_SOURCE:-}"
+            echo "      - CLAUDE_NORMALIZE_CRLF=\${CLAUDE_NORMALIZE_CRLF:-}"
             echo "      - NODE_OPTIONS=--max-old-space-size=4096"
             # Only emit ANTHROPIC_API_KEY when CLAUDE_API_KEY_<LETTER> is
             # set at generate time. Path A (OAuth) users have no value;


### PR DESCRIPTION
Closes #172
Part of #167

## Summary

Default the `/project` CRLF sweep in the entrypoint to OFF. Set `CLAUDE_NORMALIZE_CRLF=1` in `.env` to re-enable. This avoids surprise mutation of bind-mounted host files on every container start.

## How

- `scripts/entrypoint.sh`: wrap the sweep in `[[ ${CLAUDE_NORMALIZE_CRLF:-0} == 1 ]]`. Log line appended `(opt-in)` to disambiguate.
- `scripts/generate-compose.sh` / `.ps1`: propagate the new env var into each service's `environment` list.
- `README.md` Troubleshooting: rewrite to lead with the real fixes (git autocrlf, .gitattributes) and describe the flag as the last-resort host-mutating escape hatch.

## Known gap

`.env.example` could not be updated in this PR because the session's sensitive-file-guard hook blocks access to `.env*` files. Please follow up with:

```env
# Set to 1 on Windows hosts where editors default to CRLF and
# .gitattributes is not enforced. Modifies host files via bind mount.
CLAUDE_NORMALIZE_CRLF=
```

## Acceptance

- [x] Flag unset (default): entrypoint block is skipped; no host mutation.
- [x] Flag set to `1`: sweep behaves as before and logs `(opt-in)`.
- [x] Generators pass the value through for both bash and pwsh.
- [x] README documents the trade-off.
- [ ] `.env.example` entry — deferred to a maintainer follow-up (see above).

## Test Plan

```bash
# Scenario 1: unset — no sweep
docker compose up -d && docker compose logs claude-a | grep CRLF   # empty

# Scenario 2: opt-in — sweep runs
CLAUDE_NORMALIZE_CRLF=1 docker compose up -d \
  && docker compose logs claude-a | grep CRLF   # shows "(opt-in)" line
```