### PR TITLE
ci: restore bash and PowerShell test jobs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,34 @@ jobs:
         run: bash scripts/generate-compose.sh
       - name: Validate compose
         run: docker compose config > /dev/null
+
+  bash-tests:
+    name: Bash Tests (${{ matrix.test }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - tests/test_ccstatusline_xdg_symlink.sh
+          - tests/test_parse_env.sh
+          - tests/test_transform_syntax_check.sh
+          - tests/test_cleanup_backups.sh
+          - scripts/test-entrypoint-settings.sh
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Run ${{ matrix.test }}
+        run: bash "${{ matrix.test }}"
+
+  pwsh-tests:
+    name: PowerShell Tests (${{ matrix.test }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - tests/test_parse_env.ps1
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Run ${{ matrix.test }}
+        shell: pwsh
+        run: pwsh -NoProfile -File "${{ matrix.test }}"

--- a/scripts/test-entrypoint-settings.sh
+++ b/scripts/test-entrypoint-settings.sh
@@ -9,7 +9,20 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CLAUDE_CONFIG="${1:-$(cd "$SCRIPT_DIR/../.." && pwd)/claude-config/global}"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Resolution order:
+#   1. Explicit positional argument (developer override).
+#   2. CI fixture under tests/entrypoint_fixtures/global when running in
+#      GitHub Actions, where claude-config/ is not checked out alongside
+#      the project (issue #232).
+#   3. Default ../claude-config/global relative to repo (developer host).
+if [ -n "${1:-}" ]; then
+    CLAUDE_CONFIG="$1"
+elif [ -n "${GITHUB_ACTIONS:-}" ] && [ -d "$PROJECT_ROOT/tests/entrypoint_fixtures/global" ]; then
+    CLAUDE_CONFIG="$PROJECT_ROOT/tests/entrypoint_fixtures/global"
+else
+    CLAUDE_CONFIG="$(cd "$SCRIPT_DIR/../.." && pwd)/claude-config/global"
+fi
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/tests/entrypoint_fixtures/global/settings.json
+++ b/tests/entrypoint_fixtures/global/settings.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "description": "Minimal macOS-style fixture for test-entrypoint-settings.sh",
+  "sandbox": {
+    "enabled": true
+  },
+  "permissions": {
+    "defaultMode": "default",
+    "deny": [
+      "Read(./.env*)",
+      "Read(./secrets/**)",
+      "Read(./.aws/credentials)",
+      "Bash(rm -rf /)"
+    ]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "pwsh -NoProfile -File ~/.claude/scripts/statusline-command.ps1"
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/conflict-guard.ps1",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/entrypoint_fixtures/global/settings.windows.json
+++ b/tests/entrypoint_fixtures/global/settings.windows.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "description": "Minimal Windows-style fixture for test-entrypoint-settings.sh",
+  "sandbox": {
+    "enabled": true
+  },
+  "permissions": {
+    "defaultMode": "default",
+    "deny": [
+      "Read(./.env*)",
+      "Read(./secrets/**)",
+      "Read(./.aws/credentials)",
+      "Bash(rm -rf /)"
+    ]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "pwsh.exe -NoProfile -ExecutionPolicy Bypass -File ~/.claude/scripts/statusline-command.ps1"
+  },
+  "hooks": {
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -Command \"& ~/.claude/hooks/session-logger.ps1 end; & ~/.claude/hooks/cleanup.ps1\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #232

## Summary
Adds `bash-tests` and `pwsh-tests` matrix jobs to `.github/workflows/ci.yml` so the test files that already exist on disk actually run on every push and PR. Previously CI only ran shellcheck, hadolint, psanalyzer, go-test, and compose-validate.

### What runs now
- bash matrix: 5 files
  - `tests/test_ccstatusline_xdg_symlink.sh`
  - `tests/test_parse_env.sh`
  - `tests/test_transform_syntax_check.sh`
  - `tests/test_cleanup_backups.sh` (added in PR #238)
  - `scripts/test-entrypoint-settings.sh`
- pwsh matrix: 1 file
  - `tests/test_parse_env.ps1`

### Excluded from this PR (with rationale)
- `scripts/test-concurrent-git.sh` and `scripts/test-concurrent-git.ps1` are end-to-end Tier B integration tests that build the project Docker image and run docker compose with the worktree overlay across N containers. Building the image alone adds several minutes per run and these tests are sensitive to docker compose timing. Wiring them into the unit-test matrix would slow every PR while masking failures behind container start-up flakiness. They are better served by a dedicated heavyweight CI job in a follow-up issue. The acceptance criteria for #232 (regression safety net for the on-disk tests) is satisfied without them, since the bugs they cover (concurrent git in worktrees) are guarded by existing shell-level isolation.

### Fixture
`scripts/test-entrypoint-settings.sh` previously skipped silently in CI because it depended on host paths (`claude-config/global`) that don't exist in the runner. Added `tests/entrypoint_fixtures/global/{settings,settings.windows}.json` containing only the minimum keys the test asserts on (sandbox, permissions.deny with both glob and non-glob entries, statusLine, conflict-guard hook on macOS only, SessionEnd compound command on Windows). The script now resolves the fixture path automatically when `GITHUB_ACTIONS` is set; explicit positional arg and the existing host fallback are preserved.

## Test Plan
- Local: each of the 5 bash files runs green
- Local: `GITHUB_ACTIONS=true bash scripts/test-entrypoint-settings.sh` exits 0 with 17/17 assertions ran (no SKIPs)
- CI: both new jobs appear and pass on this PR

## Notes
All new `uses:` lines reuse the SHA-pinned `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2` already present in ci.yml from PR #239.