### PR TITLE
docs: align README Go version with go.mod and document sources/

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Claude Docker — Environment Configuration
 # Copy this file to .env and edit values.
 
+# Note: install.sh creates .env.backup.<unix_ts> on every run.
+# Use scripts/cleanup.sh --backups (see #235) to remove old copies.
+
 # ==== Required ====
 PROJECT_DIR=/absolute/path/to/your/project
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ per VM) by sharing a single Docker image and bind-mounting the project source.
 - **Cross-platform** -- Linux, macOS, Windows (WSL2 or native PowerShell)
 - **Flexible authentication** -- OAuth for Pro/Max/Team subscriptions, or API key for Console
 - **Scalable to N instances** -- Add accounts by copying a compose service block (up to 702 via Excel-style suffixes)
-- **TUI dashboard** -- A Bubble Tea-based terminal UI (`scripts/claude-docker tui`) for live multi-account monitoring; auto-downloads a signed prebuilt binary from GitHub Releases or builds from source when Go 1.21+ is available
+- **TUI dashboard** -- A Bubble Tea-based terminal UI (`scripts/claude-docker tui`) for live multi-account monitoring; auto-downloads a signed prebuilt binary from GitHub Releases or builds from source when Go 1.24+ is available
 
 ## Prerequisites
 
@@ -160,7 +160,7 @@ scripts/claude-docker help       # Show all available commands
 | | `exec <service>` | Open shell in a container |
 | **Usage Tracking** | `usage [type] [flags]` | Token usage report |
 | **Dashboard** | `tui` (alias `dashboard`) | Launch multi-account TUI; auto-downloads a prebuilt binary if missing |
-| | `build-tui` | Rebuild the TUI dashboard binary from source (requires Go 1.21+) |
+| | `build-tui` | Rebuild the TUI dashboard binary from source (requires Go 1.24+) |
 | **Advanced** | `config` | Show resolved compose configuration |
 | | `compose ...` | Pass raw args to docker compose |
 
@@ -373,7 +373,7 @@ authentication status, recent activity, and live token usage in one view.
 ```bash
 scripts/claude-docker tui            # Launch dashboard (auto-fetches binary if missing)
 scripts/claude-docker dashboard      # Alias of tui
-scripts/claude-docker build-tui      # Rebuild from source (Go 1.21+)
+scripts/claude-docker build-tui      # Rebuild from source (Go 1.24+)
 ```
 
 `tui` first looks for `tui/claude-docker-tui` in the project tree. If it is
@@ -695,6 +695,10 @@ claude-docker/
 +-- tests/                             Hadolint, parse_env, ccstatusline regression tests
     +-- env_fixtures/
 ```
+
+`sources/` contains local nested working directories that are gitignored
+and never copied into the Docker image. They can be removed safely if not
+in use.
 
 ## License
 


### PR DESCRIPTION
Closes #233

## Summary
Three small doc edits driven by drift between README and the actual code:

- README Go version: 1.21+ -> 1.24+ (matches `tui/go.mod`)
- README: brief note on the `sources/` directory (gitignored, not copied into the Docker image)
- .env.example: documents `.env.backup.<unix_ts>` lifecycle, points to scripts/cleanup.sh --backups (see #235)

## Test Plan
- `grep -i 'go 1\.' README.md` shows only 1.24
- `grep -in 'sources/' README.md` returns >=1 match
- `grep -in '.env.backup' .env.example` returns >=1 match