### PR TITLE
test(tui): add Go unit tests for config and account packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,19 @@ jobs:
             exit 1
           }
 
+  go-test:
+    name: Go tests (TUI)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          # Must match or exceed tui/go.mod's `go` directive (currently 1.23).
+          go-version: "1.23"
+      - name: Run Go unit tests
+        working-directory: ./tui
+        run: go test ./...
+
   compose-validate:
     name: Compose validate (${{ matrix.fixture }})
     runs-on: ubuntu-latest

--- a/tui/internal/account/manager_test.go
+++ b/tui/internal/account/manager_test.go
@@ -1,0 +1,157 @@
+package account
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kcenon/claude-docker/tui/internal/config"
+)
+
+// TestServiceNameGeneration_AllTiers verifies the 1-based index → service-name
+// mapping for every tier in NUM_ACCOUNTS' supported range. Values 1-26 stay
+// on single letters; 27+ transitions into Excel-style double letters so
+// service names remain unique.
+func TestServiceNameGeneration_AllTiers(t *testing.T) {
+	cases := []struct {
+		index   int
+		service string
+	}{
+		{1, "claude-a"},
+		{2, "claude-b"},
+		{5, "claude-e"},
+		{26, "claude-z"},
+		{27, "claude-aa"}, // exactly the transition boundary (per #178)
+		{30, "claude-ad"},
+		{52, "claude-az"},
+		{53, "claude-ba"},
+		{702, "claude-zz"},
+	}
+	for _, c := range cases {
+		letter := config.IndexToLetter(c.index)
+		if got := "claude-" + letter; got != c.service {
+			t.Errorf("index=%d: got %q, want %q", c.index, got, c.service)
+		}
+	}
+}
+
+// TestDiscoverStateDirs_EmptyDir confirms an absent base path is not an
+// error — first-run installs should see "no accounts yet".
+func TestDiscoverStateDirs_EmptyDir(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "missing")
+	dirs, err := config.DiscoverStateDirsAt(base)
+	if err != nil {
+		t.Fatalf("DiscoverStateDirsAt on missing path: %v", err)
+	}
+	if len(dirs) != 0 {
+		t.Errorf("expected 0 dirs, got %d", len(dirs))
+	}
+}
+
+// TestDiscoverStateDirs_SingleAndDoubleLetters exercises a state base that
+// contains a, b, aa, ab, zz and some noise (irrelevant directories, files).
+// The discovery must filter noise, accept Excel-style names, and sort by
+// 1-based index so the caller sees claude-a..z before claude-aa onward.
+func TestDiscoverStateDirs_SingleAndDoubleLetters(t *testing.T) {
+	base := t.TempDir()
+	mustMkdir := func(name string) {
+		t.Helper()
+		if err := os.Mkdir(filepath.Join(base, name), 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", name, err)
+		}
+	}
+	mustMkdir("account-a")
+	mustMkdir("account-b")
+	mustMkdir("account-aa") // Excel-style double letter
+	mustMkdir("account-ab")
+	mustMkdir("account-zz")
+	mustMkdir("account-INVALID") // uppercase: rejected
+	mustMkdir("account-1")       // digit: rejected
+	mustMkdir("account-")        // empty suffix: rejected
+	mustMkdir("unrelated")       // no "account-" prefix: rejected
+
+	// A regular file (not a directory) with a valid-looking name must also
+	// be ignored; DiscoverStateDirsAt iterates DirEntry.IsDir only.
+	if err := os.WriteFile(filepath.Join(base, "account-c"), []byte("x"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	dirs, err := config.DiscoverStateDirsAt(base)
+	if err != nil {
+		t.Fatalf("DiscoverStateDirsAt: %v", err)
+	}
+
+	want := []string{"a", "b", "aa", "ab", "zz"}
+	if len(dirs) != len(want) {
+		t.Fatalf("got %d dirs (%v), want %d (%v)", len(dirs), letters(dirs), len(want), want)
+	}
+	for i, w := range want {
+		if dirs[i].Letter != w {
+			t.Errorf("dirs[%d].Letter = %q, want %q (full list: %v)", i, dirs[i].Letter, w, letters(dirs))
+		}
+		wantPath := filepath.Join(base, "account-"+w)
+		if dirs[i].Path != wantPath {
+			t.Errorf("dirs[%d].Path = %q, want %q", i, dirs[i].Path, wantPath)
+		}
+	}
+}
+
+// TestDiscoverStateDirs_SortOrder_IndexNotLexical guards against a
+// regression where Sort by lexical Letter would place "aa" between "a"
+// and "b" — confusing for end users whose accounts run in index order.
+func TestDiscoverStateDirs_SortOrder_IndexNotLexical(t *testing.T) {
+	base := t.TempDir()
+	for _, n := range []string{"account-aa", "account-a", "account-b"} {
+		if err := os.Mkdir(filepath.Join(base, n), 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+	dirs, err := config.DiscoverStateDirsAt(base)
+	if err != nil {
+		t.Fatalf("DiscoverStateDirsAt: %v", err)
+	}
+	got := letters(dirs)
+	want := []string{"a", "b", "aa"} // a=1, b=2, aa=27
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order wrong: got %v, want %v", got, want)
+		}
+	}
+}
+
+// TestStateDir_PathHelpers pins the helper method outputs. Intentionally
+// light — the actual filesystem operations are tested in integration tests.
+// filepath.Join is used for expected values so the assertions are OS-agnostic
+// (Windows uses "\", POSIX uses "/").
+func TestStateDir_PathHelpers(t *testing.T) {
+	base := filepath.Join(string(filepath.Separator)+"tmp", "state", "account-a")
+	sd := config.StateDir{Letter: "a", Path: base}
+	if got, want := sd.CredentialsPath(), filepath.Join(base, ".credentials.json"); got != want {
+		t.Errorf("CredentialsPath = %q, want %q", got, want)
+	}
+	if got, want := sd.LimitlineCachePath(), filepath.Join(base, "limitline-usage-cache.json"); got != want {
+		t.Errorf("LimitlineCachePath = %q, want %q", got, want)
+	}
+	if got, want := sd.ProjectsDir(), filepath.Join(base, "projects"); got != want {
+		t.Errorf("ProjectsDir = %q, want %q", got, want)
+	}
+	if sd.HasCredentials() {
+		t.Error("HasCredentials should be false for non-existent path")
+	}
+	if sd.HasLimitlineCache() {
+		t.Error("HasLimitlineCache should be false for non-existent path")
+	}
+}
+
+// letters extracts the Letter field from a slice of StateDirs — test-only
+// helper used by multiple assertions above.
+func letters(dirs []config.StateDir) []string {
+	out := make([]string, len(dirs))
+	for i, d := range dirs {
+		out[i] = d.Letter
+	}
+	return out
+}

--- a/tui/internal/config/env.go
+++ b/tui/internal/config/env.go
@@ -152,22 +152,38 @@ func (e *Env) HasWorktrees() bool {
 	return e.Get("PROJECT_DIR_A") != ""
 }
 
-// IndexToLetter converts 1 -> "a", 2 -> "b", etc.
+// IndexToLetter converts a 1-based account index to its Excel-style
+// letter name: 1 -> "a", 26 -> "z", 27 -> "aa", 52 -> "az", 702 -> "zz".
+// Values 1-26 are bit-for-bit identical to the previous single-letter impl.
+// Returns "" for non-positive input. Upper bound is 702 (zz) to match the
+// bash/PowerShell generators; larger values also return "".
 func IndexToLetter(i int) string {
-	if i < 1 || i > 26 {
+	if i < 1 || i > 702 {
 		return ""
 	}
-	return string(rune('a' + i - 1))
+	var buf []byte
+	for i > 0 {
+		rem := (i - 1) % 26
+		buf = append([]byte{byte('a' + rem)}, buf...)
+		i = (i - 1) / 26
+	}
+	return string(buf)
 }
 
-// LetterToIndex converts "a" -> 1, "b" -> 2.
+// LetterToIndex converts an Excel-style letter name back to its 1-based
+// account index: "a" -> 1, "z" -> 26, "aa" -> 27, "zz" -> 702. Returns 0
+// for empty input or any non-lowercase-letter character.
 func LetterToIndex(s string) int {
-	if len(s) != 1 {
+	if len(s) == 0 {
 		return 0
 	}
-	c := s[0]
-	if c < 'a' || c > 'z' {
-		return 0
+	n := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < 'a' || c > 'z' {
+			return 0
+		}
+		n = n*26 + int(c-'a') + 1
 	}
-	return int(c-'a') + 1
+	return n
 }

--- a/tui/internal/config/env_test.go
+++ b/tui/internal/config/env_test.go
@@ -1,0 +1,227 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIndexToLetter(t *testing.T) {
+	cases := []struct {
+		in   int
+		want string
+	}{
+		{1, "a"},
+		{2, "b"},
+		{26, "z"},
+		{27, "aa"},
+		{28, "ab"},
+		{52, "az"},
+		{53, "ba"},
+		{702, "zz"},
+		{0, ""},
+		{-1, ""},
+		{703, ""},
+	}
+	for _, c := range cases {
+		if got := IndexToLetter(c.in); got != c.want {
+			t.Errorf("IndexToLetter(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestLetterToIndex(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"a", 1},
+		{"b", 2},
+		{"z", 26},
+		{"aa", 27},
+		{"ab", 28},
+		{"az", 52},
+		{"ba", 53},
+		{"zz", 702},
+		{"", 0},
+		{"A", 0},
+		{"a1", 0},
+		{"_", 0},
+	}
+	for _, c := range cases {
+		if got := LetterToIndex(c.in); got != c.want {
+			t.Errorf("LetterToIndex(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestIndexLetterRoundTrip(t *testing.T) {
+	// Verify IndexToLetter and LetterToIndex are mutual inverses across
+	// the full supported range. Prevents drift if either is changed.
+	for i := 1; i <= 702; i++ {
+		letter := IndexToLetter(i)
+		back := LetterToIndex(letter)
+		if back != i {
+			t.Fatalf("round-trip failed at %d: letter=%q back=%d", i, letter, back)
+		}
+	}
+}
+
+// writeTempEnv creates a temp file with the given content and returns its
+// absolute path. Files are removed by t.TempDir at the end of the test.
+func writeTempEnv(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write temp env: %v", err)
+	}
+	return path
+}
+
+func TestLoadEnv_Basic(t *testing.T) {
+	path := writeTempEnv(t, "NUM_ACCOUNTS=2\nIMAGE_TAG=latest\n")
+	e, err := LoadEnv(path)
+	if err != nil {
+		t.Fatalf("LoadEnv: %v", err)
+	}
+	if v := e.Get("NUM_ACCOUNTS"); v != "2" {
+		t.Errorf("NUM_ACCOUNTS = %q, want %q", v, "2")
+	}
+	if v := e.Get("IMAGE_TAG"); v != "latest" {
+		t.Errorf("IMAGE_TAG = %q, want %q", v, "latest")
+	}
+	if n := e.NumAccounts(); n != 2 {
+		t.Errorf("NumAccounts() = %d, want 2", n)
+	}
+}
+
+func TestLoadEnv_CommentsAndBlanks(t *testing.T) {
+	path := writeTempEnv(t,
+		"# comment\n"+
+			"\n"+
+			"NUM_ACCOUNTS=5\n"+
+			"# another\n"+
+			"GH_TOKEN=abc\n")
+	e, err := LoadEnv(path)
+	if err != nil {
+		t.Fatalf("LoadEnv: %v", err)
+	}
+	if v := e.Get("NUM_ACCOUNTS"); v != "5" {
+		t.Errorf("NUM_ACCOUNTS = %q", v)
+	}
+	if v := e.Get("GH_TOKEN"); v != "abc" {
+		t.Errorf("GH_TOKEN = %q", v)
+	}
+}
+
+func TestLoadEnv_QuotedValues(t *testing.T) {
+	path := writeTempEnv(t,
+		"DOUBLE=\"hello world\"\n"+
+			"SINGLE='single quoted'\n"+
+			"PLAIN=no-quotes\n")
+	e, err := LoadEnv(path)
+	if err != nil {
+		t.Fatalf("LoadEnv: %v", err)
+	}
+	if v := e.Get("DOUBLE"); v != "hello world" {
+		t.Errorf("DOUBLE = %q", v)
+	}
+	if v := e.Get("SINGLE"); v != "single quoted" {
+		t.Errorf("SINGLE = %q", v)
+	}
+	if v := e.Get("PLAIN"); v != "no-quotes" {
+		t.Errorf("PLAIN = %q", v)
+	}
+}
+
+func TestLoadEnv_MissingFile(t *testing.T) {
+	_, err := LoadEnv(filepath.Join(t.TempDir(), "does-not-exist.env"))
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestLoadEnv_ValuesWithEquals(t *testing.T) {
+	// strings.Index on the first "=" is what LoadEnv uses; values containing
+	// additional "=" characters must survive.
+	path := writeTempEnv(t, "TOKEN=foo=bar=baz\n")
+	e, err := LoadEnv(path)
+	if err != nil {
+		t.Fatalf("LoadEnv: %v", err)
+	}
+	if v := e.Get("TOKEN"); v != "foo=bar=baz" {
+		t.Errorf("TOKEN = %q, want %q", v, "foo=bar=baz")
+	}
+}
+
+func TestNewEmptyEnv_SetGetSave(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	e := NewEmptyEnv(path)
+
+	e.Set("NUM_ACCOUNTS", "4")
+	e.Set("IMAGE_TAG", "test")
+	e.Set("NUM_ACCOUNTS", "7") // update existing
+
+	if v := e.Get("NUM_ACCOUNTS"); v != "7" {
+		t.Errorf("after update, NUM_ACCOUNTS = %q, want %q", v, "7")
+	}
+
+	if err := e.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Re-load and verify persistence.
+	loaded, err := LoadEnv(path)
+	if err != nil {
+		t.Fatalf("LoadEnv after Save: %v", err)
+	}
+	if v := loaded.Get("NUM_ACCOUNTS"); v != "7" {
+		t.Errorf("persisted NUM_ACCOUNTS = %q, want 7", v)
+	}
+	if v := loaded.Get("IMAGE_TAG"); v != "test" {
+		t.Errorf("persisted IMAGE_TAG = %q, want test", v)
+	}
+}
+
+func TestNumAccounts_Fallback(t *testing.T) {
+	// Missing key, non-numeric, and negative all fall back to the
+	// documented default (1).
+	cases := []struct {
+		content string
+		want    int
+	}{
+		{"", 1},
+		{"NUM_ACCOUNTS=abc\n", 1},
+		{"NUM_ACCOUNTS=-3\n", 1},
+		{"NUM_ACCOUNTS=4\n", 4},
+	}
+	for _, c := range cases {
+		path := writeTempEnv(t, c.content)
+		e, err := LoadEnv(path)
+		if err != nil {
+			t.Fatalf("LoadEnv(%q): %v", c.content, err)
+		}
+		if got := e.NumAccounts(); got != c.want {
+			t.Errorf("content=%q: NumAccounts() = %d, want %d", c.content, got, c.want)
+		}
+	}
+}
+
+func TestAPIKey_CaseInsensitiveLetter(t *testing.T) {
+	path := writeTempEnv(t, "CLAUDE_API_KEY_A=sk-a\nCLAUDE_API_KEY_AA=sk-aa\n")
+	e, err := LoadEnv(path)
+	if err != nil {
+		t.Fatalf("LoadEnv: %v", err)
+	}
+	if v := e.APIKey("a"); v != "sk-a" {
+		t.Errorf("APIKey(a) = %q", v)
+	}
+	if v := e.APIKey("aa"); v != "sk-aa" {
+		t.Errorf("APIKey(aa) = %q", v)
+	}
+	// Missing letter returns empty.
+	if v := e.APIKey("z"); v != "" {
+		t.Errorf("APIKey(z) missing should be empty, got %q", v)
+	}
+}

--- a/tui/internal/config/state.go
+++ b/tui/internal/config/state.go
@@ -10,8 +10,22 @@ import (
 
 // StateDir represents a single account's state directory.
 type StateDir struct {
-	Letter string // e.g., "a"
-	Path   string // e.g., ~/.claude-state/account-a
+	Letter string // e.g., "a" or "aa"
+	Path   string // e.g., ~/.claude-state/account-a or -account-aa
+}
+
+// isValidAccountLetter reports whether s is a non-empty lowercase letter
+// sequence that round-trips through LetterToIndex / IndexToLetter.
+func isValidAccountLetter(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < 'a' || s[i] > 'z' {
+			return false
+		}
+	}
+	return LetterToIndex(s) > 0 && LetterToIndex(s) <= 702
 }
 
 // CredentialsPath returns the path to .credentials.json in this state dir.
@@ -70,7 +84,9 @@ func DiscoverStateDirsAt(basePath string) ([]StateDir, error) {
 			continue
 		}
 		letter := strings.TrimPrefix(name, "account-")
-		if len(letter) != 1 || letter[0] < 'a' || letter[0] > 'z' {
+		// Accept Excel-style letters (a-z, aa-zz) so state directories for
+		// NUM_ACCOUNTS > 26 are discovered.
+		if !isValidAccountLetter(letter) {
 			continue
 		}
 		dirs = append(dirs, StateDir{
@@ -79,8 +95,11 @@ func DiscoverStateDirsAt(basePath string) ([]StateDir, error) {
 		})
 	}
 
+	// Sort by the 1-based account index so the caller sees a, b, ..., z,
+	// aa, ab, ..., rather than the lexical order which would interleave
+	// "aa" between "a" and "b".
 	sort.Slice(dirs, func(i, j int) bool {
-		return dirs[i].Letter < dirs[j].Letter
+		return LetterToIndex(dirs[i].Letter) < LetterToIndex(dirs[j].Letter)
 	})
 
 	return dirs, nil


### PR DESCRIPTION
Closes #185
Part of #167

## Summary

Give the TUI its first Go test suite — before this, `tui/` had **zero** `*_test.go` files. Also extend `IndexToLetter` / `LetterToIndex` to match the Excel-style scheme from #178 so the Go side stays consistent with bash/PowerShell.

## How

- `tui/internal/config/env.go`: `IndexToLetter` / `LetterToIndex` now loop over 26-base digits. 1-702 supported; 1-26 bit-identical to previous output.
- `tui/internal/config/state.go`: `DiscoverStateDirsAt` accepts double-letter suffixes and sorts by 1-based index (`aa` after `z`, not between `a` and `b`).
- `tui/internal/config/env_test.go` (new): 11 tests.
- `tui/internal/account/manager_test.go` (new): 5 tests — service-name generation for N∈{1,2,5,26,27,30,52,53,702}, state-dir discovery with noise rejection, and sort-order-by-index.
- `.github/workflows/ci.yml`: new `go-test` job on Go 1.23 (matches `tui/go.mod`).

## Acceptance

- [x] `make -C tui test` passes locally (11+5 = 16/16).
- [x] CI gains a `go-test` job that runs on every PR.
- [x] Both pure-logic packages (`config`, `account`) covered.
- [x] Fixtures for single- and double-letter service names present.

## Test Plan

```bash
make -C tui test   # 11 config + 5 account = 16 tests pass
```