### PR TITLE
feat(compose): parameterize container cpu/memory limits via .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,9 +480,20 @@ repush of the tag is caught at build time as a digest mismatch. To bump:
 
 ## Resource Requirements
 
-Each container has a 4 GB memory limit (2 GB reserved). Docker RAM below is the
-recommended Docker Desktop memory allocation to allow all containers to run at
-peak load.
+Each container **defaults** to a 4 GB memory limit (2 GB reserved), 2 CPU limit
+(1 CPU reserved). Override per installation in `.env`:
+
+```env
+CONTAINER_CPU_LIMIT=2
+CONTAINER_CPU_RESERVATION=1
+CONTAINER_MEM_LIMIT=4G
+CONTAINER_MEM_RESERVATION=2G
+```
+
+Re-run `scripts/generate-compose.sh` (or `.ps1`) after changing these so the
+generated compose files pick up the new values. The table below assumes
+defaults. Docker RAM is the recommended Docker Desktop memory allocation to
+allow all containers to run at peak load.
 
 | Instances | Docker RAM (recommended) | Host RAM (Linux / macOS / Windows) |
 |:---------:|:------------------------:|:----------------------------------:|

--- a/scripts/generate-compose.ps1
+++ b/scripts/generate-compose.ps1
@@ -55,6 +55,22 @@ if ($NumAccounts -lt 1 -or $NumAccounts -gt 26) {
     exit 1
 }
 
+# Container resource envelope (override via .env or host env). Defaults
+# reproduce the historical hardcoded values so existing installs see no
+# behavior change after regenerating.
+function Resolve-EnvOrDefault([string]$Key, [string]$Default) {
+    $val = [Environment]::GetEnvironmentVariable($Key)
+    if (-not [string]::IsNullOrEmpty($val)) { return $val }
+    if ($envData.ContainsKey($Key) -and -not [string]::IsNullOrEmpty($envData[$Key])) {
+        return $envData[$Key]
+    }
+    return $Default
+}
+$CpuLimit       = Resolve-EnvOrDefault 'CONTAINER_CPU_LIMIT' '2'
+$CpuReservation = Resolve-EnvOrDefault 'CONTAINER_CPU_RESERVATION' '1'
+$MemLimit       = Resolve-EnvOrDefault 'CONTAINER_MEM_LIMIT' '4G'
+$MemReservation = Resolve-EnvOrDefault 'CONTAINER_MEM_RESERVATION' '2G'
+
 function ConvertTo-Letter([int]$Index) {
     # 1 -> a, 2 -> b, ..., 26 -> z
     [char](96 + $Index)
@@ -128,11 +144,11 @@ function New-BaseCompose {
         [void]$sb.AppendLine('    deploy:')
         [void]$sb.AppendLine('      resources:')
         [void]$sb.AppendLine('        limits:')
-        [void]$sb.AppendLine('          cpus: "2"')
-        [void]$sb.AppendLine('          memory: 4G')
+        [void]$sb.AppendLine("          cpus: `"$CpuLimit`"")
+        [void]$sb.AppendLine("          memory: $MemLimit")
         [void]$sb.AppendLine('        reservations:')
-        [void]$sb.AppendLine('          cpus: "1"')
-        [void]$sb.AppendLine('          memory: 2G')
+        [void]$sb.AppendLine("          cpus: `"$CpuReservation`"")
+        [void]$sb.AppendLine("          memory: $MemReservation")
         [void]$sb.AppendLine('    command: ["sleep", "infinity"]')
 
         if ($i -lt $NumAccounts) {

--- a/scripts/generate-compose.sh
+++ b/scripts/generate-compose.sh
@@ -31,6 +31,14 @@ if [[ "$NUM_ACCOUNTS" -lt 1 || "$NUM_ACCOUNTS" -gt 26 ]]; then
     exit 1
 fi
 
+# Container resource envelope (override via .env or host env). Defaults
+# reproduce the historical hardcoded values so existing installs see no
+# behavior change after regenerating.
+CPU_LIMIT="${CONTAINER_CPU_LIMIT:-2}"
+CPU_RESERVATION="${CONTAINER_CPU_RESERVATION:-1}"
+MEM_LIMIT="${CONTAINER_MEM_LIMIT:-4G}"
+MEM_RESERVATION="${CONTAINER_MEM_RESERVATION:-2G}"
+
 # Convert 1-based index to lowercase letter: 1→a, 2→b, ..., 26→z
 index_to_letter() {
     printf "\\$(printf '%03o' $((96 + $1)))"
@@ -106,11 +114,11 @@ generate_base() {
             echo "    deploy:"
             echo "      resources:"
             echo "        limits:"
-            echo "          cpus: \"2\""
-            echo "          memory: 4G"
+            echo "          cpus: \"${CPU_LIMIT}\""
+            echo "          memory: ${MEM_LIMIT}"
             echo "        reservations:"
-            echo "          cpus: \"1\""
-            echo "          memory: 2G"
+            echo "          cpus: \"${CPU_RESERVATION}\""
+            echo "          memory: ${MEM_RESERVATION}"
             echo "    command: [\"sleep\", \"infinity\"]"
 
             # Blank line between services (but not after the last one)


### PR DESCRIPTION
Closes #177
Part of #167

## Summary

Expose the per-service `deploy.resources` CPU/memory limits and reservations as .env-overridable variables. Defaults reproduce the current hardcoded envelope (2/1 cpus, 4G/2G memory).

## How

- `scripts/generate-compose.sh` / `.ps1`: four variables (`CONTAINER_CPU_LIMIT`, `CONTAINER_CPU_RESERVATION`, `CONTAINER_MEM_LIMIT`, `CONTAINER_MEM_RESERVATION`) resolved from env or .env with defaults; substituted into the per-service `deploy` block.
- `README.md` Resource Requirements: document the keys and make explicit that the sizing table assumes defaults.

## Known gap

`.env.example` could not be updated due to the sensitive-file-guard hook blocking .env* access. Maintainer follow-up should append the four keys with default values and a short explanatory comment.

## Acceptance

- [x] Generator reads the four variables with working defaults.
- [x] Both bash and PowerShell generators produce identical output when variables are unset.
- [x] README explains the override path.
- [ ] .env.example entries — deferred maintainer follow-up (see above).

## Test Plan

```bash
# Default
unset CONTAINER_CPU_LIMIT CONTAINER_MEM_LIMIT
bash scripts/generate-compose.sh
grep -E 'cpus|memory' docker-compose.yml   # shows 2 / 4G / 1 / 2G

# Override
CONTAINER_CPU_LIMIT=1 CONTAINER_MEM_LIMIT=2G bash scripts/generate-compose.sh
grep -E 'cpus|memory' docker-compose.yml   # shows 1 / 2G / 1 / 2G
```