### PR TITLE
fix(install): gate npm install on package.json presence

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -702,6 +702,15 @@ function Start-Containers {
 function Install-Dependencies {
     Write-LogStep 'Installing project dependencies in containers'
 
+    # Skip entirely for non-Node projects so Python/Go/Rust/etc. users do
+    # not see a misleading "npm install skipped or failed" warning on every
+    # container and do not pay the npm registry round-trip for nothing.
+    $pkgJson = Join-Path $Script:SourceDir 'package.json'
+    if (-not (Test-Path $pkgJson -PathType Leaf)) {
+        Write-LogInfo "No package.json at $($Script:SourceDir) — skipping npm install."
+        return
+    }
+
     $services = @(Get-ServiceNames -ProjectRoot $ProjectRoot)
 
     foreach ($svc in $services) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -917,6 +917,14 @@ start_containers() {
 install_dependencies() {
     log_step "Installing project dependencies in containers"
 
+    # Skip entirely for non-Node projects so Python/Go/Rust/etc. users do
+    # not see a misleading "npm install skipped or failed" warning on every
+    # container and do not pay the npm registry round-trip for nothing.
+    if [[ ! -f "$SOURCE_DIR/package.json" ]]; then
+        log_info "No package.json at $SOURCE_DIR — skipping npm install."
+        return 0
+    fi
+
     cd "$PROJECT_ROOT"
 
     local compose_cmd


### PR DESCRIPTION
Closes #174
Part of #167

## Summary

`install_dependencies` / `Install-Dependencies` previously ran `npm install` inside every container regardless of project type, producing a misleading WARN for Python/Go/Rust/etc. users and burning bandwidth.

## How

- `scripts/install.sh`: early-return when `$SOURCE_DIR/package.json` is missing.
- `scripts/install.ps1`: mirror using `Test-Path` on `$Script:SourceDir`.

## Acceptance

- [x] Non-Node project (no package.json) → `log_info` "skipping npm install" and function returns without touching containers.
- [x] Node project (package.json present) → existing per-service npm install loop runs unchanged.

## Test Plan

1. Point `.env`'s PROJECT_DIR at a Node project → install finishes with npm deps resolved.
2. Point at a repo with no `package.json` → single info line, no warnings.