### PR TITLE
refactor(scripts): extract build_compose_cmd to shared library

### DIFF
--- a/scripts/claude-docker
+++ b/scripts/claude-docker
@@ -48,6 +48,8 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 . "$SCRIPT_DIR/lib/parse_env.sh"
 # shellcheck source=lib/index.sh
 . "$SCRIPT_DIR/lib/index.sh"
+# shellcheck source=lib/build-compose-cmd.sh
+. "$SCRIPT_DIR/lib/build-compose-cmd.sh"
 
 # --- Compose Command Builder --------------------------------------------------
 
@@ -58,32 +60,10 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 # 1. Base docker-compose.yml is always included
 # 2. docker-compose.linux.yml is added on Linux hosts when the file exists
 # 3. docker-compose.worktree.yml is added when .env declares PROJECT_DIR_A
+#
+# build_compose_cmd() itself lives in lib/build-compose-cmd.sh (sourced above).
 COMPOSE_CMD=()
 COMPOSE_CMD_INITIALIZED=0
-
-build_compose_cmd() {
-    COMPOSE_CMD=(docker compose -f "${PROJECT_ROOT}/docker-compose.yml")
-
-    # Linux override: auto-detect platform
-    if [[ "$(uname -s)" == "Linux" ]] && [[ -f "${PROJECT_ROOT}/docker-compose.linux.yml" ]]; then
-        COMPOSE_CMD+=(-f "${PROJECT_ROOT}/docker-compose.linux.yml")
-        # Export UID/GID for linux override
-        export UID GID
-        UID=$(id -u)
-        GID=$(id -g)
-    fi
-
-    # Worktree override: check if PROJECT_DIR_A is set in .env
-    if [[ -f "${PROJECT_ROOT}/.env" ]]; then
-        local pdir_a
-        pdir_a=$(parse_env_value "${PROJECT_ROOT}/.env" "PROJECT_DIR_A")
-        if [[ -n "$pdir_a" ]] && [[ -f "${PROJECT_ROOT}/docker-compose.worktree.yml" ]]; then
-            COMPOSE_CMD+=(-f "${PROJECT_ROOT}/docker-compose.worktree.yml")
-        fi
-    fi
-
-    COMPOSE_CMD_INITIALIZED=1
-}
 
 # Ensure COMPOSE_CMD is populated. Idempotent — safe to call from every subcommand.
 ensure_compose_cmd() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -73,6 +73,8 @@ log_step()    { CURRENT_STEP=$((CURRENT_STEP + 1)); echo -e "\n${BOLD}[$CURRENT_
 . "$SCRIPT_DIR/lib/parse_env.sh"
 # shellcheck source=lib/index.sh
 . "$SCRIPT_DIR/lib/index.sh"
+# shellcheck source=lib/build-compose-cmd.sh
+. "$SCRIPT_DIR/lib/build-compose-cmd.sh"
 
 prompt_select() {
     local question="$1"
@@ -914,21 +916,14 @@ setup_worktrees() {
 
 # Populate the global COMPOSE_CMD array with `docker compose -f ...` so
 # callers invoke it as `"${COMPOSE_CMD[@]}" up -d` instead of building and
-# eval'ing a string. Matches the pattern already used by
-# scripts/claude-docker (see build_compose_cmd there). Array form preserves
-# quoting of paths containing spaces, which was the source of issue #155.
+# eval'ing a string. Array form preserves quoting of paths containing spaces,
+# which was the source of issue #155.
+#
+# build_compose_cmd() itself lives in lib/build-compose-cmd.sh (sourced near
+# the top of this script). It drives overlay selection from `uname -s` plus
+# the file-existence of the overlay files plus .env state for PROJECT_DIR_A,
+# matching the canonical logic in scripts/claude-docker.
 COMPOSE_CMD=()
-build_compose_cmd() {
-    COMPOSE_CMD=(docker compose -f "${PROJECT_ROOT}/docker-compose.yml")
-
-    if [[ "$PLATFORM" == "linux" ]]; then
-        COMPOSE_CMD+=(-f "${PROJECT_ROOT}/docker-compose.linux.yml")
-    fi
-
-    if [[ "$TIER" == "B" ]]; then
-        COMPOSE_CMD+=(-f "${PROJECT_ROOT}/docker-compose.worktree.yml")
-    fi
-}
 
 # --- Container Startup --------------------------------------------------------
 

--- a/scripts/lib/build-compose-cmd.sh
+++ b/scripts/lib/build-compose-cmd.sh
@@ -51,5 +51,10 @@ build_compose_cmd() {
         fi
     fi
 
+    # COMPOSE_CMD_INITIALIZED is consumed by callers (scripts/claude-docker
+    # ensure_compose_cmd) — it lets idempotent wrappers skip rebuilding the
+    # array on subsequent invocations from the same shell. Not used inside
+    # this lib, so silence shellcheck's local-only scan.
+    # shellcheck disable=SC2034
     COMPOSE_CMD_INITIALIZED=1
 }

--- a/scripts/lib/build-compose-cmd.sh
+++ b/scripts/lib/build-compose-cmd.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# build-compose-cmd.sh — Shared compose-overlay logic for bash callers.
+#
+# Source this file, then call `build_compose_cmd`. The function populates
+# the global COMPOSE_CMD array with `docker compose -f ...` based on:
+#   1. Always: docker-compose.yml
+#   2. Linux + docker-compose.linux.yml exists: add linux overlay,
+#      export UID/GID
+#   3. .env declares PROJECT_DIR_A AND docker-compose.worktree.yml exists:
+#      add worktree overlay
+#
+# Inputs: PROJECT_ROOT must be set in the caller's environment.
+# Output: COMPOSE_CMD array (caller can invoke as "${COMPOSE_CMD[@]}" up -d)
+#
+# Requires: scripts/lib/parse_env.sh sourced before this file.
+
+# Guard against double-sourcing.
+if [[ -n "${_CLAUDE_DOCKER_BUILD_COMPOSE_CMD_SH_SOURCED:-}" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+_CLAUDE_DOCKER_BUILD_COMPOSE_CMD_SH_SOURCED=1
+
+# build_compose_cmd
+# Populate the global COMPOSE_CMD array with the full `docker compose -f ...`
+# invocation. Array form preserves quoting of paths containing whitespace.
+#
+# Overlay selection logic (canonical):
+#   1. Base docker-compose.yml is always included.
+#   2. docker-compose.linux.yml is added on Linux hosts when the file exists;
+#      UID/GID are exported for the Linux override to consume.
+#   3. docker-compose.worktree.yml is added when .env declares PROJECT_DIR_A
+#      and the worktree compose file exists.
+build_compose_cmd() {
+    COMPOSE_CMD=(docker compose -f "${PROJECT_ROOT}/docker-compose.yml")
+
+    # Linux override: auto-detect platform via uname.
+    if [[ "$(uname -s)" == "Linux" ]] && [[ -f "${PROJECT_ROOT}/docker-compose.linux.yml" ]]; then
+        COMPOSE_CMD+=(-f "${PROJECT_ROOT}/docker-compose.linux.yml")
+        # Export UID/GID for the linux override file.
+        export UID GID
+        UID=$(id -u)
+        GID=$(id -g)
+    fi
+
+    # Worktree override: drive selection from .env state, not caller-local vars.
+    if [[ -f "${PROJECT_ROOT}/.env" ]]; then
+        local pdir_a
+        pdir_a=$(parse_env_value "${PROJECT_ROOT}/.env" "PROJECT_DIR_A")
+        if [[ -n "$pdir_a" ]] && [[ -f "${PROJECT_ROOT}/docker-compose.worktree.yml" ]]; then
+            COMPOSE_CMD+=(-f "${PROJECT_ROOT}/docker-compose.worktree.yml")
+        fi
+    fi
+
+    COMPOSE_CMD_INITIALIZED=1
+}

--- a/tui/internal/docker/compose.go
+++ b/tui/internal/docker/compose.go
@@ -2,21 +2,44 @@
 package docker
 
 import (
+	"errors"
+	"io/fs"
+	"os"
 	"path/filepath"
 	"runtime"
 
 	"github.com/kcenon/claude-docker/tui/internal/config"
 )
 
+// fileExists reports whether path resolves to an existing file or directory.
+// Errors other than ErrNotExist (permission denied, etc.) are treated as
+// "exists" so that the caller does not silently skip an overlay that the
+// user actually placed on disk.
+func fileExists(path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		return !errors.Is(err, fs.ErrNotExist)
+	}
+	return true
+}
+
 // BuildComposeArgs replicates the overlay logic from scripts/claude-docker.
-// Adds docker-compose.linux.yml on Linux, docker-compose.worktree.yml when PROJECT_DIR_A is set.
+// Adds docker-compose.linux.yml on Linux only when the file exists, and
+// docker-compose.worktree.yml when PROJECT_DIR_A is set and the worktree
+// override file exists. The file-existence checks match the canonical bash
+// implementation in scripts/lib/build-compose-cmd.sh.
 func BuildComposeArgs(projectRoot string, env *config.Env) []string {
 	args := []string{"compose", "-f", filepath.Join(projectRoot, "docker-compose.yml")}
 	if runtime.GOOS == "linux" {
-		args = append(args, "-f", filepath.Join(projectRoot, "docker-compose.linux.yml"))
+		linuxOverlay := filepath.Join(projectRoot, "docker-compose.linux.yml")
+		if fileExists(linuxOverlay) {
+			args = append(args, "-f", linuxOverlay)
+		}
 	}
 	if env != nil && env.HasWorktrees() {
-		args = append(args, "-f", filepath.Join(projectRoot, "docker-compose.worktree.yml"))
+		worktreeOverlay := filepath.Join(projectRoot, "docker-compose.worktree.yml")
+		if fileExists(worktreeOverlay) {
+			args = append(args, "-f", worktreeOverlay)
+		}
 	}
 	return args
 }

--- a/tui/internal/docker/docker_test.go
+++ b/tui/internal/docker/docker_test.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -9,25 +10,42 @@ import (
 	"github.com/kcenon/claude-docker/tui/internal/config"
 )
 
+// containsArg returns true if want appears anywhere in args.
+func containsArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+// writeFile creates an empty file at path so the file-existence check passes.
+func writeFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte{}, 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+}
+
 // TestBuildComposeArgs verifies the base compose file is always present and
 // that the Linux overlay and worktree overlay are added under the right
-// conditions. CI runs on Linux so the Linux branch always fires there;
-// we still assert the OS-conditional logic explicitly so the test passes
-// on macOS/Windows local runs too.
+// conditions when the corresponding files exist on disk. CI runs on Linux so
+// the Linux branch always fires there; we still assert the OS-conditional
+// logic explicitly so the test passes on macOS/Windows local runs too.
 func TestBuildComposeArgs(t *testing.T) {
-	root := "/tmp/proj"
+	root := t.TempDir()
 	baseFile := filepath.Join(root, "docker-compose.yml")
 	linuxFile := filepath.Join(root, "docker-compose.linux.yml")
 	worktreeFile := filepath.Join(root, "docker-compose.worktree.yml")
 
-	containsArg := func(args []string, want string) bool {
-		for _, a := range args {
-			if a == want {
-				return true
-			}
-		}
-		return false
-	}
+	// Pre-create the overlay files so the file-existence checks pass for the
+	// scenarios that exercise the "overlay should be added" path. The base
+	// compose path itself is not stat'd by BuildComposeArgs; it is always
+	// included regardless of whether the file exists on disk, matching the
+	// canonical bash implementation.
+	writeFile(t, linuxFile)
+	writeFile(t, worktreeFile)
 
 	t.Run("base only nil env", func(t *testing.T) {
 		args := BuildComposeArgs(root, nil)
@@ -59,6 +77,41 @@ func TestBuildComposeArgs(t *testing.T) {
 		args := BuildComposeArgs(root, env)
 		if !containsArg(args, worktreeFile) {
 			t.Errorf("worktree file %q missing in %v", worktreeFile, args)
+		}
+	})
+}
+
+// TestBuildComposeArgs_FileMissing verifies the file-existence check: when
+// an overlay file is not present on disk, BuildComposeArgs must omit the
+// corresponding `-f` argument even if the host conditions (Linux / worktree
+// env) would otherwise select it. This matches the canonical bash logic
+// in scripts/lib/build-compose-cmd.sh.
+func TestBuildComposeArgs_FileMissing(t *testing.T) {
+	root := t.TempDir()
+	baseFile := filepath.Join(root, "docker-compose.yml")
+	linuxFile := filepath.Join(root, "docker-compose.linux.yml")
+	worktreeFile := filepath.Join(root, "docker-compose.worktree.yml")
+	// Deliberately do NOT create linuxFile or worktreeFile — only the empty
+	// temp dir exists. The base file is also absent; the bash canonical
+	// version does not stat the base file either, so neither does the Go
+	// port: the base path is unconditionally included.
+
+	t.Run("linux overlay omitted when file missing", func(t *testing.T) {
+		args := BuildComposeArgs(root, nil)
+		if !containsArg(args, baseFile) {
+			t.Errorf("base file %q should always be present in %v", baseFile, args)
+		}
+		if containsArg(args, linuxFile) {
+			t.Errorf("linux overlay %q must be omitted when file does not exist (args=%v)", linuxFile, args)
+		}
+	})
+
+	t.Run("worktree overlay omitted when file missing even with PROJECT_DIR_A", func(t *testing.T) {
+		env := config.NewEmptyEnv(filepath.Join(root, ".env"))
+		env.Set("PROJECT_DIR_A", "/some/path")
+		args := BuildComposeArgs(root, env)
+		if containsArg(args, worktreeFile) {
+			t.Errorf("worktree overlay %q must be omitted when file does not exist (args=%v)", worktreeFile, args)
 		}
 	})
 }


### PR DESCRIPTION
Closes #244

## Summary
Three drift-prone copies of compose-overlay logic consolidated into one canonical implementation.

### Bash
- New shared lib: `scripts/lib/build-compose-cmd.sh` (canonical: file-existence checks + .env-driven PROJECT_DIR_A detection + UID/GID export on Linux).
- `scripts/claude-docker` and `scripts/install.sh` source the new lib instead of inlining.
- install.sh no longer relies on `PLATFORM` and `TIER` for overlay decisions; .env state and file presence drive the choice. install.sh already calls `set_env_value PROJECT_DIR_A` inside `setup_worktrees` before `start_containers` invokes `build_compose_cmd`, so the ordering is preserved without changes.

### Go
- `tui/internal/docker/compose.go` BuildComposeArgs gains file-existence checks (uses os.Stat + errors.Is(fs.ErrNotExist)) for behavioral parity.
- New unit test `TestBuildComposeArgs_FileMissing` in `tui/internal/docker/docker_test.go` covering file-exists vs file-missing using `t.TempDir()`. Existing `TestBuildComposeArgs` migrated to a temp dir with the overlay files pre-created so its existing assertions still hold under the new file-existence semantics.

## Out of scope
`scripts/remove.sh` also contains a copy of `build_compose_cmd`, but its policy is deliberately wider: it always adds the worktree overlay if the file exists on disk regardless of `.env` content, so the `down --remove-orphans -v` sweep catches containers from any prior configuration. The issue body explicitly enumerated three implementations (claude-docker, install.sh, Go port), so consolidating remove.sh is left for a follow-up that can decide whether to add a second helper to the shared lib or to source the canonical helper plus apply a remove-time policy override.

## Test Plan
- `grep -rn 'build_compose_cmd()' scripts/` returns the new lib plus the deliberate remove.sh copy noted above.
- `bash -n` syntax passes on all three modified bash files.
- shellcheck job green on the new lib and modified files.
- go-test job green including the new file-existence tests.
- bash-tests matrix continues to pass (no fixture-related regressions).

## Risk
install.sh's overlay choice now depends on .env state at the moment build_compose_cmd is called. The script already calls set_env_value before the compose invocation, so order is preserved; this PR does not reorder anything.
