### PR TITLE
fix(compose): bake host UID/GID into base compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,9 +433,17 @@ based on `NUM_ACCOUNTS` in `.env`. Do not edit them manually.
 
 | File | Purpose | When active |
 |------|---------|-------------|
-| `docker-compose.yml` | Base config (Tier A) | Always |
-| `docker-compose.linux.yml` | UID/GID + HOME override | Linux only |
+| `docker-compose.yml` | Base config (Tier A), incl. `user: ${UID:-1000}:${GID:-1000}` and `HOME=/home/node` | Always |
+| `docker-compose.linux.yml` | Legacy UID/GID + HOME override (kept for backward compat; base already carries it) | Optional |
 | `docker-compose.worktree.yml` | Per-container worktree paths | Tier B only |
+
+Set `UID` / `GID` in `.env` (or export them in the shell before running
+`docker compose up`) to match the host user that owns `~/.claude-state/`.
+Without these, bind-mounted paths such as `~/.claude-state/account-a/` are
+not writable from inside the container, producing errors like
+`hook: /home/node/.claude/hooks/<name>.sh: not found` (failure to stat
+under non-matching UID) and Bash tool failures caused by the harness
+being unable to create `session-env/` subdirectories.
 
 To regenerate after editing `.env`:
 ```bash
@@ -469,7 +477,21 @@ scripts/claude-docker down && scripts/claude-docker up
 scripts/claude-docker exec claude-a claude auth login
 ```
 
-**Permission denied on bind mount (Linux):**
+**Permission denied on bind mount (or `hook: ... not found`, `session-env` write failures):**
+
+Host UID/GID must match what owns `~/.claude-state/`. Add them to `.env`
+and restart — the base compose now reads these directly, so no extra
+overlay is required.
+
+```bash
+cat >> .env <<EOF
+UID=$(id -u)
+GID=$(id -g)
+EOF
+scripts/claude-docker down && scripts/claude-docker up
+```
+
+On Linux the legacy overlay still works and is equivalent:
 
 ```bash
 export UID=$(id -u) GID=$(id -g)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,11 @@ services:
         CLAUDE_CODE_VERSION: ${CLAUDE_CODE_VERSION:-}
     image: claude-code-base:${IMAGE_TAG:-2026.04.17}
     working_dir: ${CONTAINER_PROJECT_DIR:-/project}
+    # Match the host user's UID/GID so bind-mounted paths
+    # (${HOME}/.claude-state/account-*) stay writable from
+    # inside the container. Falls back to 1000:1000 (the
+    # upstream node:20-slim default) when UID/GID are unset.
+    user: "${UID:-1000}:${GID:-1000}"
     stdin_open: true
     tty: true
     volumes:
@@ -21,6 +26,7 @@ services:
     environment:
       - TERM=xterm-256color
       - TZ=${TZ:-UTC}
+      - HOME=/home/node
       - CLAUDE_CONFIG_DIR=/home/node/.claude
       - CLAUDE_CONFIG_SOURCE=${CLAUDE_CONFIG_SOURCE:-}
       - CLAUDE_NORMALIZE_CRLF=${CLAUDE_NORMALIZE_CRLF:-}
@@ -43,6 +49,11 @@ services:
     depends_on:
       - claude-a
     working_dir: ${CONTAINER_PROJECT_DIR:-/project}
+    # Match the host user's UID/GID so bind-mounted paths
+    # (${HOME}/.claude-state/account-*) stay writable from
+    # inside the container. Falls back to 1000:1000 (the
+    # upstream node:20-slim default) when UID/GID are unset.
+    user: "${UID:-1000}:${GID:-1000}"
     stdin_open: true
     tty: true
     volumes:
@@ -54,6 +65,7 @@ services:
     environment:
       - TERM=xterm-256color
       - TZ=${TZ:-UTC}
+      - HOME=/home/node
       - CLAUDE_CONFIG_DIR=/home/node/.claude
       - CLAUDE_CONFIG_SOURCE=${CLAUDE_CONFIG_SOURCE:-}
       - CLAUDE_NORMALIZE_CRLF=${CLAUDE_NORMALIZE_CRLF:-}

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -187,6 +187,15 @@ if [ -d "$CONFIG_SOURCE" ]; then
     # Ensure logs directory exists (hooks write to ~/.claude/logs/)
     mkdir -p "$ACCOUNT_DIR/logs" 2>/dev/null
 
+    # Ensure session-env exists so the Claude Code harness can write per-turn
+    # environment snapshots on the first session. The harness creates
+    # subdirectories under session-env/ each turn; if the parent directory is
+    # missing or not writable, every Bash tool call fails before the hook
+    # chain even runs. Pre-creating it with 700 (owner rwx) matches the
+    # harness's own default and is a no-op when the directory already exists.
+    mkdir -p "$ACCOUNT_DIR/session-env" 2>/dev/null
+    chmod 700 "$ACCOUNT_DIR/session-env" 2>/dev/null || true
+
     # Warn about hook scripts referenced in settings but missing on disk
     if [ -f "$ACCOUNT_DIR/settings.json" ] && command -v jq >/dev/null 2>&1; then
         jq -r '.. | objects | .command? // empty' "$ACCOUNT_DIR/settings.json" 2>/dev/null \

--- a/scripts/generate-compose.ps1
+++ b/scripts/generate-compose.ps1
@@ -141,6 +141,11 @@ function New-BaseCompose {
         }
 
         [void]$sb.AppendLine('    working_dir: ${CONTAINER_PROJECT_DIR:-/project}')
+        # Match the host user's UID/GID so bind-mounted paths
+        # (${HOME}/.claude-state/account-*) stay writable from inside
+        # the container. Falls back to 1000:1000 (the upstream
+        # node:20-slim default) when UID/GID are unset.
+        [void]$sb.AppendLine('    user: "${UID:-1000}:${GID:-1000}"')
         [void]$sb.AppendLine('    stdin_open: true')
         [void]$sb.AppendLine('    tty: true')
         [void]$sb.AppendLine('    volumes:')
@@ -152,6 +157,10 @@ function New-BaseCompose {
         [void]$sb.AppendLine('    environment:')
         [void]$sb.AppendLine('      - TERM=xterm-256color')
         [void]$sb.AppendLine('      - TZ=${TZ:-UTC}')
+        # When the container runs as the host UID instead of node(1000),
+        # the passwd entry for that UID is missing, so $HOME defaults to
+        # /. Pinning HOME keeps ~/.claude, ~/.config, etc. resolvable.
+        [void]$sb.AppendLine('      - HOME=/home/node')
         [void]$sb.AppendLine('      - CLAUDE_CONFIG_DIR=/home/node/.claude')
         [void]$sb.AppendLine('      - CLAUDE_CONFIG_SOURCE=${CLAUDE_CONFIG_SOURCE:-}')
         [void]$sb.AppendLine('      - CLAUDE_NORMALIZE_CRLF=${CLAUDE_NORMALIZE_CRLF:-}')

--- a/scripts/generate-compose.sh
+++ b/scripts/generate-compose.sh
@@ -91,6 +91,11 @@ generate_base() {
             fi
 
             echo "    working_dir: \${CONTAINER_PROJECT_DIR:-/project}"
+            echo "    # Match the host user's UID/GID so bind-mounted paths"
+            echo "    # (\${HOME}/.claude-state/account-*) stay writable from"
+            echo "    # inside the container. Falls back to 1000:1000 (the"
+            echo "    # upstream node:20-slim default) when UID/GID are unset."
+            echo "    user: \"\${UID:-1000}:\${GID:-1000}\""
             echo "    stdin_open: true"
             echo "    tty: true"
             echo "    volumes:"
@@ -102,6 +107,10 @@ generate_base() {
             echo "    environment:"
             echo "      - TERM=xterm-256color"
             echo "      - TZ=\${TZ:-UTC}"
+            # When the container runs as the host UID instead of node(1000),
+            # the passwd entry for that UID is missing, so \$HOME defaults
+            # to /. Pinning HOME keeps ~/.claude, ~/.config, etc. resolvable.
+            echo "      - HOME=/home/node"
             echo "      - CLAUDE_CONFIG_DIR=/home/node/.claude"
             echo "      - CLAUDE_CONFIG_SOURCE=\${CLAUDE_CONFIG_SOURCE:-}"
             echo "      - CLAUDE_NORMALIZE_CRLF=\${CLAUDE_NORMALIZE_CRLF:-}"


### PR DESCRIPTION
## What

- Bake host UID/GID matching into base `docker-compose.yml`
- Pre-create `session-env/` in entrypoint so Bash tool calls never race the harness mkdir on the first session of a fresh state dir
- Update README 'Compose Overrides' and 'Troubleshooting' to document the new `.env`-only flow

### Change Type
- [x] Bugfix
- [x] Refactor (compose generator)
- [x] Documentation

## Why

### Problem Solved
Container-side Bash tool failures on macOS (Docker Desktop / VirtioFS):

```
/bin/sh: 1: /home/node/.claude/hooks/<name>.sh: not found
harness failing to create /home/node/.claude/session-env/<turn>
```

Both stem from the container running as `node` (UID 1000) while the bind-mounted state dir is owned by the host UID (e.g. 501 on macOS, `id -u` on Linux). Recent Docker Desktop versions no longer transparently remap ownership for every combination, so macOS now exhibits the same pattern Linux hosts have always had.

### Alternative Approaches Considered
Remapping node's UID at build time via `usermod` inside the Dockerfile. Rejected because it introduces group-conflict handling (macOS `staff` GID 20 vs container `dialout` GID 20) and forces a non-trivial Dockerfile change for every UID tweak. Compose-level `user:` override is simpler and covers every writable path that actually matters (all writes flow through the `~/.claude-state` bind mount).

## Who

- Reviewers: @kcenon
- Stakeholders: all claude-docker users on macOS and Linux

## When

Normal priority. Unblocks Bash-dependent workflows (`issue-work`, `pr-work`) immediately for users who hit the symptom.

## Where

| File | Type of Change |
|---|---|
| `docker-compose.yml` | Regenerated — adds `user:` and `HOME` |
| `scripts/generate-compose.sh` | Source of the change |
| `scripts/generate-compose.ps1` | Sync PowerShell generator |
| `scripts/entrypoint.sh` | `mkdir -p session-env` |
| `README.md` | Compose Overrides + Troubleshooting |

## How

### Implementation Details
- Base compose gains `user: "${UID:-1000}:${GID:-1000}"` and `- HOME=/home/node`. Default 1000:1000 preserves the previous behavior when `UID`/`GID` are not set, so existing working installs are unaffected.
- Users only need to add `UID=$(id -u)` and `GID=$(id -g)` to `.env`; no `-f docker-compose.linux.yml` overlay required. The overlay file is kept (backward compat) and now simply duplicates the base settings.
- `entrypoint.sh` pre-creates `session-env/` with 0700 alongside the existing `logs/` directory. Idempotent.

### Testing Done
- `bash -n` on `entrypoint.sh` and `generate-compose.sh`
- `python3 -c 'yaml.safe_load(...)'` on all three generated compose files
- `tests/test_parse_env.sh` and `tests/test_transform_syntax_check.sh` — core assertions pass. (A subset of assertions that rely on `mktemp` into `/var/folders` fail under the sandbox this session runs in; unrelated to this change.)

### Test Plan for Reviewers
1. `scripts/generate-compose.sh` — confirms output matches committed compose files.
2. In `.env`: add `UID=$(id -u)` and `GID=$(id -g)`.
3. `scripts/claude-docker down && scripts/claude-docker up`
4. `docker compose exec claude-a bash -c 'id && touch ~/.claude/session-env/__t && rm \$_'` — should print host UID/GID and succeed.

### Breaking Changes
None. Users who never set `UID`/`GID` keep the 1000:1000 behavior they always had.

### Rollback Plan
Revert the commit; regenerated compose files have no schema changes beyond the two added keys.