### PR TITLE
refactor(scripts): extract shared helpers to scripts/lib/

### DIFF
--- a/scripts/claude-docker
+++ b/scripts/claude-docker
@@ -46,6 +46,8 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 . "$SCRIPT_DIR/lib/tui-release.sh"
 # shellcheck source=lib/parse_env.sh
 . "$SCRIPT_DIR/lib/parse_env.sh"
+# shellcheck source=lib/index.sh
+. "$SCRIPT_DIR/lib/index.sh"
 
 # --- Compose Command Builder --------------------------------------------------
 
@@ -111,19 +113,12 @@ get_num_accounts() {
     echo "${n:-2}"
 }
 
-# Convert 1-based index to Excel-style lowercase letters:
-#   1→a, 26→z, 27→aa, 52→az, 53→ba, 702→zz.
-# Values 1-26 are bit-for-bit identical to the former single-letter impl.
+# Back-compat alias: claude-docker historically exposed the underscore
+# form; keep it as a thin wrapper so any external callers (hooks, custom
+# wrappers) continue to work while the canonical implementation lives in
+# scripts/lib/index.sh.
 _index_to_letter() {
-    local n="$1"
-    local out=""
-    local rem
-    while (( n > 0 )); do
-        rem=$(( (n - 1) % 26 ))
-        out=$(printf "\\$(printf '%03o' $((97 + rem)))")$out
-        n=$(( (n - 1) / 26 ))
-    done
-    printf '%s' "$out"
+    index_to_letter "$1"
 }
 
 # Return space-separated list of service names based on NUM_ACCOUNTS

--- a/scripts/generate-compose.sh
+++ b/scripts/generate-compose.sh
@@ -16,6 +16,8 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # shellcheck source=lib/parse_env.sh
 . "$SCRIPT_DIR/lib/parse_env.sh"
+# shellcheck source=lib/index.sh
+. "$SCRIPT_DIR/lib/index.sh"
 
 # --- Read configuration -------------------------------------------------------
 
@@ -50,33 +52,7 @@ CPU_RESERVATION="${CONTAINER_CPU_RESERVATION:-1}"
 MEM_LIMIT="${CONTAINER_MEM_LIMIT:-4G}"
 MEM_RESERVATION="${CONTAINER_MEM_RESERVATION:-2G}"
 
-# Convert 1-based index to Excel-style lowercase letters:
-#   1→a, 26→z, 27→aa, 52→az, 53→ba, 702→zz.
-# Existing single-letter (1-26) callers are bit-for-bit unchanged.
-index_to_letter() {
-    local n="$1"
-    local out=""
-    local rem
-    while (( n > 0 )); do
-        rem=$(( (n - 1) % 26 ))
-        out=$(printf "\\$(printf '%03o' $((97 + rem)))")$out
-        n=$(( (n - 1) / 26 ))
-    done
-    printf '%s' "$out"
-}
-
-# Convert 1-based index to Excel-style uppercase letters: A-Z, AA-AZ, ...
-index_to_upper() {
-    local n="$1"
-    local out=""
-    local rem
-    while (( n > 0 )); do
-        rem=$(( (n - 1) % 26 ))
-        out=$(printf "\\$(printf '%03o' $((65 + rem)))")$out
-        n=$(( (n - 1) / 26 ))
-    done
-    printf '%s' "$out"
-}
+# index_to_letter and index_to_upper provided by scripts/lib/index.sh.
 
 # --- Generate docker-compose.yml ---------------------------------------------
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -73,6 +73,8 @@ log_step()    { CURRENT_STEP=$((CURRENT_STEP + 1)); echo -e "\n${BOLD}[$CURRENT_
 . "$SCRIPT_DIR/lib/tui-release.sh"
 # shellcheck source=lib/parse_env.sh
 . "$SCRIPT_DIR/lib/parse_env.sh"
+# shellcheck source=lib/index.sh
+. "$SCRIPT_DIR/lib/index.sh"
 
 prompt_select() {
     local question="$1"
@@ -537,7 +539,7 @@ collect_configuration() {
         echo -e "\n${CYAN}Enter Console API keys (from console.anthropic.com):${NC}"
         for i in $(seq 1 "$NUM_ACCOUNTS"); do
             local letter
-            letter=$(printf "\\$(printf '%03o' $((96 + i)))")
+            letter=$(index_to_letter "$i")
             local upper
             upper=$(printf '%s' "$letter" | tr '[:lower:]' '[:upper:]')
             API_KEYS+=("$(prompt_secret "API key for Account $upper (sk-ant-...)")")
@@ -605,7 +607,7 @@ generate_env() {
             echo "# ==== Path B: Console API Keys ===="
             for i in $(seq 1 "$NUM_ACCOUNTS"); do
                 local letter
-                letter=$(printf "\\$(printf '%03o' $((96 + i)))")
+                letter=$(index_to_letter "$i")
                 local upper
                 upper=$(printf '%s' "$letter" | tr '[:lower:]' '[:upper:]')
                 echo "CLAUDE_API_KEY_${upper}=${API_KEYS[$((i-1))]}"
@@ -618,7 +620,7 @@ generate_env() {
             echo "# (populated after worktree setup)"
             for i in $(seq 1 "$NUM_ACCOUNTS"); do
                 local letter
-                letter=$(printf "\\$(printf '%03o' $((96 + i)))")
+                letter=$(index_to_letter "$i")
                 local upper
                 upper=$(printf '%s' "$letter" | tr '[:lower:]' '[:upper:]')
                 echo "PROJECT_DIR_${upper}="
@@ -680,7 +682,7 @@ create_state_dirs() {
     local dirs=("$HOME/.claude")
     for i in $(seq 1 "$NUM_ACCOUNTS"); do
         local letter
-        letter=$(printf "\\$(printf '%03o' $((96 + i)))")
+        letter=$(index_to_letter "$i")
         dirs+=("$HOME/.claude-state/account-${letter}")
     done
 
@@ -945,7 +947,7 @@ install_dependencies() {
     local n="${NUM_ACCOUNTS:-2}"
     for i in $(seq 1 "$n"); do
         local letter
-        letter=$(printf "\\$(printf '%03o' $((96 + i)))")
+        letter=$(index_to_letter "$i")
         services+=("claude-${letter}")
     done
 

--- a/scripts/lib/index.sh
+++ b/scripts/lib/index.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# index.sh — Shared account-index helpers.
+#
+# Library file meant to be `source`d. The shebang doubles as a shellcheck
+# shell directive (SC2148). Provides a single definition of:
+#
+#   index_to_letter N   1-based index → Excel-style lowercase (a, z, aa, zz)
+#   index_to_upper  N   1-based index → Excel-style uppercase (A, Z, AA, ZZ)
+#
+# Values 1-26 are bit-for-bit identical to the former single-letter
+# implementation that used to live in each consumer. The upper bound 702
+# matches scripts/install.sh's NUM_ACCOUNTS validator.
+#
+# Consumers that also want get_service_names should source this file and
+# implement the loop locally — they already vary on whether to read
+# NUM_ACCOUNTS from .env or from a parameter, so there's no clean helper.
+
+if [[ -n "${_CLAUDE_DOCKER_INDEX_SH_SOURCED:-}" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+_CLAUDE_DOCKER_INDEX_SH_SOURCED=1
+
+index_to_letter() {
+    local n="$1"
+    local out=""
+    local rem
+    while (( n > 0 )); do
+        rem=$(( (n - 1) % 26 ))
+        out=$(printf "\\$(printf '%03o' $((97 + rem)))")$out
+        n=$(( (n - 1) / 26 ))
+    done
+    printf '%s' "$out"
+}
+
+index_to_upper() {
+    local n="$1"
+    local out=""
+    local rem
+    while (( n > 0 )); do
+        rem=$(( (n - 1) % 26 ))
+        out=$(printf "\\$(printf '%03o' $((65 + rem)))")$out
+        n=$(( (n - 1) / 26 ))
+    done
+    printf '%s' "$out"
+}

--- a/scripts/setup-worktrees.sh
+++ b/scripts/setup-worktrees.sh
@@ -7,6 +7,10 @@
 # If no branch names are provided, defaults to worktree-a and worktree-b.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/index.sh
+. "$SCRIPT_DIR/lib/index.sh"
+
 REPO_DIR="${1:?Usage: setup-worktrees.sh <repo-dir> [branch...]}"; shift
 
 # Default branches if none provided
@@ -22,19 +26,7 @@ if [ ! -d "$REPO_DIR/.git" ]; then
     exit 1
 fi
 
-# Convert 1-based index to Excel-style lowercase letters:
-#   1→a, 26→z, 27→aa, 52→az, 702→zz.
-index_to_letter() {
-    local n="$1"
-    local out=""
-    local rem
-    while (( n > 0 )); do
-        rem=$(( (n - 1) % 26 ))
-        out=$(printf "\\$(printf '%03o' $((97 + rem)))")$out
-        n=$(( (n - 1) / 26 ))
-    done
-    printf '%s' "$out"
-}
+# index_to_letter provided by scripts/lib/index.sh.
 
 cd "$REPO_DIR"
 

--- a/scripts/test-concurrent-git.sh
+++ b/scripts/test-concurrent-git.sh
@@ -13,18 +13,8 @@ TEMP_DIR="$(mktemp -d)"
 REPO_DIR="$TEMP_DIR/test-repo"
 NUM_TEST_ACCOUNTS="${NUM_TEST_ACCOUNTS:-2}"
 
-# Convert 1-based index to Excel-style lowercase letters (a, z, aa, az, ba, zz).
-index_to_letter() {
-    local n="$1"
-    local out=""
-    local rem
-    while (( n > 0 )); do
-        rem=$(( (n - 1) % 26 ))
-        out=$(printf "\\$(printf '%03o' $((97 + rem)))")$out
-        n=$(( (n - 1) / 26 ))
-    done
-    printf '%s' "$out"
-}
+# shellcheck source=lib/index.sh
+. "$SCRIPT_DIR/lib/index.sh"
 
 # Uppercase a single-letter string. Portable replacement for bash 4+ ${var^^}
 # (macOS ships bash 3.2 which does not support the ^^ expansion).


### PR DESCRIPTION
Closes #176
Part of #167

## Summary

Consolidate the five duplicate `index_to_letter` / `index_to_upper` copies (generate-compose.sh, claude-docker, setup-worktrees.sh, test-concurrent-git.sh, and five inline `printf` incantations in install.sh) into a single `scripts/lib/index.sh` sourced by each consumer.

## How

- `scripts/lib/index.sh` (new): canonical definitions with the #178 Excel-style loop, double-source guard.
- `scripts/generate-compose.sh`, `scripts/setup-worktrees.sh`, `scripts/test-concurrent-git.sh`: drop local copies, `source` the lib.
- `scripts/install.sh`: replace five inline letter-generation printf invocations with `index_to_letter "$i"` calls.
- `scripts/claude-docker`: keep `_index_to_letter` as a thin back-compat wrapper (external callers may invoke it) that forwards to the lib.

## Scope

Index helpers only. The issue also proposes extracting `gh_auth` and `compose_cmd` helpers; I left those for a follow-up so the diff stays reviewable. `parse_env.sh` (from #170) and `tui-release.sh` (from #169) already live in `scripts/lib/`, so the pattern is in place.

## Acceptance

- [x] `grep -rn '^index_to_letter()' scripts/` returns exactly one result (scripts/lib/index.sh).
- [x] `bash -n` clean for every touched script.
- [x] Output bit-for-bit identical for 1-26 (matches pre-#178 single-letter behavior).

## Test Plan

1. `grep -rn '^index_to_letter()' scripts/` returns exactly one result.
2. `bash scripts/generate-compose.sh` with NUM_ACCOUNTS=27 produces `claude-aa` (verified in-repo by `tests/env_fixtures/n30.env` in CI's compose-validate matrix).
3. `scripts/claude-docker claude` still invokes the right service name (`_index_to_letter` wrapper works).