### PR TITLE
docs(readme): replace 'Path A/B' with 'OAuth / API key' and add a decision tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,27 +89,35 @@ PROJECT_DIR=/absolute/path/to/your/project
 
 ### 2. Authenticate
 
-Choose your authentication path:
+Choose **OAuth** (subscription) or **API key** (Anthropic Console):
 
-**Path A -- Subscription accounts (Pro / Max / Team):**
+| You have... | Host OS | Use |
+|-------------|---------|-----|
+| Claude.ai Pro / Max / Team subscription | Linux / WSL2 | **OAuth** |
+| Claude.ai Pro / Max / Team subscription | macOS | **OAuth** inside container; fall back to API key if Keychain errors appear |
+| Anthropic Console account only | any | **API key** |
+| Mix of both | any | **Per-container**: set `CLAUDE_API_KEY_<LETTER>` only for API-key slots — others fall back to OAuth |
 
-Authenticate inside each container after starting:
+**OAuth** — authenticate inside each container after starting:
+
 ```bash
 scripts/claude-docker claude claude-a
 # Inside container: claude auth login
 ```
 
-Note: Container-internal OAuth may fail on macOS due to Docker network
-boundary limitations. If it does, use Path B (API keys) below.
+Container-internal OAuth may fail on macOS due to Docker network
+boundary limitations. If it does, switch the affected account to API key.
 
-**Path B -- Console API keys:**
-
-Add to `.env`:
+**API key** — add to `.env`:
 
 ```bash
 CLAUDE_API_KEY_A=sk-ant-...
 CLAUDE_API_KEY_B=sk-ant-...
 ```
+
+Re-run `scripts/generate-compose.sh` after editing so the generator emits
+`ANTHROPIC_API_KEY` only for slots that actually have a key (see
+[Switching between OAuth and API key](#authentication) below).
 
 ### 3. Build and run
 
@@ -201,9 +209,9 @@ scripts/claude-docker exec claude-a claude auth status
 ```
 
 If container-internal OAuth fails on macOS due to Docker network boundary
-limitations, switch to Path B (API keys) in `.env`.
+limitations, switch to API keys in `.env`.
 
-> **Switching between Path A and Path B**: After editing `CLAUDE_API_KEY_*`
+> **Switching between OAuth and API key**: After editing `CLAUDE_API_KEY_*`
 > in `.env`, re-run `scripts/generate-compose.sh` (or `.ps1`) and
 > `docker compose up -d` so the generated compose files reflect the new
 > state. `ANTHROPIC_API_KEY` is only injected into a container when the

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -267,11 +267,12 @@ function Get-Configuration {
     $authChoice = Read-Selection `
         -Question 'Which authentication method will you use?' `
         -Options @(
-            'Path A: Subscription (Pro/Max/Team) - OAuth browser login',
-            'Path B: Console API key - paste key directly'
+            'OAuth - Claude.ai Pro/Max/Team subscription (browser login inside container)',
+            'API key - Anthropic Console account (paste key)'
         )
-    $Script:AuthPath = if ($authChoice -like '*Path A*') { 'A' } else { 'B' }
-    Write-LogInfo "Authentication: Path $($Script:AuthPath)"
+    $Script:AuthPath = if ($authChoice -like 'OAuth*') { 'A' } else { 'B' }
+    $label = if ($Script:AuthPath -eq 'A') { 'OAuth' } else { 'API key' }
+    Write-LogInfo "Authentication method: $label"
 
     # Sharing Tier
     $tierChoice = Read-Selection `

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -470,10 +470,10 @@ collect_configuration() {
     local auth_choice
     auth_choice=$(prompt_select \
         "Which authentication method will you use?" \
-        "Path A: Subscription (Pro/Max/Team) — OAuth browser login" \
-        "Path B: Console API key — paste key directly")
-    [[ "$auth_choice" == *"Path A"* ]] && AUTH_PATH="A" || AUTH_PATH="B"
-    log_info "Authentication: Path $AUTH_PATH"
+        "OAuth — Claude.ai Pro/Max/Team subscription (browser login inside container)" \
+        "API key — Anthropic Console account (paste key)")
+    [[ "$auth_choice" == OAuth* ]] && AUTH_PATH="A" || AUTH_PATH="B"
+    log_info "Authentication method: $([[ "$AUTH_PATH" == "A" ]] && echo OAuth || echo 'API key')"
 
     # Sharing Tier
     local tier_choice


### PR DESCRIPTION
Closes #184
Part of #167

## Summary

Rename the user-facing authentication naming from jargon ("Path A/B") to descriptive ("OAuth / API key") and add a 4-row decision-tree table so a new user picks the right method in seconds.

## How

- `README.md` Quick Start section: new table keyed on subscription × host OS. Mixed-mode path documented.
- `README.md` Authentication callout: rename "Switching between Path A and Path B" to "Switching between OAuth and API key".
- `scripts/install.sh` and `scripts/install.ps1`: prompt_select options lead with the method name, log line renders "OAuth" or "API key". Internal `AUTH_PATH` keeps `A`/`B` for compatibility with existing conditional blocks elsewhere in the installer (deliberate — per issue spec).

## Acceptance

- [x] All user-facing Path A/B references renamed.
- [x] Decision-tree table present.
- [x] Internal AUTH_PATH left alone (keeps A/B values).
- [x] Both bash and pwsh installer prompts updated symmetrically.

## Test Plan

1. Fresh install: `bash scripts/install.sh` — the auth prompt shows the new labels; selecting either routes to the same code paths as before.
2. README Quick Start renders the table correctly on GitHub.