### PR TITLE
fix(docker): restore ccstatusline under host UID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,10 +100,22 @@ RUN npm install -g ccstatusline claude-limitline \
 # Memory heap limit
 ENV NODE_OPTIONS=--max-old-space-size=4096
 
-# Pre-create .config directories with node ownership
-# (prevents root-owned dir when Docker bind-mounts ~/.config/gh)
+# Pre-create ccstatusline XDG config dir world-writable.
+#
+# ccstatusline reads (and on first run writes defaults to) ~/.config/
+# ccstatusline/settings.json — path derived from os.homedir(), not XDG_
+# CONFIG_HOME. When docker-compose runs the container as the host UID/GID
+# (see user: "${UID:-1000}:${GID:-1000}" in docker-compose.yml, added by
+# commit a09f997), chown'ing this dir to node:node leaves the running
+# process unable to write, and ccstatusline silently falls back to its
+# hardcoded single-line default instead of the user's multi-line layout.
+#
+# Using chmod -R a+rwX (capital X grants execute on dirs/already-executables
+# only, never on plain files) keeps the tree writable regardless of which
+# UID the compose file chooses. gh mounts its own subdir read-only at
+# runtime, so loosening the parent does not affect gh's token security.
 RUN mkdir -p /home/node/.config/ccstatusline \
-    && chown -R node:node /home/node/.config
+    && chmod -R a+rwX /home/node/.config
 
 # Copy entrypoint script (symlinks host config into account state dir).
 # Explicit chmod ensures the executable bit is set regardless of the host

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -216,15 +216,61 @@ if [ -d "$CONFIG_SOURCE" ]; then
         fi
     done
 
-    # Symlink ccstatusline config to XDG path (~/.config/ccstatusline/)
-    # ccstatusline reads from ~/.config/ccstatusline/settings.json, not ~/.claude/ccstatusline/
+    # Symlink ccstatusline config to XDG path (~/.config/ccstatusline/).
+    #
+    # ccstatusline resolves its settings path from os.homedir() + ".config/
+    # ccstatusline/settings.json"; it does not honor XDG_CONFIG_HOME or any
+    # override env. If the file is absent it attempts to *write* a default
+    # there — when that write fails (EACCES), ccstatusline silently falls
+    # back to a hardcoded single-line layout and the user's multi-line
+    # config in $CONFIG_SOURCE/ccstatusline/ is never applied.
+    #
+    # Two things must hold for this block to succeed:
+    #   1. $XDG_CCSL must be writable by the current UID. Dockerfile handles
+    #      this with `chmod -R a+rwX /home/node/.config` — if you see the
+    #      "could not create XDG symlink" warning below, that chmod was lost
+    #      (e.g. stale base image) or overridden by a volume mount.
+    #   2. A source settings.json must exist. $ACCOUNT_DIR points to the
+    #      bind-mounted account state; $CONFIG_SOURCE points to the read-only
+    #      host config mount (or CLAUDE_CONFIG_SOURCE override).
     XDG_CCSL="/home/node/.config/ccstatusline"
-    mkdir -p "$XDG_CCSL" 2>/dev/null
-    if [ -d "$XDG_CCSL" ] && [ ! -e "$XDG_CCSL/settings.json" ]; then
+    mkdir -p "$XDG_CCSL" 2>/dev/null || true
+    if [ -d "$XDG_CCSL" ]; then
+        # Pick the source, preferring account state (host-synced via earlier
+        # symlink) over raw config source.
+        ccsl_src=""
         if [ -f "$ACCOUNT_DIR/ccstatusline/settings.json" ]; then
-            ln -sf "$ACCOUNT_DIR/ccstatusline/settings.json" "$XDG_CCSL/settings.json"
+            ccsl_src="$ACCOUNT_DIR/ccstatusline/settings.json"
         elif [ -f "$CONFIG_SOURCE/ccstatusline/settings.json" ]; then
-            ln -sf "$CONFIG_SOURCE/ccstatusline/settings.json" "$XDG_CCSL/settings.json"
+            ccsl_src="$CONFIG_SOURCE/ccstatusline/settings.json"
+        fi
+
+        if [ -n "$ccsl_src" ]; then
+            # Replace any stale symlink or pre-existing file so a new
+            # ACCOUNT_DIR / CONFIG_SOURCE binding is picked up on restart.
+            # `ln -sf` without this would leave a broken symlink dangling
+            # when the previous target has moved.
+            current_target=""
+            if [ -L "$XDG_CCSL/settings.json" ]; then
+                current_target=$(readlink "$XDG_CCSL/settings.json" 2>/dev/null || true)
+            fi
+            if [ "$current_target" != "$ccsl_src" ]; then
+                rm -f "$XDG_CCSL/settings.json" 2>/dev/null || true
+                if ln -s "$ccsl_src" "$XDG_CCSL/settings.json" 2>/dev/null; then
+                    echo "[entrypoint] ccstatusline: linked XDG settings.json -> $ccsl_src"
+                else
+                    # Most common cause: $XDG_CCSL owned by a different UID
+                    # (Dockerfile chown'd to node:node but container runs
+                    # as host UID). Warn loudly so the user sees the single-
+                    # line fallback is a config plumbing issue, not a
+                    # ccstatusline bug.
+                    xdg_owner=$(stat -c '%u:%g' "$XDG_CCSL" 2>/dev/null || echo "?")
+                    echo "[entrypoint] WARNING: could not create XDG symlink at $XDG_CCSL/settings.json" >&2
+                    echo "[entrypoint]   $XDG_CCSL owned by $xdg_owner, running as $(id -u):$(id -g)" >&2
+                    echo "[entrypoint]   ccstatusline will show its hardcoded default layout" >&2
+                    echo "[entrypoint]   Fix: rebuild base image so Dockerfile's chmod -R a+rwX takes effect" >&2
+                fi
+            fi
         fi
     fi
 fi

--- a/tests/test_ccstatusline_xdg_symlink.sh
+++ b/tests/test_ccstatusline_xdg_symlink.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# test_ccstatusline_xdg_symlink.sh — Verify the XDG symlink block in
+# scripts/entrypoint.sh works under the conditions that broke it in
+# production:
+#
+#   1. Symlink gets created when $XDG_CCSL is writable and a source
+#      settings.json exists at $ACCOUNT_DIR/ccstatusline/.
+#   2. Stale symlink pointing at a moved target is replaced on restart.
+#   3. When $XDG_CCSL is owned by another UID and not writable, the
+#      entrypoint prints the "could not create XDG symlink" warning to
+#      stderr — the signal that tells users their statusline is missing
+#      because of a permission mismatch, not a ccstatusline bug.
+#
+# Why this file exists: the original XDG fix (commit 9af34d5) was silently
+# regressed when docker-compose.yml switched to `user: "${UID}:${GID}"`
+# (commit a09f997), because the Dockerfile chown'd the dir to node:node
+# and the container now runs as the host UID. The regression was invisible
+# — ccstatusline kept running, just with its hardcoded default layout.
+# This test codifies the path so the next regression trips in CI.
+#
+# Run: bash tests/test_ccstatusline_xdg_symlink.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENTRYPOINT="$SCRIPT_DIR/../scripts/entrypoint.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+fail() { echo -e "  ${RED}FAIL${NC}: $*"; FAIL=$((FAIL + 1)); }
+pass() { echo -e "  ${GREEN}PASS${NC}: $*"; PASS=$((PASS + 1)); }
+
+# Mini fixture builder: lay out a host CONFIG_SOURCE and ACCOUNT_DIR with
+# a known ccstatusline settings.json, plus a target XDG_CCSL dir under
+# the caller-provided permissions mode.
+make_fixture() {
+    local root="$1" xdg_mode="${2:-755}"
+    mkdir -p "$root/config-source/ccstatusline"
+    mkdir -p "$root/account/ccstatusline"
+    mkdir -p "$root/xdg"
+    printf '{"version":3,"lines":[[{"id":"1","type":"model"}]]}\n' \
+        > "$root/config-source/ccstatusline/settings.json"
+    # Account dir mirrors config source via a symlink (matches what the
+    # earlier loop in entrypoint.sh sets up).
+    ln -sfn "$root/config-source/ccstatusline/settings.json" \
+        "$root/account/ccstatusline/settings.json"
+    chmod "$xdg_mode" "$root/xdg"
+}
+
+# Run the XDG block of entrypoint.sh against a fabricated environment.
+# We extract the block (lines between the "Symlink ccstatusline" marker
+# and the closing "fi" that matches it) instead of sourcing the whole
+# entrypoint, which would try to create /home/node paths and call
+# generate_container_settings on unrelated inputs.
+run_xdg_block() {
+    local root="$1"
+    local xdg="$root/xdg" account="$root/account" src="$root/config-source"
+
+    # Shim the paths the block hardcodes. XDG_CCSL is a local var in the
+    # real script; we override by redefining the literal via sed.
+    local tmp_block
+    tmp_block=$(mktemp)
+    awk '
+        /# Symlink ccstatusline config to XDG path/ { capture=1 }
+        capture { print }
+        capture && /^    fi$/ { exit }
+    ' "$ENTRYPOINT" > "$tmp_block"
+
+    # Redirect the block's hardcoded /home/node/.config/ccstatusline to
+    # our fixture. The block also references $ACCOUNT_DIR and
+    # $CONFIG_SOURCE — those we set via env so no patching is needed.
+    sed -i.bak "s|/home/node/.config/ccstatusline|$xdg/ccstatusline|g" "$tmp_block"
+
+    ACCOUNT_DIR="$account" CONFIG_SOURCE="$src" bash "$tmp_block" 2>"$root/stderr"
+    local rc=$?
+    rm -f "$tmp_block" "$tmp_block.bak"
+    return $rc
+}
+
+# ---------------------------------------------------------------------------
+echo "== Test 1: fresh writable XDG dir → symlink created =="
+# ---------------------------------------------------------------------------
+ROOT=$(mktemp -d)
+make_fixture "$ROOT"
+run_xdg_block "$ROOT" || fail "block exited non-zero on happy path"
+
+if [ -L "$ROOT/xdg/ccstatusline/settings.json" ]; then
+    target=$(readlink "$ROOT/xdg/ccstatusline/settings.json")
+    if [ "$target" = "$ROOT/account/ccstatusline/settings.json" ]; then
+        pass "symlink points to ACCOUNT_DIR source"
+    else
+        fail "symlink points to $target (expected account source)"
+    fi
+else
+    fail "no symlink created at $ROOT/xdg/ccstatusline/settings.json"
+fi
+rm -rf "$ROOT"
+
+# ---------------------------------------------------------------------------
+echo "== Test 2: stale symlink to removed target is replaced =="
+# ---------------------------------------------------------------------------
+ROOT=$(mktemp -d)
+make_fixture "$ROOT"
+# Pre-populate with a stale symlink to a nonexistent path — simulates a
+# container restart after CLAUDE_CONFIG_SOURCE was redirected. The parent
+# dir must exist first; make_fixture creates xdg/ but not xdg/ccstatusline/.
+mkdir -p "$ROOT/xdg/ccstatusline"
+ln -sfn "/nonexistent/old/settings.json" "$ROOT/xdg/ccstatusline/settings.json"
+run_xdg_block "$ROOT"
+
+new_target=$(readlink "$ROOT/xdg/ccstatusline/settings.json" 2>/dev/null || echo "")
+if [ "$new_target" = "$ROOT/account/ccstatusline/settings.json" ]; then
+    pass "stale symlink rewritten to current source"
+else
+    fail "stale symlink not replaced (points to '$new_target')"
+fi
+rm -rf "$ROOT"
+
+# ---------------------------------------------------------------------------
+echo "== Test 3: unwritable XDG dir → warning on stderr, no crash =="
+# ---------------------------------------------------------------------------
+ROOT=$(mktemp -d)
+make_fixture "$ROOT"
+# Drop write perms on xdg/ccstatusline to simulate the chown+UID mismatch
+# that caused the production regression. We cannot change ownership
+# without root, but removing write bits for the current user achieves the
+# same EACCES from ln(1)'s perspective.
+mkdir -p "$ROOT/xdg/ccstatusline"
+chmod 555 "$ROOT/xdg/ccstatusline"
+run_xdg_block "$ROOT"
+block_rc=$?
+
+if [ "$block_rc" -eq 0 ]; then
+    pass "block exits cleanly even when symlink cannot be created"
+else
+    fail "block failed with rc=$block_rc (should degrade gracefully)"
+fi
+
+if grep -q "could not create XDG symlink" "$ROOT/stderr"; then
+    pass "warning printed to stderr"
+else
+    fail "no warning printed (stderr: $(cat "$ROOT/stderr"))"
+fi
+
+# Restore perms so mktemp cleanup can remove the tree.
+chmod 755 "$ROOT/xdg/ccstatusline"
+rm -rf "$ROOT"
+
+# ---------------------------------------------------------------------------
+echo "== Test 4: CONFIG_SOURCE fallback when ACCOUNT_DIR is empty =="
+# ---------------------------------------------------------------------------
+ROOT=$(mktemp -d)
+make_fixture "$ROOT"
+# Remove the account-side settings so only CONFIG_SOURCE is available.
+rm -f "$ROOT/account/ccstatusline/settings.json"
+run_xdg_block "$ROOT"
+
+target=$(readlink "$ROOT/xdg/ccstatusline/settings.json" 2>/dev/null || echo "")
+if [ "$target" = "$ROOT/config-source/ccstatusline/settings.json" ]; then
+    pass "falls back to CONFIG_SOURCE when ACCOUNT_DIR lacks settings.json"
+else
+    fail "fallback did not reach CONFIG_SOURCE (target='$target')"
+fi
+rm -rf "$ROOT"
+
+# ---------------------------------------------------------------------------
+echo
+echo "== Summary: PASS=$PASS FAIL=$FAIL =="
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## What

### Summary
Restore the multi-line ccstatusline layout inside the container after the recent switch to running as the host UID/GID.

### Change Type
- [x] Bugfix

### Affected Components
- `Dockerfile` — XDG config directory permissions
- `scripts/entrypoint.sh` — symlink handling and diagnostics
- `tests/test_ccstatusline_xdg_symlink.sh` — new coverage

## Why

### Problem Solved
Two prior commits interacted badly and silently broke ccstatusline:

- `9af34d5` pre-created `/home/node/.config/ccstatusline` with `node:node` ownership so ccstatusline could write its defaults on first run.
- `a09f997` then made the container run as the host UID/GID via `docker-compose.yml`.

Together they leave the XDG dir owned by a UID the running process cannot write to, so ccstatusline hits `EACCES` when writing its default `settings.json`, silently falls back to a hardcoded single-line layout, and the multi-line config in `claude-config/global/ccstatusline/` is never applied.

### Related Issues
No tracking issue — regression surfaced locally while verifying the host-UID change from `a09f997`.

## Where

### Files Changed
| File | Type |
|------|------|
| `Dockerfile` | Modified |
| `scripts/entrypoint.sh` | Modified |
| `tests/test_ccstatusline_xdg_symlink.sh` | New |

### Runtime Impact
- Container user: unchanged (still host UID/GID)
- Permissions on `/home/node/.config`: broadened from `node:node` to world-writable (`a+rwX`)
- `gh` config mount remains read-only at runtime, so loosening the parent does not affect token handling

## How

### Implementation Details
- **`Dockerfile`**: replaced `chown -R node:node /home/node/.config` with `chmod -R a+rwX /home/node/.config`. Capital `X` keeps directories traversable for any UID without granting exec on plain files.
- **`scripts/entrypoint.sh`**: emit an audible `WARNING` when the XDG symlink cannot be created so the next regression is visible at container start instead of a silent fallback. Also replace stale symlinks when `CLAUDE_CONFIG_SOURCE` is redirected on restart.
- **`tests/test_ccstatusline_xdg_symlink.sh`**: covers the happy path, stale-symlink replacement, the unwritable-dir warning, and `CONFIG_SOURCE` fallback.

### Testing Done
Verified in-container:
- `HOME` pointed at a writable tree renders the full multi-line layout.
- `HOME=/home/node` raises `EACCES` and falls back to one line.
- With the `chmod` in place, both paths produce the full layout after a rebuild.

### Test Plan for Reviewers
1. Rebuild the image: `docker compose build`
2. Start a container and observe the ccstatusline layout — should be multi-line.
3. Run `bash tests/test_ccstatusline_xdg_symlink.sh` — all cases should pass.

### Breaking Changes
None.

### Rollback Plan
Revert this PR. No data migrations involved.
