### PR TITLE
feat(scale): support NUM_ACCOUNTS > 26 with double-letter indexing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fixture: [minimal, tier-b, n5, with-special-chars]
+        fixture: [minimal, tier-b, n5, n30, with-special-chars]
     steps:
       - uses: actions/checkout@v4
       - name: Stage fixture

--- a/README.md
+++ b/README.md
@@ -403,6 +403,10 @@ The `scale` command automatically:
 
 Each additional container needs ~4 GB RAM (2 GB reserved, 4 GB limit).
 
+Account names follow Excel-style letters: 1→`a`, 26→`z`, 27→`aa`, 52→`az`,
+53→`ba`, ..., 702→`zz`. You can set `NUM_ACCOUNTS` up to 702, though host
+memory is usually the binding constraint well before then.
+
 On Windows (PowerShell):
 ```powershell
 .\scripts\claude-docker.ps1 scale 4

--- a/scripts/ClaudeDocker.psm1
+++ b/scripts/ClaudeDocker.psm1
@@ -313,10 +313,33 @@ function Get-NumAccounts {
     return 2
 }
 
+function ConvertTo-AccountLetter {
+    <#
+    .SYNOPSIS
+    Convert a 1-based index to Excel-style lowercase letters (a, z, aa, az,
+    ba, zz). Values 1-26 are bit-identical to the previous single-letter
+    scheme.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][int]$Index)
+
+    if ($Index -lt 1) { throw "Index must be 1 or greater (got: $Index)" }
+    [int]$n = $Index
+    $builder = ''
+    while ($n -gt 0) {
+        [int]$rem = ($n - 1) % 26
+        $builder = [char]([int](97 + $rem)) + $builder
+        [int]$n = [math]::Floor(($n - 1) / 26)
+    }
+    return $builder
+}
+
 function Get-ServiceNames {
     <#
     .SYNOPSIS
-    Return an array of service names (claude-a, claude-b, ...) based on NUM_ACCOUNTS.
+    Return an array of service names (claude-a, claude-b, ...) based on
+    NUM_ACCOUNTS. Supports more than 26 via Excel-style double-letter
+    indexing (claude-aa, claude-zz, ...).
     #>
     [CmdletBinding()]
     param([Parameter(Mandatory)][string]$ProjectRoot)
@@ -324,8 +347,7 @@ function Get-ServiceNames {
     $n = Get-NumAccounts -ProjectRoot $ProjectRoot
     $names = @()
     for ($i = 1; $i -le $n; $i++) {
-        $letter = [char](96 + $i)
-        $names += "claude-$letter"
+        $names += "claude-$(ConvertTo-AccountLetter -Index $i)"
     }
     return $names
 }
@@ -431,7 +453,7 @@ Export-ModuleMember -Function @(
     # Utilities
     'Test-Command', 'ConvertTo-ForwardSlash',
     # Accounts
-    'Get-NumAccounts', 'Get-ServiceNames',
+    'Get-NumAccounts', 'Get-ServiceNames', 'ConvertTo-AccountLetter',
     # .env
     'Read-EnvFile', 'Get-EnvValue', 'Write-EnvContent', 'Set-EnvValue',
     # Docker Compose

--- a/scripts/claude-docker
+++ b/scripts/claude-docker
@@ -111,9 +111,19 @@ get_num_accounts() {
     echo "${n:-2}"
 }
 
-# Convert 1-based index to lowercase letter: 1→a, 2→b, ..., 26→z
+# Convert 1-based index to Excel-style lowercase letters:
+#   1→a, 26→z, 27→aa, 52→az, 53→ba, 702→zz.
+# Values 1-26 are bit-for-bit identical to the former single-letter impl.
 _index_to_letter() {
-    printf "\\$(printf '%03o' $((96 + $1)))"
+    local n="$1"
+    local out=""
+    local rem
+    while (( n > 0 )); do
+        rem=$(( (n - 1) % 26 ))
+        out=$(printf "\\$(printf '%03o' $((97 + rem)))")$out
+        n=$(( (n - 1) / 26 ))
+    done
+    printf '%s' "$out"
 }
 
 # Return space-separated list of service names based on NUM_ACCOUNTS

--- a/scripts/generate-compose.ps1
+++ b/scripts/generate-compose.ps1
@@ -59,8 +59,8 @@ if ([string]::IsNullOrEmpty($ImageTag)) {
     }
 }
 
-if ($NumAccounts -lt 1 -or $NumAccounts -gt 26) {
-    Write-Error "NUM_ACCOUNTS must be between 1 and 26 (got: $NumAccounts)"
+if ($NumAccounts -lt 1 -or $NumAccounts -gt 702) {
+    Write-Error "NUM_ACCOUNTS must be between 1 and 702 (got: $NumAccounts)"
     exit 1
 }
 
@@ -81,13 +81,30 @@ $MemLimit       = Resolve-EnvOrDefault 'CONTAINER_MEM_LIMIT' '4G'
 $MemReservation = Resolve-EnvOrDefault 'CONTAINER_MEM_RESERVATION' '2G'
 
 function ConvertTo-Letter([int]$Index) {
-    # 1 -> a, 2 -> b, ..., 26 -> z
-    [char](96 + $Index)
+    # Excel-style: 1 -> a, 26 -> z, 27 -> aa, 52 -> az, 702 -> zz.
+    # 1-26 identical to the former single-letter mapping.
+    # Casts to [int] are required because [math]::Floor and `%` can
+    # return Double/Decimal, which will not implicit-cast to [char].
+    [int]$n = $Index
+    $builder = ''
+    while ($n -gt 0) {
+        [int]$rem = ($n - 1) % 26
+        $builder = [char]([int](97 + $rem)) + $builder
+        [int]$n = [math]::Floor(($n - 1) / 26)
+    }
+    return $builder
 }
 
 function ConvertTo-UpperLetter([int]$Index) {
-    # 1 -> A, 2 -> B, ..., 26 -> Z
-    [char](64 + $Index)
+    # Same scheme, uppercase.
+    [int]$n = $Index
+    $builder = ''
+    while ($n -gt 0) {
+        [int]$rem = ($n - 1) % 26
+        $builder = [char]([int](65 + $rem)) + $builder
+        [int]$n = [math]::Floor(($n - 1) / 26)
+    }
+    return $builder
 }
 
 # --- Generate docker-compose.yml ---------------------------------------------

--- a/scripts/generate-compose.sh
+++ b/scripts/generate-compose.sh
@@ -35,9 +35,10 @@ if [[ -z "${IMAGE_TAG:-}" ]]; then
     IMAGE_TAG="${IMAGE_TAG:-latest}"
 fi
 
-# Validate
-if [[ "$NUM_ACCOUNTS" -lt 1 || "$NUM_ACCOUNTS" -gt 26 ]]; then
-    echo "Error: NUM_ACCOUNTS must be between 1 and 26 (got: $NUM_ACCOUNTS)" >&2
+# Validate. Practical upper bound is "zz" (702) from Excel-style letter
+# enumeration; keep the cap well below that to catch typos like 2600.
+if [[ "$NUM_ACCOUNTS" -lt 1 || "$NUM_ACCOUNTS" -gt 702 ]]; then
+    echo "Error: NUM_ACCOUNTS must be between 1 and 702 (got: $NUM_ACCOUNTS)" >&2
     exit 1
 fi
 
@@ -49,14 +50,32 @@ CPU_RESERVATION="${CONTAINER_CPU_RESERVATION:-1}"
 MEM_LIMIT="${CONTAINER_MEM_LIMIT:-4G}"
 MEM_RESERVATION="${CONTAINER_MEM_RESERVATION:-2G}"
 
-# Convert 1-based index to lowercase letter: 1→a, 2→b, ..., 26→z
+# Convert 1-based index to Excel-style lowercase letters:
+#   1→a, 26→z, 27→aa, 52→az, 53→ba, 702→zz.
+# Existing single-letter (1-26) callers are bit-for-bit unchanged.
 index_to_letter() {
-    printf "\\$(printf '%03o' $((96 + $1)))"
+    local n="$1"
+    local out=""
+    local rem
+    while (( n > 0 )); do
+        rem=$(( (n - 1) % 26 ))
+        out=$(printf "\\$(printf '%03o' $((97 + rem)))")$out
+        n=$(( (n - 1) / 26 ))
+    done
+    printf '%s' "$out"
 }
 
-# Convert 1-based index to uppercase letter: 1→A, 2→B, ..., 26→Z
+# Convert 1-based index to Excel-style uppercase letters: A-Z, AA-AZ, ...
 index_to_upper() {
-    printf "\\$(printf '%03o' $((64 + $1)))"
+    local n="$1"
+    local out=""
+    local rem
+    while (( n > 0 )); do
+        rem=$(( (n - 1) % 26 ))
+        out=$(printf "\\$(printf '%03o' $((65 + rem)))")$out
+        n=$(( (n - 1) / 26 ))
+    done
+    printf '%s' "$out"
 }
 
 # --- Generate docker-compose.yml ---------------------------------------------

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -521,10 +521,12 @@ collect_configuration() {
         log_info "Claude Code version: $CLAUDE_VERSION"
     fi
 
-    # Number of accounts
-    NUM_ACCOUNTS=$(prompt_input "Number of accounts to configure (1-26)" "2")
-    if ! [[ "$NUM_ACCOUNTS" =~ ^[0-9]+$ ]] || [[ "$NUM_ACCOUNTS" -lt 1 || "$NUM_ACCOUNTS" -gt 26 ]]; then
-        log_error "Number of accounts must be between 1 and 26."
+    # Number of accounts. Upper bound is "zz" (702) from Excel-style letter
+    # enumeration; the validator catches typos like 2600 without capping
+    # legitimate multi-tenant setups at the historic 26-account ceiling.
+    NUM_ACCOUNTS=$(prompt_input "Number of accounts to configure (1-702)" "2")
+    if ! [[ "$NUM_ACCOUNTS" =~ ^[0-9]+$ ]] || [[ "$NUM_ACCOUNTS" -lt 1 || "$NUM_ACCOUNTS" -gt 702 ]]; then
+        log_error "Number of accounts must be between 1 and 702."
         exit 1
     fi
     log_info "Accounts: $NUM_ACCOUNTS"

--- a/scripts/setup-worktrees.sh
+++ b/scripts/setup-worktrees.sh
@@ -22,9 +22,18 @@ if [ ! -d "$REPO_DIR/.git" ]; then
     exit 1
 fi
 
-# Convert 1-based index to lowercase letter: 1→a, 2→b, ..., 26→z
+# Convert 1-based index to Excel-style lowercase letters:
+#   1→a, 26→z, 27→aa, 52→az, 702→zz.
 index_to_letter() {
-    printf "\\$(printf '%03o' $((96 + $1)))"
+    local n="$1"
+    local out=""
+    local rem
+    while (( n > 0 )); do
+        rem=$(( (n - 1) % 26 ))
+        out=$(printf "\\$(printf '%03o' $((97 + rem)))")$out
+        n=$(( (n - 1) / 26 ))
+    done
+    printf '%s' "$out"
 }
 
 cd "$REPO_DIR"

--- a/scripts/test-concurrent-git.sh
+++ b/scripts/test-concurrent-git.sh
@@ -13,9 +13,17 @@ TEMP_DIR="$(mktemp -d)"
 REPO_DIR="$TEMP_DIR/test-repo"
 NUM_TEST_ACCOUNTS="${NUM_TEST_ACCOUNTS:-2}"
 
-# Convert 1-based index to lowercase letter
+# Convert 1-based index to Excel-style lowercase letters (a, z, aa, az, ba, zz).
 index_to_letter() {
-    printf "\\$(printf '%03o' $((96 + $1)))"
+    local n="$1"
+    local out=""
+    local rem
+    while (( n > 0 )); do
+        rem=$(( (n - 1) % 26 ))
+        out=$(printf "\\$(printf '%03o' $((97 + rem)))")$out
+        n=$(( (n - 1) / 26 ))
+    done
+    printf '%s' "$out"
 }
 
 # Uppercase a single-letter string. Portable replacement for bash 4+ ${var^^}

--- a/tests/env_fixtures/README.md
+++ b/tests/env_fixtures/README.md
@@ -9,9 +9,8 @@ is copied to the repo root as `.env`, then `scripts/generate-compose.sh` and
 | `minimal.env` | Default 2-account Tier A setup without API keys |
 | `tier-b.env` | Worktree paths (`PROJECT_DIR_A/B`, `CONTAINER_PROJECT_DIR_A/B`) |
 | `n5.env` | `NUM_ACCOUNTS=5` scaling path (claude-a..claude-e) |
-
-`with-special-chars.env` (values containing `#`, `=`, quotes, whitespace) is
-added by #170 alongside the unified `.env` parser.
+| `n30.env` | `NUM_ACCOUNTS=30` Excel-style letter enumeration (#178) |
+| `with-special-chars.env` | Values containing `#`, `=`, quotes, whitespace — exercises the #170 parser |
 
 ## Running locally
 

--- a/tests/env_fixtures/n30.env
+++ b/tests/env_fixtures/n30.env
@@ -1,0 +1,9 @@
+# Fixture: n30 — 30-account Excel-style letter enumeration (claude-a..z +
+# claude-aa..ad). Validates the #178 scaling path in CI's compose-validate
+# matrix: claude-aa / claude-ab must be generated and accepted by docker
+# compose config.
+NUM_ACCOUNTS=30
+HOME=/tmp/claude-test
+PROJECT_DIR=/tmp/claude-test/project
+CONTAINER_PROJECT_DIR=/project
+IMAGE_TAG=ci-test


### PR DESCRIPTION
Closes #178
Part of #167

## Summary

Extend the account-letter naming scheme from single-letter (26 max) to Excel-style (`a`, `z`, `aa`, `az`, `ba`, …, `zz`) so `NUM_ACCOUNTS` can go up to **702**. Values 1–26 are **bit-for-bit identical** to the current output, so existing installs see no behavior change.

## How

- `scripts/generate-compose.sh`: new `index_to_letter` / `index_to_upper` with Excel-style loop. Validator raised from 26 to 702.
- `scripts/generate-compose.ps1`: `ConvertTo-Letter` / `ConvertTo-UpperLetter` with explicit `[int]` casts (`[math]::Floor` / `%` return Double/Decimal, which will not cast to `[char]`).
- `scripts/claude-docker` and `scripts/ClaudeDocker.psm1`: same loop, new `ConvertTo-AccountLetter` exported helper.
- `scripts/install.sh`: prompt text and validator at 1–702.
- `scripts/setup-worktrees.sh` and `scripts/test-concurrent-git.sh`: matching update so auxiliary tools stay consistent.
- `tests/env_fixtures/n30.env` (new): NUM_ACCOUNTS=30 fixture exercising `claude-aa`/`claude-ab`. Added to the ci.yml `compose-validate` matrix.

## Verified locally

| Input | bash | pwsh |
|-------|------|------|
| 1 | a | a |
| 26 | z | z |
| 27 | aa | aa |
| 52 | az | az |
| 53 | ba | ba |
| 702 | zz | zz |

## Acceptance

- [x] index_to_letter 1/26/27/52/53/702 → a/z/aa/az/ba/zz on both runtimes.
- [x] `tests/env_fixtures/n30.env` added and wired into the CI matrix.
- [x] Existing NUM_ACCOUNTS=2 generator output unchanged.
- [ ] Fresh install with NUM_ACCOUNTS=27 creates a working `claude-aa` service — deferred to reviewer / next release smoke test (requires actual container start).