### PR TITLE
build(docker): install python3 for JSON validator fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,11 @@ ARG CLAUDE_CODE_VERSION
 
 WORKDIR /workspace
 
-# Dev tools — single layer, cache cleaned
+# Dev tools — single layer, cache cleaned.
+# python3 is included so hook test harnesses (e.g. claude-config
+# tests/hooks/test-*.sh) that validate JSON via `python3 -m json.tool`
+# fall back correctly when jq is unavailable; the image stays slim
+# because this is the interpreter only, no pip or venv.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        git \
@@ -26,6 +30,7 @@ RUN apt-get update \
        zsh \
        sudo \
        procps \
+       python3 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub CLI (gh) — separate layer for cache efficiency


### PR DESCRIPTION
## What

Add \`python3\` to the dev-tools apt layer in \`Dockerfile\` so the runtime image ships with a JSON validator fallback.

## Why

Hook test harnesses in \`claude-config/tests/hooks/\` (notably \`test-instructions-loaded-reinforcer.sh\` and \`test-post-compact-restore.sh\`) validate hook output with \`python -m json.tool\` / \`python3 -m json.tool\`. The \`node:20-slim\` base has neither binary, so both branches exit 127 and valid JSON is reported as invalid whenever those tests run inside the container.

Paired with kcenon/claude-config#355 which promotes \`jq\` to the primary validator — either change alone resolves the failure, but the Dockerfile update also helps any other shell tooling that expects a system python interpreter.

## How

- Add \`python3\` to the existing single-layer \`apt-get install\` block
- Added a short comment above the block explaining why python3 is included
- No pip, no venv — interpreter only, ~30 MB image growth

## Test plan

- [ ] \`docker compose build --no-cache\` succeeds
- [ ] Container has \`/usr/bin/python3\` on PATH after build
- [ ] Inside the container: \`echo '{}' | python3 -m json.tool\` exits 0
- [ ] Reviewer: confirm final image size delta is within acceptable range