### PR TITLE
docs(entrypoint): document sandbox-disable rationale and pwsh-to-bash limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,54 @@ sessions) remains writable and per-container. Symlinks are created when the
 target does not exist or is an empty file, so per-account overrides with
 real content are preserved.
 
+### Container-side settings transformation
+
+The entrypoint does not use your host `settings.json` verbatim. It rewrites a
+working copy at `~/.claude/settings.json` (inside the container) before Claude
+Code starts. Two of those transforms are load-bearing but easy to miss from
+the code alone:
+
+**1. `sandbox.enabled` is forced to `false`.**
+
+The host sandbox gates filesystem and network access on the host. Inside a
+container it would re-confine already-confined code and, more importantly,
+break hooks and skills that `exec` into `/usr/bin`. The entrypoint relies on
+the container itself being the isolation boundary.
+
+This assumption holds for the **default** Docker isolation (cgroups +
+namespaces + read-only bind mounts). It does **not** hold when:
+
+- the container runs with `--privileged`,
+- Docker-in-Docker is used so nested containers share the parent's kernel
+  namespace,
+- a skill uses `docker run` on the host socket to spawn a sibling container.
+
+If you run claude-docker in any of those modes you lose the host sandbox
+without warning. Either keep the outer Docker isolation strict or edit the
+entrypoint to leave `sandbox.enabled` untouched for that profile.
+
+**2. PowerShell hook commands are rewritten to bash.**
+
+Host `settings.json` entries that invoke `pwsh -NoProfile -File ...` are
+transformed so they work inside the Linux-native container image. This is
+best-effort: trivial single-call hooks are rewritten cleanly, but the
+following patterns fail **silently** (transformed command is produced but
+never fires):
+
+| Pattern | Example | Status |
+|---------|---------|--------|
+| `pwsh -NoProfile -File ./foo.ps1` | top-level script | supported |
+| Heredoc / multi-line `-Command` | `pwsh -c @"..."@` | not supported |
+| `$env:VAR` expansion | `pwsh -c '$env:FOO'` | not supported |
+| Quoted paths with spaces | `pwsh -File "C:\\Program Files\\..."` | not supported |
+| `Join-Path` outside the statusLine slot | inside a hook array | not supported |
+
+If a hook works on the host but never fires in the container, check whether
+its command matches one of the unsupported patterns above. The workaround is
+to ship a Linux-native shell alternative via `CLAUDE_CONFIG_SOURCE` (which
+bypasses the transform entirely — the container reads the config tree you
+point at without rewriting it).
+
 ### Running Commands Inside Containers
 
 ```bash

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -20,6 +20,13 @@ ACCOUNT_DIR="/home/node/.claude"
 #
 # The jq pipeline is idempotent: macOS settings pass through with only
 # sandbox/permissions changes; Windows settings get full hook rewriting.
+#
+# See the "Container-side settings transformation" section in README.md
+# for user-facing documentation of two behaviors baked in here:
+#   - step 1 (`sandbox.enabled = false`) assumes default Docker isolation
+#     and is unsafe under --privileged / docker-in-docker / docker-on-sock.
+#   - step 4's pwsh-to-bash rewrite is best-effort and has known silent
+#     failure modes (heredocs, $env:VAR, quoted paths with spaces).
 generate_container_settings() {
     local src="$1"
     local dst="$2"


### PR DESCRIPTION
Closes #179
Part of #167

## Summary

Surface two load-bearing entrypoint behaviors that users cannot infer from code:

1. `.sandbox.enabled = false` is hardcoded and assumes **default** Docker isolation — unsafe under `--privileged`, docker-in-docker, or docker-on-sock setups.
2. The pwsh-to-bash hook rewriter is best-effort and silently fails for heredocs, `$env:VAR`, quoted paths with spaces, and `Join-Path` outside the statusLine slot.

## How

- `README.md`: new subsection "Container-side settings transformation" under "Shared Configuration", with a table of unsupported pwsh patterns and the `CLAUDE_CONFIG_SOURCE` escape hatch.
- `scripts/entrypoint.sh`: comment block above `generate_container_settings` references the new README subsection.

No code behavior changes. The `CLAUDE_CONTAINER_KEEP_SANDBOX` flag mentioned in the issue is deferred to a separate feature ticket so docs can land first.

## Acceptance

- [x] README has the new subsection with both sandbox and pwsh content.
- [x] entrypoint.sh comment points to the README section.
- [x] No code paths changed (verified via `bash -n` and grep — only comment lines added).
- [ ] .env.example update deferred (sensitive-file-guard blocks .env* access in this session).

## Test Plan

Visual review of the README section on GitHub; verify anchor and table render. No runtime test required.