### PR TITLE
feat(entrypoint): forward full-suite probe and document config contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,20 @@ scripts/claude-docker exec claude-a gh pr list
 If you use [claude-config](https://github.com/kcenon/claude-config) to manage global
 Claude Code settings, containers automatically inherit your host configuration.
 
+> **Prerequisite**: Run claude-config's installer (`scripts/install.sh` /
+> `install.ps1`, or `bootstrap.sh`) on the host **before** starting any
+> claude-docker container. Containers are pure consumers — they do not run
+> the installer. Without a populated `~/.claude/` tree on the host, the
+> entrypoint symlinks below resolve to missing targets and Claude Code
+> falls back to its built-in defaults.
+>
+> **Compatibility**: Tested against claude-config v1.10+. The contract
+> claude-docker relies on (directory layout, hook command grammar,
+> dual-variant pairing, full-suite probe, CRLF normalization) is documented
+> in [`docs/CLAUDE_DOCKER_CONTRACT.md`](https://github.com/kcenon/claude-config/blob/develop/docs/CLAUDE_DOCKER_CONTRACT.md)
+> in the claude-config repo. Older claude-config installs may work but are
+> not gate-tested.
+
 The host's `~/.claude/` is mounted read-only at `/home/node/.claude-host/` inside
 each container. On startup, the entrypoint script creates symlinks from the
 account state directory to the shared config:
@@ -250,6 +264,7 @@ account state directory to the shared config:
 | Global instructions | `~/.claude/CLAUDE.md` | `/home/node/.claude/CLAUDE.md` -> `.claude-host/CLAUDE.md` |
 | Commit settings | `~/.claude/commit-settings.md` | `/home/node/.claude/commit-settings.md` -> `.claude-host/commit-settings.md` |
 | Hook config | `~/.claude/settings.json` | `/home/node/.claude/settings.json` -> `.claude-host/settings.json` |
+| Full-suite probe | `~/.claude/.full-suite-active` (optional) | `/home/node/.claude/.full-suite-active` -> `.claude-host/.full-suite-active` |
 
 The host config is read-only. Account-specific state (credentials, memory,
 sessions) remains writable and per-container. Symlinks are created when the

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -207,8 +207,15 @@ if [ -d "$CONFIG_SOURCE" ]; then
         done
     fi
 
-    # Symlink other shared config files
-    for item in CLAUDE.md commit-settings.md .claudeignore; do
+    # Symlink other shared config files.
+    #
+    # `.full-suite-active` is the probe file written by claude-config's
+    # full-install path (issue #423 contract). Plugin and global hooks read
+    # it from $HOME/.claude/.full-suite-active to gate on whether the host
+    # ran the full installer or only the lite/plugin install. Without
+    # forwarding, container-side hooks would treat every host as lite.
+    # See claude-config docs/CLAUDE_DOCKER_CONTRACT.md for the contract.
+    for item in CLAUDE.md commit-settings.md .claudeignore .full-suite-active; do
         if [ -f "$CONFIG_SOURCE/$item" ]; then
             if [ "$FORCE_LINK" = "true" ] || [ ! -e "$ACCOUNT_DIR/$item" ] || [ ! -s "$ACCOUNT_DIR/$item" ]; then
                 ln -sf "$CONFIG_SOURCE/$item" "$ACCOUNT_DIR/$item"


### PR DESCRIPTION
## What

### Summary

Forward the `.full-suite-active` probe from the host's `~/.claude/` into each container's account state, and document the producer/consumer contract this entrypoint relies on.

### Change Type

- [x] Bugfix (silent misclassification of host install profile inside container)
- [x] Documentation
- [ ] Breaking change

### Affected Files

| File | Lines | Change |
|------|-------|--------|
| `scripts/entrypoint.sh` | +9 / -2 | Add `.full-suite-active` to the symlink loop alongside CLAUDE.md / commit-settings.md / .claudeignore |
| `README.md` | +15 | Prerequisite + version compatibility note; probe row in symlink table; link to the companion contract document |

## Why

### Problem

The companion config repo writes a probe file at `~/.claude/.full-suite-active` (single-line JSON) when its full installer runs. Plugin and global hooks read it via `$HOME/.claude/.full-suite-active` to gate behavior on whether the host has the full suite or only the lite/plugin install (companion repo issue #423).

Inside a container, `$HOME/.claude/` is the per-account state directory, not the host config. The entrypoint already symlinks `CLAUDE.md`, `commit-settings.md`, and `.claudeignore` from `/home/node/.claude-host/` into the account state, but the probe was missing from that loop. Result: every container saw the probe as absent and silently fell back to lite behavior, even when the host had the full suite installed.

### Why now

A new contract document in the companion repo (PR linked below) formalizes the `.full-suite-active` semantics. Forwarding the probe is one of the five invariants that document specifies; closing this gap on the consumer side is the matching half.

### Related

- Companion repo PR adding the formal contract document: kcenon/claude-config#495
- Companion repo issue (probe origin): kcenon/claude-config#423

## Who

### Reviewers
- Anyone maintaining the entrypoint
- Anyone touching the companion repo's installer or hooks (paired contract review)

## When

### Urgency
- [x] Normal — paired with the companion contract PR; should land in the same release window

### Target Release
Next claude-docker release.

## Where

### Files Changed

- `scripts/entrypoint.sh` — single loop modification, no flow changes
- `README.md` — additive: prereq note, version compatibility note, one new table row

### Compatibility

- **Backward compatible**: when `.full-suite-active` is absent on the host (lite install / plugin-only), the loop's `[ -f ... ]` guard skips it and the container keeps the prior behavior.
- **No schema changes** to settings.json or any other generated file.

## How

### Implementation

```diff
-    for item in CLAUDE.md commit-settings.md .claudeignore; do
+    # See companion repo docs/CLAUDE_DOCKER_CONTRACT.md for the contract.
+    for item in CLAUDE.md commit-settings.md .claudeignore .full-suite-active; do
         if [ -f "$CONFIG_SOURCE/$item" ]; then
             if [ "$FORCE_LINK" = "true" ] || [ ! -e "$ACCOUNT_DIR/$item" ] || [ ! -s "$ACCOUNT_DIR/$item" ]; then
                 ln -sf "$CONFIG_SOURCE/$item" "$ACCOUNT_DIR/$item"
             fi
         fi
     done
```

The README update adds:

- A **Prerequisite** callout stating users must run the companion installer on the host before starting any container (containers are pure consumers).
- A **Compatibility** callout stating the v1.10+ target and linking to the contract document.
- A **probe row** in the existing symlink table.

### Testing Done

- [x] `bash -n scripts/entrypoint.sh` — syntax check passes
- [x] Probe present case verified by inspecting the patched loop logic (host has the file ⇒ symlink is created)
- [x] Probe absent case verified by the existing `[ -f ... ]` guard (no file ⇒ no symlink ⇒ prior behavior preserved)

### Breaking Changes

None.

### Rollback

Revert the commit. The container reverts to the prior probe-missing behavior — same as if the host had not installed the full suite.

## Checklist

- [x] No AI/Claude attribution in commit messages, PR title, or PR body
- [x] No emojis in commit messages
- [x] PR targets `develop`
- [x] Conventional Commits format (feat scope=entrypoint)
- [x] Companion PR linked above
- [x] Self-review completed
- [x] No new dependencies
