### PR TITLE
test: harden test_parse_env.sh shell options

### DIFF
--- a/tests/test_parse_env.sh
+++ b/tests/test_parse_env.sh
@@ -4,7 +4,7 @@
 # Run:  bash tests/test_parse_env.sh
 # Exits non-zero on any failure; prints a summary at the end.
 
-set -uo pipefail
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"


### PR DESCRIPTION
Closes #234

## Summary
Change `set -uo pipefail` to `set -euo pipefail` in `tests/test_parse_env.sh:7` so command failures inside the test fail the suite immediately instead of being silently ignored.

## Test Plan
- `bash tests/test_parse_env.sh` exits 0 locally
- `grep -n '^set ' tests/test_parse_env.sh` shows `set -euo pipefail`

## Verification
Manual smoke check: inserting a deliberate `false` line into a test case now causes the suite to fail with non-zero exit (verified locally before merge).