### PR TITLE
docs: surface TUI dashboard and native installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ per VM) by sharing a single Docker image and bind-mounting the project source.
 - **Shared source code** -- Bind mount (Tier A) or git worktree (Tier B) for concurrent editing
 - **Cross-platform** -- Linux, macOS, Windows (WSL2 or native PowerShell)
 - **Flexible authentication** -- OAuth for Pro/Max/Team subscriptions, or API key for Console
-- **Scalable to N instances** -- Add accounts by copying a compose service block
+- **Scalable to N instances** -- Add accounts by copying a compose service block (up to 702 via Excel-style suffixes)
+- **TUI dashboard** -- A Bubble Tea-based terminal UI (`scripts/claude-docker tui`) for live multi-account monitoring; auto-downloads a signed prebuilt binary from GitHub Releases or builds from source when Go 1.21+ is available
 
 ## Prerequisites
 
@@ -158,6 +159,8 @@ scripts/claude-docker help       # Show all available commands
 | **Interactive** | `claude [service]` | Start Claude Code (default: claude-a) |
 | | `exec <service>` | Open shell in a container |
 | **Usage Tracking** | `usage [type] [flags]` | Token usage report |
+| **Dashboard** | `tui` (alias `dashboard`) | Launch multi-account TUI; auto-downloads a prebuilt binary if missing |
+| | `build-tui` | Rebuild the TUI dashboard binary from source (requires Go 1.21+) |
 | **Advanced** | `config` | Show resolved compose configuration |
 | | `compose ...` | Pass raw args to docker compose |
 
@@ -361,6 +364,25 @@ scripts/claude-docker usage                                  # Daily (default)
 scripts/claude-docker usage monthly                          # Monthly
 scripts/claude-docker usage daily --since 20260301 --json    # Date filter + JSON
 ```
+
+### Multi-account dashboard (TUI)
+
+A Bubble Tea-based terminal dashboard surfaces per-account container state,
+authentication status, recent activity, and live token usage in one view.
+
+```bash
+scripts/claude-docker tui            # Launch dashboard (auto-fetches binary if missing)
+scripts/claude-docker dashboard      # Alias of tui
+scripts/claude-docker build-tui      # Rebuild from source (Go 1.21+)
+```
+
+`tui` first looks for `tui/claude-docker-tui` in the project tree. If it is
+missing, the wrapper calls `download_tui_release` (`scripts/lib/tui-release.sh`)
+to fetch the matching `claude-docker-tui-<os>-<arch>` asset from the latest
+GitHub Release, verifies its `.sha256`, and installs it in place. If neither
+the binary nor `curl` is available, the command falls back to a clear error
+that points operators to `build-tui`. PowerShell users can run
+`.\scripts\claude-docker.ps1 tui` for the same flow.
 
 ### Rebuilding the Image
 
@@ -575,7 +597,13 @@ Requirements section below uses `limits` to size Docker Desktop memory;
 
 The `Dockerfile` pins the Node base image to a specific patch version **and
 content digest** so rebuilds are byte-for-byte reproducible and any upstream
-repush of the tag is caught at build time as a digest mismatch. To bump:
+repush of the tag is caught at build time as a digest mismatch. Inside the
+image, **Claude Code is installed via Anthropic's official native installer**
+(`https://claude.ai/install.sh`), not via npm. The installer places `claude`
+at `/home/node/.local/bin/claude`, so `/doctor` no longer warns about
+"leftover npm global install". Pin a specific Claude Code release with the
+`CLAUDE_CODE_VERSION` build arg (read from `.env`); leave it empty for
+`latest`. To bump:
 
 1. Check <https://hub.docker.com/_/node/tags?name=slim> for the latest 20.x LTS
 2. Capture the digest on a trusted host (**required**, not optional):
@@ -625,7 +653,8 @@ allow all containers to run at peak load.
 ```
 claude-docker/
 +-- .dockerignore                      Docker build context exclusions
-+-- Dockerfile                         Base image
++-- Dockerfile                         Base image (Claude Code installed via Anthropic native installer)
++-- VERSION                            Release tag consumed by docker-compose IMAGE_TAG
 +-- docker-compose.yml                 Generated: base config (Tier A)
 +-- docker-compose.linux.yml           Generated: Linux override
 +-- docker-compose.worktree.yml        Generated: Tier B override
@@ -635,23 +664,36 @@ claude-docker/
 +-- LICENSE                            BSD 3-Clause
 +-- README.md                          This file
 +-- scripts/
-    +-- claude-docker                  CLI wrapper (bash)
-    +-- claude-docker.ps1              CLI wrapper (PowerShell)
-    +-- claude-docker.cmd              CLI wrapper (cmd.exe batch)
-    +-- ClaudeDocker.psm1              Shared PowerShell module
-    +-- generate-compose.sh            Compose file generator (bash)
-    +-- generate-compose.ps1           Compose file generator (PowerShell)
-    +-- entrypoint.sh                 Container init (config symlinks)
-    +-- install.sh                     Interactive setup (bash)
-    +-- install.ps1                    Interactive setup (PowerShell)
-    +-- remove.sh                      Complete removal (bash)
-    +-- remove.ps1                     Complete removal (PowerShell)
-    +-- cleanup.sh                     Quick cleanup (bash)
-    +-- cleanup.ps1                    Quick cleanup (PowerShell)
-    +-- setup-worktrees.sh             Tier B worktree setup (bash)
-    +-- setup-worktrees.ps1            Tier B worktree setup (PowerShell)
-    +-- test-concurrent-git.sh         E2E test (bash)
-    +-- test-concurrent-git.ps1        E2E test (PowerShell)
+|   +-- claude-docker                  CLI wrapper (bash)
+|   +-- claude-docker.ps1              CLI wrapper (PowerShell)
+|   +-- claude-docker.cmd              CLI wrapper (cmd.exe batch)
+|   +-- ClaudeDocker.psm1              Shared PowerShell module
+|   +-- generate-compose.sh            Compose file generator (bash)
+|   +-- generate-compose.ps1           Compose file generator (PowerShell)
+|   +-- entrypoint.sh                  Container init (config symlinks, full-suite probe forwarding)
+|   +-- install.sh                     Interactive setup (bash)
+|   +-- install.ps1                    Interactive setup (PowerShell)
+|   +-- remove.sh                      Complete removal (bash)
+|   +-- remove.ps1                     Complete removal (PowerShell)
+|   +-- cleanup.sh                     Quick cleanup (bash)
+|   +-- cleanup.ps1                    Quick cleanup (PowerShell)
+|   +-- setup-worktrees.sh             Tier B worktree setup (bash)
+|   +-- setup-worktrees.ps1            Tier B worktree setup (PowerShell)
+|   +-- test-concurrent-git.sh         E2E test (bash)
+|   +-- test-concurrent-git.ps1        E2E test (PowerShell)
+|   +-- test-entrypoint-settings.sh    Entrypoint settings normalization test (bash)
+|   +-- lib/
+|       +-- tui-release.sh             Download + SHA256-verify prebuilt TUI binary (bash)
+|       +-- tui-release.ps1            Same, PowerShell port
+|       +-- parse_env.sh               Shared .env parser (bash)
+|       +-- index.sh / index.ps1       Excel-style account index helpers
++-- tui/                               Bubble Tea multi-account dashboard (Go module)
+|   +-- main.go
+|   +-- Makefile
+|   +-- go.mod / go.sum
+|   +-- internal/                      account, auth, config, docker, ui, usage subpackages
++-- tests/                             Hadolint, parse_env, ccstatusline regression tests
+    +-- env_fixtures/
 ```
 
 ## License


### PR DESCRIPTION
## What

Update `README.md` so it documents two recent shifts that already shipped to
the codebase: the Bubble Tea TUI dashboard and the migration of in-image
Claude Code installation to the Anthropic native installer.

### Change Type
- [x] Documentation
- [ ] Feature / Bugfix / Refactor / Test / Chore

### Affected Components
- `README.md` (sole file touched)

## Why

Two non-trivial pieces of operator-visible behaviour landed without a
README pass:

| Code change                                         | Doc state before   |
|-----------------------------------------------------|--------------------|
| `scripts/claude-docker tui` / `build-tui` plus the prebuilt-binary download fallback in `scripts/lib/tui-release.sh` (#229) | TUI not mentioned anywhere in the README |
| `Dockerfile` installs Claude Code via `claude.ai/install.sh`, not npm | "Bumping the Base Image" still implied an npm install |
| `entrypoint.sh` forwards the `.full-suite-active` probe and host config | Project Structure described `entrypoint.sh` only as "config symlinks" |
| `tui/` Go module, `scripts/lib/`, `tests/`, root `VERSION` file | Project Structure tree omitted them entirely |

### Related Issues

No tracking issue. Closes the doc gap created by:

- #229 (prebuilt TUI binary download fallback)
- #228 (forward full-suite probe)
- The Dockerfile migration to the native installer
- #163 / #214 (account scaling > 26)

## Where

| Section | Change |
|---------|--------|
| Features | Adds a TUI dashboard bullet and notes the 702-account ceiling. |
| Usage > Quick Reference | New `Dashboard` rows for `tui` (alias `dashboard`) and `build-tui`. |
| Usage body | New "Multi-account dashboard (TUI)" subsection covering the download + SHA256 verify flow and the Go 1.21+ rebuild path. |
| Bumping the Base Image | Notes that Claude Code is now installed via the Anthropic native installer at `/home/node/.local/bin/claude` and pinned through the `CLAUDE_CODE_VERSION` build arg. |
| Project Structure | Adds `VERSION`, `tui/` (with `internal/` subpackages), `scripts/lib/` (`tui-release.{sh,ps1}`, `parse_env.sh`, `index.{sh,ps1}`), `scripts/test-entrypoint-settings.sh`, and `tests/`. Clarifies `entrypoint.sh` forwards the full-suite probe. |

No code, Dockerfile, compose, or script changes. CI does not run on
develop-targeting PRs (per the branching strategy).

## How

### Verification

- Cross-checked each new claim against:
  - `scripts/claude-docker:595-734` (cmd_tui, cmd_build_tui, dispatch table)
  - `scripts/lib/tui-release.sh` (download_tui_release flow)
  - `Dockerfile` (native installer block, ARG CLAUDE_CODE_VERSION)
  - `scripts/entrypoint.sh` (full-suite probe forwarding)
  - `ls scripts/lib/ tui/ tests/` (Project Structure additions)
- `git diff --stat`: 1 file changed, +62 / -20.

### Test Plan for Reviewers

1. Run `scripts/claude-docker help` and confirm `tui` and `build-tui` are
   listed where the new Quick Reference rows say they are.
2. Confirm `tui/` is a real Go module (`cat tui/go.mod`).
3. Confirm `scripts/lib/tui-release.sh` exposes `download_tui_release` and
   matches the README's description of the SHA256 verification step.
4. Inside the image (`scripts/claude-docker exec claude-a which claude`)
   resolve to `/home/node/.local/bin/claude`, matching the README claim.

### Breaking Changes

None. Documentation only.

### Rollback Plan

Revert this PR. No artifacts emitted.

## Checklist

- [x] Documentation matches current code behaviour
- [x] No AI/Claude attribution added
- [x] Targets `develop` (per the branching strategy)
- [x] No new compose / Dockerfile / scripts changes
