### PR TITLE
security(install): replace nodesource curl pipe with signed apt source

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -363,7 +363,17 @@ install_prerequisite() {
                         log_warn "Added $USER to docker group. You may need to log out and back in."
                         ;;
                     node)
-                        curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+                        # NodeSource keyring + signed apt source (replaces 'curl | sudo bash').
+                        # NodeSource GPG fingerprint: 9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280
+                        # Verify periodically against https://github.com/nodesource/distributions
+                        local keyring="/etc/apt/keyrings/nodesource.gpg"
+                        sudo install -m 0755 -d /etc/apt/keyrings
+                        curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+                            | sudo gpg --dearmor -o "$keyring"
+                        sudo chmod a+r "$keyring"
+                        echo "deb [signed-by=$keyring] https://deb.nodesource.com/node_20.x nodistro main" \
+                            | sudo tee /etc/apt/sources.list.d/nodesource.list >/dev/null
+                        sudo apt-get update -qq
                         sudo apt-get install -y -qq nodejs
                         ;;
                     git) sudo apt-get install -y -qq git ;;


### PR DESCRIPTION
Closes #251

## Summary
Replaces the unsigned `curl ... | sudo bash` Node.js install pattern in `scripts/install.sh` with the NodeSource-recommended modern flow: GPG keyring at `/etc/apt/keyrings/nodesource.gpg`, an apt source line with `signed-by=`, then `apt-get install nodejs`. The fingerprint (9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280) is documented inline.

## Why
The previous flow piped a remote shell script to sudo bash with no integrity verification. A NodeSource compromise or build-time MITM would yield root on every dev machine running install.sh.

## Trade-off
Slightly more verbose (5 commands instead of 2), but auditable in code review and resistant to upstream tampering.

## Test Plan
- `bash -n scripts/install.sh` exits 0
- CI `shellcheck` job passes
- `grep -nE 'curl[^|]*nodesource.*\|.*sudo bash' scripts/install.sh` returns no matches
- Manual: a reviewer runs the new flow on a clean Ubuntu/Debian VM and verifies node 20.x installs without errors

## Local verification skipped
This environment lacks apt-get / root, so end-to-end install was not run locally. Reviewer SHOULD smoke test on a fresh VM before merging.