### PR TITLE
chore(cleanup): add --backups flag to remove stale .env.backup.* files

### DIFF
--- a/scripts/cleanup.ps1
+++ b/scripts/cleanup.ps1
@@ -15,12 +15,20 @@
 .PARAMETER SkipState
     Decline state-directory removal non-interactively. Useful in automation
     that only wants container/volume/worktree cleanup.
+.PARAMETER Backups
+    Remove stale .env.backup.* and .env.bak files older than -BackupAgeDays
+    days from the project root. Preserves .env, .env.example, and fresh
+    backups.
+.PARAMETER BackupAgeDays
+    Age threshold in days for -Backups removal. Default: 7.
 #>
 [CmdletBinding()]
 param(
     [string]$RepoDir,
     [Alias('Yes')][switch]$Force,
-    [Alias('No')][switch]$SkipState
+    [Alias('No')][switch]$SkipState,
+    [Alias('B')][switch]$Backups,
+    [int]$BackupAgeDays = 7
 )
 
 if ($Force -and $SkipState) {
@@ -35,6 +43,17 @@ $ProjectRoot = Split-Path $PSScriptRoot -Parent
 Push-Location $ProjectRoot
 
 try {
+    if ($Backups) {
+        Write-Host "=== Removing stale .env backup files (>$BackupAgeDays days) ===" -ForegroundColor Cyan
+        $cutoff = (Get-Date).AddDays(-$BackupAgeDays)
+        Get-ChildItem -Path $ProjectRoot -Filter '.env.backup.*' -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.LastWriteTime -lt $cutoff } |
+            Remove-Item -Force
+        Get-ChildItem -Path $ProjectRoot -Filter '.env.bak' -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.LastWriteTime -lt $cutoff } |
+            Remove-Item -Force
+    }
+
     Write-Host '=== Stopping containers ===' -ForegroundColor Cyan
     & docker compose down --remove-orphans 2>$null
     # Ignore errors if no containers running

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -2,26 +2,40 @@
 # Cleanup containers, worktrees, and state.
 #
 # Usage:
-#   scripts/cleanup.sh [REPO_DIR] [--yes|-y | --no|-n]
+#   scripts/cleanup.sh [REPO_DIR] [--yes|-y | --no|-n] [--backups|-b] [--backup-age-days N]
 #
 # Without --yes or --no, state-directory removal is prompted interactively
 # when stdin is a TTY and aborted (non-zero exit) otherwise, so CI or piped
 # invocations never hang waiting for an answer.
+#
+# When --backups is given, .env.backup.* and .env.bak files older than
+# --backup-age-days (default 7) are deleted from PROJECT_ROOT. Set
+# PROJECT_ROOT_OVERRIDE to redirect the script root for tests.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROJECT_ROOT="${PROJECT_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 cd "$PROJECT_ROOT"
 
 REPO_DIR=""
 CONFIRM="ask"
+RUN_BACKUPS=0
+BACKUP_AGE_DAYS=7
+expect_age_days=0
 for arg in "$@"; do
+    if [ "$expect_age_days" = "1" ]; then
+        BACKUP_AGE_DAYS="$arg"
+        expect_age_days=0
+        continue
+    fi
     case "$arg" in
         --yes|-y) CONFIRM="yes" ;;
         --no|-n)  CONFIRM="no"  ;;
+        --backups|-b) RUN_BACKUPS=1 ;;
+        --backup-age-days) expect_age_days=1 ;;
         -*)
             echo "Unknown option: $arg" >&2
-            echo "Usage: scripts/cleanup.sh [REPO_DIR] [--yes|-y | --no|-n]" >&2
+            echo "Usage: scripts/cleanup.sh [REPO_DIR] [--yes|-y | --no|-n] [--backups|-b] [--backup-age-days N]" >&2
             exit 2
             ;;
         *)
@@ -34,6 +48,38 @@ for arg in "$@"; do
             ;;
     esac
 done
+
+if [ "$expect_age_days" = "1" ]; then
+    echo "Missing value for --backup-age-days" >&2
+    exit 2
+fi
+
+if [ "$RUN_BACKUPS" = "1" ]; then
+    echo "=== Removing stale .env backup files (>${BACKUP_AGE_DAYS} days) ==="
+    BACKUP_CONFIRM="$CONFIRM"
+    if [ "$BACKUP_CONFIRM" = "ask" ]; then
+        if [ -t 0 ]; then
+            read -p "Remove stale .env.backup.* and .env.bak files older than ${BACKUP_AGE_DAYS} days? (y/N) " confirm
+            case "$confirm" in
+                y|Y|yes|YES) BACKUP_CONFIRM="yes" ;;
+                *)           BACKUP_CONFIRM="no"  ;;
+            esac
+        else
+            echo "  Error: stdin is not a TTY. Pass --yes to remove backups non-interactively," >&2
+            echo "         or --no to skip backup removal in automation." >&2
+            exit 1
+        fi
+    fi
+    if [ "$BACKUP_CONFIRM" = "yes" ]; then
+        find "$PROJECT_ROOT" -maxdepth 1 \
+            \( -name ".env.backup.*" -o -name ".env.bak" \) \
+            -mtime +"${BACKUP_AGE_DAYS}" \
+            -print -delete 2>/dev/null || true
+        echo "  Stale backups removed."
+    else
+        echo "  Skipped."
+    fi
+fi
 
 echo "=== Stopping containers ==="
 docker compose down --remove-orphans 2>/dev/null || true

--- a/tests/test_cleanup_backups.sh
+++ b/tests/test_cleanup_backups.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# test_cleanup_backups.sh — Verifies scripts/cleanup.sh --backups flag.
+#
+# Run:  bash tests/test_cleanup_backups.sh
+# Exits non-zero on any failure; prints a summary at the end.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLEANUP="$PROJECT_ROOT/scripts/cleanup.sh"
+
+PASS=0
+FAIL=0
+
+assert_missing() {
+    local label="$1" path="$2"
+    if [ ! -e "$path" ]; then
+        printf '  PASS  %s\n' "$label"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL  %s\n        expected missing: %s\n' "$label" "$path"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_present() {
+    local label="$1" path="$2"
+    if [ -e "$path" ]; then
+        printf '  PASS  %s\n' "$label"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL  %s\n        expected present: %s\n' "$label" "$path"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        printf '  PASS  %s\n' "$label"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL  %s\n        expected: %q\n        actual:   %q\n' \
+            "$label" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+TMPDIR_FAKE_ROOT="$(mktemp -d)"
+cleanup_tmp() {
+    rm -rf "$TMPDIR_FAKE_ROOT"
+}
+trap cleanup_tmp EXIT
+
+# Build the fake project root.
+ENV_FILE="$TMPDIR_FAKE_ROOT/.env"
+ENV_EXAMPLE="$TMPDIR_FAKE_ROOT/.env.example"
+OLD_BACKUP="$TMPDIR_FAKE_ROOT/.env.backup.1234567890"
+RECENT_BACKUP="$TMPDIR_FAKE_ROOT/.env.backup.9999999999"
+OLD_BAK="$TMPDIR_FAKE_ROOT/.env.bak"
+
+printf 'KEY=value\n' > "$ENV_FILE"
+printf 'KEY=example\n' > "$ENV_EXAMPLE"
+printf 'KEY=old\n' > "$OLD_BACKUP"
+printf 'KEY=fresh\n' > "$RECENT_BACKUP"
+printf 'KEY=oldbak\n' > "$OLD_BAK"
+
+# Mark old files 30 days in the past, leave fresh backup at current mtime.
+# Use `touch -d` (GNU/BSD-portable form).
+touch -d "30 days ago" "$OLD_BACKUP" "$OLD_BAK"
+
+echo "== Pre-check: fixture layout =="
+assert_present ".env exists"               "$ENV_FILE"
+assert_present ".env.example exists"       "$ENV_EXAMPLE"
+assert_present "old .env.backup.* exists"  "$OLD_BACKUP"
+assert_present "fresh .env.backup.* exists" "$RECENT_BACKUP"
+assert_present ".env.bak exists"           "$OLD_BAK"
+
+echo "== Running: cleanup.sh --backups --yes --backup-age-days 7 =="
+# --yes accepts both backup deletion and state-directory removal without
+# prompting. HOME is redirected to a sandboxed temp dir so the real
+# ~/.claude-state is never touched by the test. PROJECT_ROOT_OVERRIDE
+# redirects the script to the temp fixture root.
+# docker compose calls error harmlessly to /dev/null inside cleanup.sh.
+FAKE_HOME="$(mktemp -d)"
+HOME="$FAKE_HOME" PROJECT_ROOT_OVERRIDE="$TMPDIR_FAKE_ROOT" \
+    bash "$CLEANUP" --backups --yes --backup-age-days 7 >/dev/null 2>&1 || true
+rm -rf "$FAKE_HOME"
+
+echo "== Post-conditions =="
+assert_missing "old .env.backup.* deleted" "$OLD_BACKUP"
+assert_missing "old .env.bak deleted"      "$OLD_BAK"
+assert_present "fresh .env.backup.* kept"  "$RECENT_BACKUP"
+assert_present ".env preserved"            "$ENV_FILE"
+assert_present ".env.example preserved"    "$ENV_EXAMPLE"
+
+# Content sanity check on preserved files.
+assert_eq ".env content unchanged"         "KEY=value"   "$(cat "$ENV_FILE")"
+assert_eq ".env.example content unchanged" "KEY=example" "$(cat "$ENV_EXAMPLE")"
+assert_eq "fresh backup content unchanged" "KEY=fresh"   "$(cat "$RECENT_BACKUP")"
+
+echo
+echo "== Summary: PASS=$PASS FAIL=$FAIL =="
+if (( FAIL > 0 )); then
+    exit 1
+fi


### PR DESCRIPTION
Closes #235

## Summary
Adds `--backups` (`-b`) to `scripts/cleanup.sh` and `-Backups` to `scripts/cleanup.ps1` so users can purge stale `.env.backup.<timestamp>` and `.env.bak` files generated by repeated `install.sh` runs.

- Default age threshold: 7 days, override via `--backup-age-days N` / `-BackupAgeDays`
- Honors existing `--yes` / `-y` to skip confirmation
- Preserves `.env`, `.env.example`, and fresh backups
- New test `tests/test_cleanup_backups.sh` covers both age cases

## Test Plan
- `bash tests/test_cleanup_backups.sh` exits 0
- `bash tests/test_parse_env.sh` still exits 0 (no regression)
- Manual: create `.env.backup.0001` with mtime 30 days ago -> run `cleanup.sh --backups --yes` -> file removed
- Manual: create `.env.backup.0001` with current mtime -> run -> file kept