### PR TITLE
fix(cleanup): add --yes flag and stdin detection for non-interactive use

### DIFF
--- a/scripts/cleanup.ps1
+++ b/scripts/cleanup.ps1
@@ -8,11 +8,25 @@
     removes state directories.
 .PARAMETER RepoDir
     Git repository path for worktree cleanup (Tier B). Optional.
+.PARAMETER Force
+    Remove state directories without prompting. Without -Force, an
+    interactive console prompts y/N; a non-interactive host (CI, piped
+    stdin) aborts instead of hanging.
+.PARAMETER SkipState
+    Decline state-directory removal non-interactively. Useful in automation
+    that only wants container/volume/worktree cleanup.
 #>
 [CmdletBinding()]
 param(
-    [string]$RepoDir
+    [string]$RepoDir,
+    [Alias('Yes')][switch]$Force,
+    [Alias('No')][switch]$SkipState
 )
+
+if ($Force -and $SkipState) {
+    Write-Error '-Force and -SkipState are mutually exclusive.'
+    exit 2
+}
 
 $ErrorActionPreference = 'Stop'
 Import-Module "$PSScriptRoot\ClaudeDocker.psm1" -Force
@@ -50,7 +64,24 @@ try {
     }
 
     Write-Host '=== Removing state directories ===' -ForegroundColor Cyan
-    if (Read-Confirmation -Question 'Remove ~/.claude-state/*?') {
+    $shouldRemove = $false
+    if ($Force) {
+        $shouldRemove = $true
+    } elseif ($SkipState) {
+        $shouldRemove = $false
+    } else {
+        # Interactive-only path: detect a real host that can accept input.
+        # Read-Confirmation throws on non-interactive hosts (ServerRemoteHost,
+        # redirected stdin) which prevents CI hangs.
+        $interactive = ($Host.Name -ne 'ServerRemoteHost') -and (-not [Console]::IsInputRedirected)
+        if (-not $interactive) {
+            Write-Error '  stdin is not interactive. Pass -Force to remove state non-interactively, or -SkipState to skip.'
+            exit 1
+        }
+        $shouldRemove = Read-Confirmation -Question 'Remove ~/.claude-state/*?'
+    }
+
+    if ($shouldRemove) {
         $statePath = Join-Path $env:USERPROFILE '.claude-state'
         if (Test-Path $statePath) {
             Remove-Item $statePath -Recurse -Force

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,10 +1,39 @@
 #!/usr/bin/env bash
-# Cleanup containers, worktrees, and state
+# Cleanup containers, worktrees, and state.
+#
+# Usage:
+#   scripts/cleanup.sh [REPO_DIR] [--yes|-y | --no|-n]
+#
+# Without --yes or --no, state-directory removal is prompted interactively
+# when stdin is a TTY and aborted (non-zero exit) otherwise, so CI or piped
+# invocations never hang waiting for an answer.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
+
+REPO_DIR=""
+CONFIRM="ask"
+for arg in "$@"; do
+    case "$arg" in
+        --yes|-y) CONFIRM="yes" ;;
+        --no|-n)  CONFIRM="no"  ;;
+        -*)
+            echo "Unknown option: $arg" >&2
+            echo "Usage: scripts/cleanup.sh [REPO_DIR] [--yes|-y | --no|-n]" >&2
+            exit 2
+            ;;
+        *)
+            if [ -z "$REPO_DIR" ]; then
+                REPO_DIR="$arg"
+            else
+                echo "Unexpected extra argument: $arg" >&2
+                exit 2
+            fi
+            ;;
+    esac
+done
 
 echo "=== Stopping containers ==="
 docker compose down --remove-orphans 2>/dev/null || true
@@ -13,7 +42,6 @@ echo "=== Removing named volumes ==="
 docker compose down -v 2>/dev/null || true
 
 echo "=== Removing worktrees (if Tier B) ==="
-REPO_DIR="${1:-}"
 if [ -n "$REPO_DIR" ] && [ -d "$REPO_DIR/.git" ]; then
     cd "$REPO_DIR"
     for wt in $(git worktree list --porcelain | grep "^worktree " | awk '{print $2}'); do
@@ -25,8 +53,21 @@ if [ -n "$REPO_DIR" ] && [ -d "$REPO_DIR/.git" ]; then
 fi
 
 echo "=== Removing state directories ==="
-read -p "Remove ~/.claude-state/*? (y/N) " confirm
-if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then
+if [ "$CONFIRM" = "ask" ]; then
+    if [ -t 0 ]; then
+        read -p "Remove ~/.claude-state/*? (y/N) " confirm
+        case "$confirm" in
+            y|Y|yes|YES) CONFIRM="yes" ;;
+            *)           CONFIRM="no"  ;;
+        esac
+    else
+        echo "  Error: stdin is not a TTY. Pass --yes to remove state non-interactively," >&2
+        echo "         or --no to skip state removal in automation." >&2
+        exit 1
+    fi
+fi
+
+if [ "$CONFIRM" = "yes" ]; then
     rm -rf "${HOME}/.claude-state"
     echo "  State directories removed."
 else


### PR DESCRIPTION
Closes #183
Part of #167

## Summary

`scripts/cleanup.sh` called `read -p` unconditionally, hanging forever in CI or piped invocations. Add `--yes`/`-y` and `--no`/`-n` flags; fall back to the interactive prompt only when stdin is a TTY. Non-TTY invocation without either flag exits with a clear error.

## How

- `scripts/cleanup.sh`: positional argument parser (keeps `REPO_DIR` behavior), interactive branch gated on `[ -t 0 ]`.
- `scripts/cleanup.ps1`: `-Force` / `-SkipState` switches, non-interactive host detection via `[Console]::IsInputRedirected` and `$Host.Name`.
- Usage documented in each script's header comment.

## Verified

| Invocation | Result |
|------------|--------|
| `bash cleanup.sh --yes` | removes state, exits 0 |
| `bash cleanup.sh --no` | skips state, exits 0 |
| `echo '' \| bash cleanup.sh` (no flag) | prints error with flag hints, exits 1 |
| Interactive TTY, no flag | unchanged y/N prompt |

## Test Plan

1. Run `scripts/cleanup.sh` in a terminal → interactive prompt as before.
2. Run `scripts/cleanup.sh --yes` in CI or `echo '' \|` → removes state without hanging.
3. Run `scripts/cleanup.sh` with redirected stdin → hard error naming the flags.