### PR TITLE
fix(tui): correct dashboard multi-byte padding and forward WindowSizeMsg

### DIFF
--- a/tui/internal/ui/app.go
+++ b/tui/internal/ui/app.go
@@ -50,7 +50,9 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.width = msg.Width
 		a.height = msg.Height
 		a.dashboard.SetSize(msg.Width, msg.Height-4) // reserve space for header
-		return a, nil
+		var cmd tea.Cmd
+		a.dashboard, cmd = a.dashboard.Update(msg)
+		return a, cmd
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "q", "ctrl+c":

--- a/tui/internal/ui/dashboard/model.go
+++ b/tui/internal/ui/dashboard/model.go
@@ -616,10 +616,11 @@ func renderAccountTable(accounts []account.Account, cursor int, width int) strin
 }
 
 func padPlain(s string, width int) string {
-	if len(s) >= width {
+	visual := lipgloss.Width(s)
+	if visual >= width {
 		return s
 	}
-	return s + strings.Repeat(" ", width-len(s))
+	return s + strings.Repeat(" ", width-visual)
 }
 
 func padStyled(text string, width int, style lipgloss.Style) string {

--- a/tui/internal/ui/dashboard/model_test.go
+++ b/tui/internal/ui/dashboard/model_test.go
@@ -1,0 +1,37 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestPadPlainAscii(t *testing.T) {
+	got := padPlain("hello", 10)
+	if w := lipgloss.Width(got); w != 10 {
+		t.Fatalf("ascii: visual width = %d, want 10", w)
+	}
+}
+
+func TestPadPlainHangul(t *testing.T) {
+	// "한글" is 2 runes, each 2 columns wide -> visual width 4
+	got := padPlain("한글", 10)
+	if w := lipgloss.Width(got); w != 10 {
+		t.Fatalf("hangul: visual width = %d, want 10", w)
+	}
+}
+
+func TestPadPlainMixed(t *testing.T) {
+	got := padPlain("hi 한", 10)
+	if w := lipgloss.Width(got); w != 10 {
+		t.Fatalf("mixed: visual width = %d, want 10", w)
+	}
+}
+
+func TestPadPlainAlreadyWide(t *testing.T) {
+	s := "hello world"
+	got := padPlain(s, 5)
+	if got != s {
+		t.Fatalf("over-width: returned %q, want unchanged", got)
+	}
+}


### PR DESCRIPTION
Closes #241

## Summary
Two related TUI rendering defects affecting users whose terminals show multi-byte characters (Hangul, CJK, emoji):

- `padPlain` (and transitively `padStyled`) used `len(s)` for column-width math instead of `lipgloss.Width(s)`. The same file already uses `lipgloss.Width` correctly at line 631; this fix makes the file internally consistent.
- `app.go` forwarded `WindowSizeMsg` to dashboard via `SetSize` only, not via `Update`. Sub-components inside dashboard could not react to resize directly. Now forwarded via both.

## Why
Users with Hangul in their host username, project path, or account fields see misaligned dashboard rows and frame-to-frame residue, regardless of locale or TERM. The TUI binary runs on the host (`scripts/claude-docker:600,607`), so this was never a docker / PTY / locale issue.

## Test Plan
- `cd tui && go build ./...` passes
- `cd tui && go test ./...` passes (including new `padPlain` tests for ASCII, Hangul, mixed, already-wide)
- `grep -nE 'strings\.Repeat\(" ", .*-len\(' tui/internal/ui/` returns no matches
- Manual: run `scripts/claude-docker tui` with Hangul-bearing rows; alignment is stable across redraws