### PR TITLE
perf(tui): cache parsed JSONL sessions by size+mtime

### DIFF
--- a/tui/internal/account/manager.go
+++ b/tui/internal/account/manager.go
@@ -12,17 +12,23 @@ import (
 	"github.com/kcenon/claude-docker/tui/internal/auth"
 	"github.com/kcenon/claude-docker/tui/internal/config"
 	"github.com/kcenon/claude-docker/tui/internal/docker"
+	"github.com/kcenon/claude-docker/tui/internal/usage"
 )
 
 // Manager provides CRUD operations on accounts.
 type Manager struct {
 	env    *config.Env
 	client *docker.Client
+	// usageCache memoizes parsed JSONL session files across ListAccounts
+	// calls. Unchanged files (same size+mtime) are returned from the cache
+	// instead of being re-read and re-decoded, which keeps refresh cost
+	// proportional to changed data rather than total accumulated history.
+	usageCache *usage.Cache
 }
 
 // NewManager creates an account manager.
 func NewManager(env *config.Env, client *docker.Client) *Manager {
-	return &Manager{env: env, client: client}
+	return &Manager{env: env, client: client, usageCache: usage.NewCache()}
 }
 
 // ListAccounts returns all configured accounts with enriched runtime status.

--- a/tui/internal/account/manager_helpers.go
+++ b/tui/internal/account/manager_helpers.go
@@ -70,7 +70,9 @@ func (m *Manager) buildAccounts(n int, stateDirs map[string]config.StateDir, con
 			}
 
 			// JSONL token summary (always populated when session data exists).
-			if sessions, err := usage.ScanAccountSessions(sd.ProjectsDir()); err == nil && len(sessions) > 0 {
+			// Uses the manager-scoped cache so unchanged session files are
+			// not re-read and re-decoded on every dashboard refresh.
+			if sessions, err := usage.ScanAccountSessionsWithCache(sd.ProjectsDir(), m.usageCache); err == nil && len(sessions) > 0 {
 				opts := usage.AllTimeOptions()
 				tokens := usage.AggregateSessions(sessions, opts)
 				count := usage.CountFilteredSessions(sessions, opts)

--- a/tui/internal/usage/cache_test.go
+++ b/tui/internal/usage/cache_test.go
@@ -1,0 +1,254 @@
+package usage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const asstLine = `{"type":"assistant","timestamp":"2026-01-01T00:00:00Z","message":{"model":"sonnet","usage":{"input_tokens":1,"output_tokens":2,"cache_creation_input_tokens":3,"cache_read_input_tokens":4}}}` + "\n"
+
+// writeJSONL is a helper that writes a single-line JSONL file containing
+// one assistant entry and returns its absolute path.
+func writeJSONL(t *testing.T, dir, name string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(asstLine), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+// TestCacheReusesUnchangedFiles verifies that a second scan with the
+// same cache reuses parsed sessions for unchanged files (size+mtime
+// match), so parseSessionFile is not invoked again.
+func TestCacheReusesUnchangedFiles(t *testing.T) {
+	root := t.TempDir()
+	proj := filepath.Join(root, "project-a")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeJSONL(t, proj, "a.jsonl")
+	writeJSONL(t, proj, "b.jsonl")
+
+	cache := NewCache()
+	first, err := ScanAccountSessionsWithCache(root, cache)
+	if err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	if len(first) != 2 {
+		t.Fatalf("first scan len = %d, want 2", len(first))
+	}
+	if cache.Len() != 2 {
+		t.Errorf("cache.Len after first scan = %d, want 2", cache.Len())
+	}
+
+	// Capture a stable identity reference to the cached Session value.
+	// On reuse the cache returns the same Entries slice by value, but the
+	// underlying array header should be identical because we round-trip
+	// the stored cacheEntry.
+	firstByPath := make(map[string]*SessionEntry, len(first))
+	for i := range first {
+		if len(first[i].Entries) > 0 {
+			firstByPath[first[i].Path] = &first[i].Entries[0]
+		}
+	}
+
+	second, err := ScanAccountSessionsWithCache(root, cache)
+	if err != nil {
+		t.Fatalf("second scan: %v", err)
+	}
+	if len(second) != 2 {
+		t.Fatalf("second scan len = %d, want 2", len(second))
+	}
+	for i := range second {
+		ent0, ok := firstByPath[second[i].Path]
+		if !ok {
+			t.Errorf("second scan returned unexpected path %q", second[i].Path)
+			continue
+		}
+		if len(second[i].Entries) == 0 {
+			t.Errorf("second scan: %q has no entries", second[i].Path)
+			continue
+		}
+		// Reused entry slice should point at the same underlying array as
+		// the first scan; if it had been reparsed we would have a new slice.
+		if &second[i].Entries[0] != ent0 {
+			t.Errorf("second scan: %q was reparsed (entry slice differs)", second[i].Path)
+		}
+	}
+}
+
+// TestCacheReparsesOnMtimeChange verifies that when a file's mtime
+// changes, the cache discards the stale entry and reparses.
+func TestCacheReparsesOnMtimeChange(t *testing.T) {
+	root := t.TempDir()
+	proj := filepath.Join(root, "project-a")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := writeJSONL(t, proj, "a.jsonl")
+
+	cache := NewCache()
+	if _, err := ScanAccountSessionsWithCache(root, cache); err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+
+	// Capture the cached entry slice header for later identity comparison.
+	firstSessions, _ := ScanAccountSessionsWithCache(root, cache)
+	var firstEntryPtr *SessionEntry
+	for i := range firstSessions {
+		if firstSessions[i].Path == path && len(firstSessions[i].Entries) > 0 {
+			firstEntryPtr = &firstSessions[i].Entries[0]
+			break
+		}
+	}
+	if firstEntryPtr == nil {
+		t.Fatalf("did not find cached entry for %q", path)
+	}
+
+	// Bump mtime forward by one second to invalidate the fingerprint.
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(path, future, future); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	third, err := ScanAccountSessionsWithCache(root, cache)
+	if err != nil {
+		t.Fatalf("third scan: %v", err)
+	}
+	for i := range third {
+		if third[i].Path != path {
+			continue
+		}
+		if len(third[i].Entries) == 0 {
+			t.Fatalf("reparsed session has no entries")
+		}
+		if &third[i].Entries[0] == firstEntryPtr {
+			t.Errorf("entry slice was reused despite mtime change; want reparse")
+		}
+	}
+}
+
+// TestCacheReparsesOnSizeChange verifies that appending to a file (size
+// change) invalidates the cached entry even if mtime resolution would
+// not differ.
+func TestCacheReparsesOnSizeChange(t *testing.T) {
+	root := t.TempDir()
+	proj := filepath.Join(root, "project-a")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := writeJSONL(t, proj, "a.jsonl")
+
+	cache := NewCache()
+	first, err := ScanAccountSessionsWithCache(root, cache)
+	if err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	if got := len(first[0].Entries); got != 1 {
+		t.Fatalf("first scan entries = %d, want 1", got)
+	}
+
+	// Append a second assistant line so file size changes.
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open append: %v", err)
+	}
+	if _, err := f.WriteString(asstLine); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	f.Close()
+
+	second, err := ScanAccountSessionsWithCache(root, cache)
+	if err != nil {
+		t.Fatalf("second scan: %v", err)
+	}
+	if got := len(second[0].Entries); got != 2 {
+		t.Errorf("second scan entries = %d, want 2 (size change should trigger reparse)", got)
+	}
+}
+
+// TestCachePrunesDeletedFiles verifies that a file removed between
+// scans is dropped from the cache so memory does not grow unbounded.
+func TestCachePrunesDeletedFiles(t *testing.T) {
+	root := t.TempDir()
+	proj := filepath.Join(root, "project-a")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	pathA := writeJSONL(t, proj, "a.jsonl")
+	writeJSONL(t, proj, "b.jsonl")
+
+	cache := NewCache()
+	if _, err := ScanAccountSessionsWithCache(root, cache); err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	if cache.Len() != 2 {
+		t.Fatalf("cache.Len after first scan = %d, want 2", cache.Len())
+	}
+
+	if err := os.Remove(pathA); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, err := ScanAccountSessionsWithCache(root, cache); err != nil {
+		t.Fatalf("second scan: %v", err)
+	}
+	if cache.Len() != 1 {
+		t.Errorf("cache.Len after delete = %d, want 1 (deleted file should be pruned)", cache.Len())
+	}
+}
+
+// TestNilCacheParsesEveryTime guarantees the wrapper without a cache
+// still works (preserves existing ScanAccountSessions behavior).
+func TestNilCacheParsesEveryTime(t *testing.T) {
+	root := t.TempDir()
+	proj := filepath.Join(root, "project-a")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeJSONL(t, proj, "a.jsonl")
+
+	first, err := ScanAccountSessions(root)
+	if err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	second, err := ScanAccountSessions(root)
+	if err != nil {
+		t.Fatalf("second scan: %v", err)
+	}
+	if len(first) != 1 || len(second) != 1 {
+		t.Fatalf("scan lens = %d, %d; want 1, 1", len(first), len(second))
+	}
+	if len(first[0].Entries) == 0 || len(second[0].Entries) == 0 {
+		t.Fatalf("scans produced empty entries")
+	}
+	// Without a shared cache the two slices must come from independent parses.
+	if &first[0].Entries[0] == &second[0].Entries[0] {
+		t.Errorf("nil-cache scans reused entry slice; want independent parses")
+	}
+}
+
+// TestCacheMissingDirReturnsNil verifies that a missing projects dir
+// is not an error and pruning still empties the cache so callers that
+// switch state directories do not leak stale entries.
+func TestCacheMissingDirReturnsNil(t *testing.T) {
+	cache := NewCache()
+	// Pre-seed cache so prune has something to do.
+	cache.put("/non/existent/seed.jsonl", 1, 2, Session{Path: "/non/existent/seed.jsonl"})
+	if cache.Len() != 1 {
+		t.Fatalf("seed Len = %d, want 1", cache.Len())
+	}
+
+	got, err := ScanAccountSessionsWithCache(filepath.Join(t.TempDir(), "does-not-exist"), cache)
+	if err != nil {
+		t.Fatalf("scan missing dir: err = %v, want nil", err)
+	}
+	if got != nil {
+		t.Errorf("scan missing dir sessions = %v, want nil", got)
+	}
+	if cache.Len() != 0 {
+		t.Errorf("cache.Len after missing-dir scan = %d, want 0", cache.Len())
+	}
+}

--- a/tui/internal/usage/parser.go
+++ b/tui/internal/usage/parser.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 )
 
 // SessionEntry is a single assistant message with usage info.
@@ -33,15 +34,113 @@ type Session struct {
 	Entries []SessionEntry
 }
 
+// cacheEntry records a previously parsed session along with the file
+// fingerprint used to decide whether re-parsing is needed.
+type cacheEntry struct {
+	size    int64
+	modUnix int64 // mtime in unix nanoseconds
+	session Session
+}
+
+// Cache memoizes parsed session files by path. A cached entry is reused
+// when both file size and mtime match the entry on disk. The zero value
+// is unusable; call NewCache.
+//
+// Cache is safe for concurrent use. Across refreshes the same Cache
+// instance should be reused so unchanged JSONL files are not reparsed.
+type Cache struct {
+	mu      sync.Mutex
+	entries map[string]cacheEntry
+}
+
+// NewCache creates an empty session-parse cache.
+func NewCache() *Cache {
+	return &Cache{entries: make(map[string]cacheEntry)}
+}
+
+// get returns the cached session for path when its fingerprint matches
+// size and modUnix. Returns ok=false otherwise.
+func (c *Cache) get(path string, size, modUnix int64) (Session, bool) {
+	if c == nil {
+		return Session{}, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[path]
+	if !ok || e.size != size || e.modUnix != modUnix {
+		return Session{}, false
+	}
+	return e.session, true
+}
+
+// put records a parsed session for path with its fingerprint.
+func (c *Cache) put(path string, size, modUnix int64, s Session) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[path] = cacheEntry{size: size, modUnix: modUnix, session: s}
+}
+
+// prune removes cache entries whose paths are not present in seen. This
+// drops entries for files that have been deleted or moved out of the
+// projects tree, keeping cache memory bounded by current state.
+func (c *Cache) prune(seen map[string]struct{}) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for path := range c.entries {
+		if _, ok := seen[path]; !ok {
+			delete(c.entries, path)
+		}
+	}
+}
+
+// Len returns the number of cached entries. Intended for tests and
+// diagnostics; never used in hot paths.
+func (c *Cache) Len() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries)
+}
+
 // ScanAccountSessions walks the projects dir and parses all .jsonl files.
+// This is a convenience wrapper around ScanAccountSessionsWithCache with
+// no cache; every call reparses every file. Hot paths (TUI refresh)
+// should use ScanAccountSessionsWithCache with a long-lived cache instead.
 func ScanAccountSessions(projectsDir string) ([]Session, error) {
+	return ScanAccountSessionsWithCache(projectsDir, nil)
+}
+
+// ScanAccountSessionsWithCache walks the projects dir and returns parsed
+// sessions for every .jsonl file. When cache is non-nil, files whose
+// path, size, and mtime match a cached entry are returned from the
+// cache without re-reading the file. After the scan, cache entries for
+// files no longer present on disk are pruned.
+func ScanAccountSessionsWithCache(projectsDir string, cache *Cache) ([]Session, error) {
 	var sessions []Session
 	if _, err := os.Stat(projectsDir); err != nil {
 		if os.IsNotExist(err) {
+			// Even with a missing dir we should prune anything still in
+			// the cache that pointed under this tree, otherwise switching
+			// away from a state dir would leak entries. Callers that share
+			// one cache across multiple projects dirs handle this via the
+			// per-call seen set returned to prune below.
+			if cache != nil {
+				cache.prune(map[string]struct{}{})
+			}
 			return nil, nil
 		}
 		return nil, err
 	}
+
+	seen := make(map[string]struct{})
 
 	err := filepath.WalkDir(projectsDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -53,16 +152,41 @@ func ScanAccountSessions(projectsDir string) ([]Session, error) {
 		if !strings.HasSuffix(path, ".jsonl") {
 			return nil
 		}
-		s, err := parseSessionFile(path)
-		if err != nil {
+
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			// Fall back to a stat-less parse; never cache without a fingerprint.
+			s, parseErr := parseSessionFile(path)
+			if parseErr != nil {
+				return nil
+			}
+			sessions = append(sessions, s)
+			seen[path] = struct{}{}
+			return nil
+		}
+
+		size := info.Size()
+		modUnix := info.ModTime().UnixNano()
+		seen[path] = struct{}{}
+
+		if cached, ok := cache.get(path, size, modUnix); ok {
+			sessions = append(sessions, cached)
+			return nil
+		}
+
+		s, parseErr := parseSessionFile(path)
+		if parseErr != nil {
 			return nil // skip unparseable files
 		}
+		cache.put(path, size, modUnix, s)
 		sessions = append(sessions, s)
 		return nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("walk projects dir: %w", err)
 	}
+
+	cache.prune(seen)
 	return sessions, nil
 }
 


### PR DESCRIPTION
## What

Add an in-memory cache for parsed JSONL session files so the TUI dashboard refresh no longer re-decodes every `.jsonl` under `projects/` on every tick.

### Change Type
- [x] Performance / bug fix (no behavior change on the happy path)
- [ ] Feature
- [ ] Refactor

### Affected Components
- `tui/internal/usage/parser.go` -- new `Cache` type and `ScanAccountSessionsWithCache`. `ScanAccountSessions` becomes a thin wrapper for backwards compatibility.
- `tui/internal/usage/cache_test.go` -- new tests covering cache reuse, invalidation, prune, and nil-cache fallback.
- `tui/internal/account/manager.go` -- `Manager` holds one `*usage.Cache` for its lifetime and threads it through the listing path.

## Why

Closes #262.

The dashboard refresh called `usage.ScanAccountSessions(sd.ProjectsDir())` once per account on every refresh. `ScanAccountSessions` walks the entire `projects` tree and decodes every assistant line in every `.jsonl` file. On a machine with accumulated history (the issue reports 486 files, ~302 MB), this is hundreds of file opens and a full JSON decode pass over hundreds of MB on every refresh -- the root cause of the intermittent CPU/IO spikes described in the issue.

The fix reduces work to be proportional to what actually changed. Most `.jsonl` files in older projects are append-only or fully cold; their size and mtime do not change between refreshes, so the next scan returns the cached `Session` without touching the file. Only new or modified files are reparsed.

This is improvement #1 from the issue's "Proposed improvements" list. The other items (split refresh cadences, smarter backoff, lightweight mode) are deferred -- this PR is the minimum-viable change that addresses the dominant hot path called out in the issue.

## Where

| File | Type of Change |
|------|----------------|
| `tui/internal/usage/parser.go` | New `Cache` type, `ScanAccountSessionsWithCache`. `ScanAccountSessions` rewired as a no-cache wrapper. |
| `tui/internal/usage/cache_test.go` | 6 new tests. |
| `tui/internal/account/manager.go` | `Manager` owns a `*usage.Cache`. Listing path uses the cache-aware scan. |

No public API removed. `ScanAccountSessions` keeps the same signature and behavior (no cache).

## How

### Cache semantics

- Key: absolute file path returned by `filepath.WalkDir`.
- Fingerprint: `(size int64, modUnix int64)` where `modUnix` is `FileInfo.ModTime().UnixNano()`.
- Hit policy: both size and mtime must match the on-disk stat. Any mismatch falls through to a full reparse.
- Eviction: after each scan the cache calls `prune(seen)` to drop entries for paths the latest walk did not visit, so removed/relocated files do not accumulate.
- Concurrency: `Cache` is guarded by a single `sync.Mutex`. Get/put/prune are short critical sections; parsing happens outside the lock.
- A nil `*Cache` is valid and behaves as "no caching" -- useful for one-shot callers and the existing `ScanAccountSessions` wrapper.

### Why size+mtime and not just mtime

mtime alone is unreliable when filesystems quantize timestamps or when an editor rewrites a file in-place inside the same second. Pairing it with size catches the common JSONL append case (size strictly grows) and reduces the false-hit window to truly-identical edits.

### Manager wiring

`account.Manager` now holds a `usageCache *usage.Cache` initialised in `NewManager` and reused across every `ListAccounts` call. Each refresh prunes deleted files, so the cache size tracks the actual JSONL count on disk rather than the cumulative history of files the TUI has ever seen.

## Testing Done

- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `go test ./...` -- all packages pass (account, config, usage).
- [x] New `cache_test.go` adds 6 focused tests:
  - `TestCacheReusesUnchangedFiles` -- second scan returns the same entry slice header for unchanged files (proves no reparse).
  - `TestCacheReparsesOnMtimeChange` -- `os.Chtimes` forward bumps mtime; entry slice header changes (proves reparse).
  - `TestCacheReparsesOnSizeChange` -- appending one line grows size; entry count goes from 1 to 2 (proves size invalidation).
  - `TestCachePrunesDeletedFiles` -- removed file is dropped from the cache after the next scan.
  - `TestNilCacheParsesEveryTime` -- `ScanAccountSessions` (no cache) keeps existing behavior.
  - `TestCacheMissingDirReturnsNil` -- non-existent projects dir is still not an error, and the cache is pruned to empty.

All 6 new tests pass; full `go test ./...` suite is green.

## Breaking Changes

None. `ScanAccountSessions` keeps the same signature and the same uncached behavior. The new `ScanAccountSessionsWithCache` is additive.

## Rollback Plan

Revert this PR. No on-disk format or schema changed (the cache is in-memory only).
