### PR TITLE
docs(env): document secret rotation and backup policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,17 @@
 # Claude Docker — Environment Configuration
 # Copy this file to .env and edit values.
 
-# Note: install.sh creates .env.backup.<unix_ts> on every run.
-# Use scripts/cleanup.sh --backups (see #235) to remove old copies.
+# === Secrets and rotation ===
+# The following fields are secrets and should be rotated regularly:
+#   - CLAUDE_API_KEY_A / CLAUDE_API_KEY_B (Claude Console; mapped to
+#     ANTHROPIC_API_KEY at container runtime)
+#   - GH_TOKEN                            (GitHub CLI token)
+# Recommended rotation cadence: every 90 days for production keys.
+#
+# install.sh creates .env.backup.<unix_ts> on every run, capturing the
+# previous secret values in plaintext. Remove stale backups with:
+#   scripts/cleanup.sh --backups [--backup-age-days N]   (default: 7 days)
+# See tests/test_cleanup_backups.sh for verified cleanup behavior.
 
 # ==== Required ====
 PROJECT_DIR=/absolute/path/to/your/project


### PR DESCRIPTION
Closes #245

## Summary
Adds a documentation block at the top of `.env.example` covering:

- Which fields are secrets (`CLAUDE_API_KEY_A` / `CLAUDE_API_KEY_B` mapped to `ANTHROPIC_API_KEY` at container runtime, and `GH_TOKEN`)
- Recommended rotation cadence (90 days)
- `.env.backup.<unix_ts>` lifecycle (created by `install.sh` on every run)
- How to remove stale backups via `scripts/cleanup.sh --backups [--backup-age-days N]` (added in PR #238)
- Reference to `tests/test_cleanup_backups.sh` for verified cleanup behavior

The existing single-line note from PR #237 is integrated into the new block to avoid duplication.

## Test Plan
- `grep -in 'rotation' .env.example` returns matches
- `grep -in 'backup' .env.example` returns >=2 matches
- `grep -in 'scripts/cleanup.sh' .env.example` returns match
- `bash -n .env.example` exits 0 (file remains valid shell-style env)