### PR TITLE
fix(entrypoint): syntax-check pwsh-to-bash hook transform output

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -150,6 +150,24 @@ if [ -d "$CONFIG_SOURCE" ]; then
                         echo "[entrypoint] settings.json: rewrote $pwsh_count PowerShell hook(s) to bash"
                     fi
                     echo "[entrypoint] settings.json: container-optimized (sandbox=off, glob deny rules stripped)"
+
+                    # Post-transform syntax check: `bash -n -c` every .command
+                    # string in the generated file. The rewriter in
+                    # generate_container_settings() is best-effort (see
+                    # README "Container-side settings transformation"); the
+                    # check catches silent failures so the user learns about
+                    # them at container start rather than when a hook misfires.
+                    syntax_failures=0
+                    while IFS= read -r _cmd; do
+                        [ -z "$_cmd" ] && continue
+                        if ! bash -n -c "$_cmd" 2>/dev/null; then
+                            echo "[entrypoint] WARNING: transformed hook command failed bash syntax check: $_cmd" >&2
+                            syntax_failures=$((syntax_failures + 1))
+                        fi
+                    done < <(jq -r '.. | objects | .command? // empty | select(type == "string")' "$CONTAINER_SETTINGS" 2>/dev/null)
+                    if [ "$syntax_failures" -gt 0 ]; then
+                        echo "[entrypoint] WARNING: $syntax_failures hook command(s) failed syntax check — those hooks will not fire. Set CLAUDE_CONFIG_SOURCE to a Linux-native config tree to bypass the pwsh rewriter." >&2
+                    fi
                 else
                     echo "[entrypoint] ERROR: generated settings.container.json is invalid JSON, using raw host settings"
                     ln -sf "$CONFIG_SOURCE/settings.json" "$ACCOUNT_DIR/settings.json"

--- a/tests/test_transform_syntax_check.sh
+++ b/tests/test_transform_syntax_check.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# test_transform_syntax_check.sh — Validate the post-transform bash -n -c
+# gate added to scripts/entrypoint.sh by issue #180.
+#
+# The test fabricates a mock container settings file containing a mix of
+# runnable and deliberately broken .command entries, then runs the same
+# `jq ... | bash -n -c` loop the entrypoint uses. Passes when every
+# broken entry is detected and every runnable entry is accepted.
+#
+# Run: bash tests/test_transform_syntax_check.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PASS=0
+FAIL=0
+
+check_case() {
+    local label="$1" expect="$2" cmd="$3"  # expect: ok | bad
+    local actual="ok"
+    if ! bash -n -c "$cmd" 2>/dev/null; then
+        actual="bad"
+    fi
+    if [[ "$actual" == "$expect" ]]; then
+        printf '  PASS  %s\n' "$label"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL  %s (expected=%s actual=%s)\n        cmd: %q\n' \
+            "$label" "$expect" "$actual" "$cmd"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "== Runnable commands (the syntax check must accept) =="
+check_case "trivial shell call"        ok  'echo hello'
+check_case "pipe + redirect"           ok  'cat README.md | head -5 > /tmp/out'
+check_case "transformed pwsh -File"    ok  '/home/node/.claude/hooks/foo.sh arg1'
+check_case "transformed pwsh -Command" ok  '/usr/local/bin/git status && echo ok'
+
+echo "== Broken commands (the syntax check must reject) =="
+# Unbalanced quote: classic pwsh -Command "...; " rewrite gone wrong.
+check_case "unbalanced double quote"   bad 'echo "no closing quote'
+# Dangling && left by gsub("; "; " && ") when the trailing segment is empty.
+check_case "dangling &&"               bad 'echo one && '
+# Broken if/fi from a multi-line pwsh script fragment.
+check_case "unterminated if block"     bad 'if [ -z "$x" ]; then echo empty'
+
+echo
+echo "== Summary: PASS=$PASS FAIL=$FAIL =="
+if (( FAIL > 0 )); then
+    exit 1
+fi
+
+# Integration sanity: build a fake container settings.json and ensure the
+# extractor yields the three broken commands plus no spurious entries.
+# Skipped when jq is unavailable locally — the entrypoint always has jq in
+# the container image, and the loop logic itself is already covered above.
+if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP  extractor integration (jq not installed locally)"
+    exit 0
+fi
+
+TMP=$(mktemp)
+cat >"$TMP" <<'JSON'
+{
+  "hooks": {
+    "PreToolUse": [
+      {"command": "echo good"},
+      {"command": "echo \"bad"},
+      {"nested": {"command": "if [ -z $x ]; then"}}
+    ]
+  },
+  "statusLine": {
+    "command": "echo line && "
+  }
+}
+JSON
+
+broken_count=0
+while IFS= read -r cmd; do
+    [[ -z "$cmd" ]] && continue
+    if ! bash -n -c "$cmd" 2>/dev/null; then
+        broken_count=$((broken_count + 1))
+    fi
+done < <(jq -r '.. | objects | .command? // empty | select(type == "string")' "$TMP")
+rm -f "$TMP"
+
+if [[ "$broken_count" -eq 3 ]]; then
+    echo "  PASS  extractor + syntax check detects 3 broken commands in fixture"
+    exit 0
+else
+    echo "  FAIL  extractor reported $broken_count broken commands (expected 3)"
+    exit 1
+fi


### PR DESCRIPTION
Closes #180
Part of #167

## Summary

Gate the generated container `settings.json` on `bash -n -c` for every `.command` the transformer produces. The gsub pipeline in `entrypoint.sh:44-52` silently yields malformed bash when the input uses nested quotes, heredocs, or `$env:VAR` expansion — without this gate, the broken command just "doesn't fire" at runtime with no error surfaced to the user.

## How

- `scripts/entrypoint.sh`: after `jq empty` validates the generated file, walk `.command` fields and `bash -n -c` each one. Per-failure WARNING line + an aggregated summary naming `CLAUDE_CONFIG_SOURCE` as the escape hatch. Does **not** abort startup (the user's session survives; only the broken hook is reported).
- `tests/test_transform_syntax_check.sh` (new): 7 assertions covering good commands and three failure modes (unbalanced quote, dangling `&&`, unterminated `if`). Integration sanity replays the entrypoint's jq-extract + `bash -n` pipeline against a 3-broken, 1-good fixture. Integration half is skipped when jq is absent locally; the container image always has jq.

## Acceptance

- [x] Injecting a broken pwsh hook into a test fixture produces a WARNING at start.
- [x] Clean macOS-native settings.json produces zero warnings.
- [x] Entrypoint still exits 0 on transform failures.
- [x] 3+ failing-input cases covered (unbalanced quote, dangling &&, unterminated if).

## Test Plan

```bash
bash tests/test_transform_syntax_check.sh   # 7/7 pass + integration sanity
```

Manual: inject a bad pwsh command into a local host settings.json, start the container, grep entrypoint logs for "failed bash syntax check".