### PR TITLE
feat(runtime): support Codex containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Version pinning via build arg (omit for latest)
 ARG CLAUDE_CODE_VERSION
+ARG CODEX_CLI_VERSION
 
 WORKDIR /workspace
 
@@ -96,13 +97,18 @@ RUN curl -fsSL https://claude.ai/install.sh -o /tmp/claude-install.sh \
 # Add the native install location to PATH for all users
 ENV PATH="/home/node/.local/bin:${PATH}"
 
-# Install statusline tools globally (still npm packages)
+# Install Codex CLI and statusline tools globally (npm packages)
 #
-# DL3016 waived: ccstatusline and claude-limitline are latest-tracking
-# helper packages; pinning them would block bug fixes without a security
-# benefit. The base npm version is pinned via the node:20.18.1-slim digest.
+# DL3016 waived: @openai/codex, ccstatusline, and claude-limitline are
+# latest-tracking helper packages; pinning them would block bug fixes without
+# a security benefit. CODEX_CLI_VERSION is available when reproducibility is
+# preferred for the Codex CLI.
 # hadolint ignore=DL3016
-RUN npm install -g ccstatusline claude-limitline \
+RUN if [[ -n "${CODEX_CLI_VERSION:-}" ]]; then \
+        npm install -g "@openai/codex@${CODEX_CLI_VERSION}" ccstatusline claude-limitline; \
+    else \
+        npm install -g @openai/codex ccstatusline claude-limitline; \
+    fi \
     && npm cache clean --force
 
 # Memory heap limit

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ scripts/claude-docker help       # Show all available commands
 | | `ps` | Show container status |
 | | `logs` | Follow container logs |
 | **Interactive** | `claude [service]` | Start Claude Code (default: claude-a) |
+| | `codex [service]` | Start OpenAI Codex CLI (default: codex-a) |
 | | `exec <service>` | Open shell in a container |
 | **Usage Tracking** | `usage [type] [flags]` | Token usage report |
 | **Dashboard** | `tui` (alias `dashboard`) | Launch multi-account TUI; auto-downloads a prebuilt binary if missing |
@@ -196,6 +197,36 @@ scripts/claude-docker claude claude-b
 Both sessions see the same project source at `${PROJECT_DIR}` (Tier A) or
 their own worktree (Tier B). Each session has independent conversation
 history, settings, memory, and credentials.
+
+### Running OpenAI Codex CLI
+
+Codex support is opt-in. Set `AGENT_RUNTIME=codex` in `.env`, then regenerate
+compose files and recreate containers:
+
+```bash
+scripts/generate-compose.sh
+scripts/claude-docker up --remove-orphans
+scripts/claude-docker codex
+```
+
+PowerShell users can run `.\scripts\generate-compose.ps1` and
+`.\scripts\claude-docker.ps1 codex` instead.
+
+When `AGENT_RUNTIME=codex` is active, generated services are named
+`codex-a`, `codex-b`, and so on. Each account stores mutable Codex state in
+`~/.codex-state/account-*/`, while host-managed Codex config is mounted
+read-only from `~/.codex/` and copied or linked into `CODEX_HOME` without
+importing `auth.json`, sessions, caches, or logs. Codex skills are mounted
+from `${AGENTS_SKILLS_DIR}` or `~/.agents/skills`.
+
+For API-key based Codex sessions, set per-account keys such as
+`CODEX_API_KEY_A`; the generator injects `OPENAI_API_KEY` only for accounts
+that have a non-empty key. The `codex` wrapper starts the CLI with
+`cli_auth_credentials_store="file"` so container logins persist in the
+account state bind mount.
+
+The TUI can list and attach to Codex services. Claude-specific usage
+aggregation and `scripts/claude-docker usage` remain Claude-only.
 
 ### Authentication
 

--- a/scripts/ClaudeDocker.psm1
+++ b/scripts/ClaudeDocker.psm1
@@ -313,6 +313,53 @@ function Get-NumAccounts {
     return 2
 }
 
+function Get-AgentRuntime {
+    <#
+    .SYNOPSIS
+    Resolve the selected agent runtime. Defaults to claude for compatibility.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$ProjectRoot)
+
+    $runtime = [Environment]::GetEnvironmentVariable('AGENT_RUNTIME')
+    if ([string]::IsNullOrWhiteSpace($runtime)) {
+        $envFile = Join-Path $ProjectRoot '.env'
+        if (Test-Path $envFile) {
+            $runtime = Get-EnvValue -Path $envFile -Key 'AGENT_RUNTIME'
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($runtime)) {
+        $runtime = 'claude'
+    }
+    $runtime = $runtime.ToLowerInvariant()
+    if ($runtime -notin @('claude', 'codex')) {
+        throw "AGENT_RUNTIME must be 'claude' or 'codex' (got: $runtime)"
+    }
+    return $runtime
+}
+
+function Get-ServicePrefix {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$ProjectRoot)
+
+    return Get-AgentRuntime -ProjectRoot $ProjectRoot
+}
+
+function Get-PrimaryService {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$ProjectRoot)
+
+    return "$(Get-ServicePrefix -ProjectRoot $ProjectRoot)-a"
+}
+
+function Get-AgentStateRoot {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$ProjectRoot)
+
+    $dirName = if ((Get-AgentRuntime -ProjectRoot $ProjectRoot) -eq 'codex') { '.codex-state' } else { '.claude-state' }
+    return Join-Path $env:USERPROFILE $dirName
+}
+
 function ConvertTo-AccountLetter {
     <#
     .SYNOPSIS
@@ -339,15 +386,17 @@ function Get-ServiceNames {
     .SYNOPSIS
     Return an array of service names (claude-a, claude-b, ...) based on
     NUM_ACCOUNTS. Supports more than 26 via Excel-style double-letter
-    indexing (claude-aa, claude-zz, ...).
+    indexing (claude-aa, claude-zz, ...). When AGENT_RUNTIME=codex, the
+    service prefix becomes codex.
     #>
     [CmdletBinding()]
     param([Parameter(Mandatory)][string]$ProjectRoot)
 
     $n = Get-NumAccounts -ProjectRoot $ProjectRoot
+    $prefix = Get-ServicePrefix -ProjectRoot $ProjectRoot
     $names = @()
     for ($i = 1; $i -le $n; $i++) {
-        $names += "claude-$(ConvertTo-AccountLetter -Index $i)"
+        $names += "$prefix-$(ConvertTo-AccountLetter -Index $i)"
     }
     return $names
 }
@@ -453,7 +502,9 @@ Export-ModuleMember -Function @(
     # Utilities
     'Test-Command', 'ConvertTo-ForwardSlash',
     # Accounts
-    'Get-NumAccounts', 'Get-ServiceNames', 'ConvertTo-AccountLetter',
+    'Get-NumAccounts', 'Get-AgentRuntime', 'Get-ServicePrefix',
+    'Get-PrimaryService', 'Get-AgentStateRoot', 'Get-ServiceNames',
+    'ConvertTo-AccountLetter',
     # .env
     'Read-EnvFile', 'Get-EnvValue', 'Write-EnvContent', 'Set-EnvValue',
     # Docker Compose

--- a/scripts/claude-docker
+++ b/scripts/claude-docker
@@ -7,6 +7,7 @@
 # Commands:
 #   up/down/restart   Manage containers
 #   claude [svc]      Start Claude Code (default: claude-a)
+#   codex [svc]       Start OpenAI Codex CLI (default: codex-a)
 #   exec <svc>        Open shell in a service
 #   usage [type]      Token usage report
 #   build             Build/rebuild Docker image
@@ -48,6 +49,8 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 . "$SCRIPT_DIR/lib/parse_env.sh"
 # shellcheck source=lib/index.sh
 . "$SCRIPT_DIR/lib/index.sh"
+# shellcheck source=lib/runtime.sh
+. "$SCRIPT_DIR/lib/runtime.sh"
 # shellcheck source=lib/build-compose-cmd.sh
 . "$SCRIPT_DIR/lib/build-compose-cmd.sh"
 
@@ -81,7 +84,7 @@ compose_cmd_display() {
 
 # Determine the primary interactive service
 get_primary_service() {
-    echo "claude-a"
+    echo "$(agent_service_prefix)-a"
 }
 
 # --- Account Helpers ----------------------------------------------------------
@@ -105,9 +108,11 @@ _index_to_letter() {
 get_service_names() {
     local n
     n=$(get_num_accounts)
+    local prefix
+    prefix=$(agent_service_prefix)
     local names=()
     for i in $(seq 1 "$n"); do
-        names+=("claude-$(_index_to_letter "$i")")
+        names+=("${prefix}-$(_index_to_letter "$i")")
     done
     echo "${names[@]}"
 }
@@ -117,7 +122,8 @@ get_service_names() {
 # List account state directories under ~/.claude-state/account-*.
 # Outputs one path per line.
 list_account_dirs() {
-    local state_base="$HOME/.claude-state"
+    local state_base
+    state_base="$(agent_state_root)"
     [[ -d "$state_base" ]] || return
     for dir in "$state_base"/account-*; do
         [[ -d "$dir" ]] || continue
@@ -166,10 +172,12 @@ cmd_up() {
     # Lightweight post-start GitHub auth check (non-blocking)
     echo ""
     local cid
-    cid=$(get_container_id "claude-a")
+    local primary
+    primary=$(get_primary_service)
+    cid=$(get_container_id "$primary")
     if [[ -n "$cid" ]]; then
         sleep 2  # wait for entrypoint gh auth setup
-        verify_container_gh_auth "claude-a" || true
+        verify_container_gh_auth "$primary" || true
     fi
 }
 
@@ -217,7 +225,7 @@ cmd_claude() {
             *) [[ -z "$service" ]] && service="$arg" ;;
         esac
     done
-    service="${service:-$(get_primary_service)}"
+    service="${service:-claude-a}"
     ensure_compose_cmd
     echo -e "${CYAN}Starting Claude Code in ${BOLD}$service${NC}${CYAN}...${NC}"
     if [[ "$skip_perms" == true ]]; then
@@ -225,6 +233,30 @@ cmd_claude() {
     else
         "${COMPOSE_CMD[@]}" exec "$service" claude
     fi
+}
+
+cmd_codex() {
+    if [[ "$(agent_runtime)" != "codex" ]]; then
+        log_error "codex command requires AGENT_RUNTIME=codex. Set it in .env, regenerate compose files, then run again."
+        exit 1
+    fi
+
+    local skip_perms=false
+    local service=""
+    for arg in "$@"; do
+        case "$arg" in
+            --dangerously-bypass-approvals-and-sandbox|--dangerously-skip-permissions) skip_perms=true ;;
+            *) [[ -z "$service" ]] && service="$arg" ;;
+        esac
+    done
+    service="${service:-codex-a}"
+    ensure_compose_cmd
+    echo -e "${CYAN}Starting Codex CLI in ${BOLD}$service${NC}${CYAN}...${NC}"
+    local codex_args=(codex -c 'cli_auth_credentials_store="file"')
+    if [[ "$skip_perms" == true ]]; then
+        codex_args+=("--dangerously-bypass-approvals-and-sandbox")
+    fi
+    "${COMPOSE_CMD[@]}" exec "$service" "${codex_args[@]}"
 }
 
 # Resolve a compose service name to its running Docker container ID.
@@ -355,11 +387,13 @@ cmd_gh_auth() {
 
         # Verify inside container
         sleep 2
+        local primary
+        primary=$(get_primary_service)
         local cid
-        cid=$(get_container_id "claude-a")
+        cid=$(get_container_id "$primary")
         if [[ -n "$cid" ]]; then
             echo ""
-            echo -e "${BOLD}Verifying GitHub auth in claude-a:${NC}"
+            echo -e "${BOLD}Verifying GitHub auth in ${primary}:${NC}"
             docker exec "$cid" gh auth status 2>&1 || true
         fi
     else
@@ -377,7 +411,10 @@ cmd_build() {
 cmd_update() {
     ensure_compose_cmd
 
-    echo -e "${BOLD}Updating Claude Code to latest version${NC}"
+    local binary
+    binary=$(agent_binary)
+
+    echo -e "${BOLD}Updating ${binary} CLI to latest version${NC}"
     echo ""
 
     # Pre-check and refresh GitHub auth token from host
@@ -404,15 +441,17 @@ cmd_update() {
     # Verify version and GitHub auth
     echo -e "${CYAN}[5/5] Verifying...${NC}"
     local cid
-    cid=$(get_container_id "claude-a")
+    local primary
+    primary=$(get_primary_service)
+    cid=$(get_container_id "$primary")
     if [[ -n "$cid" ]]; then
         local version
-        version=$(docker exec "$cid" claude --version 2>/dev/null || echo "unknown")
-        echo -e "  ${GREEN}*${NC} Claude Code version: ${BOLD}$version${NC}"
+        version=$(docker exec "$cid" "$binary" --version 2>/dev/null || echo "unknown")
+        echo -e "  ${GREEN}*${NC} ${binary} version: ${BOLD}$version${NC}"
 
         # Wait briefly for entrypoint to complete gh auth setup
         sleep 2
-        verify_container_gh_auth "claude-a" || true
+        verify_container_gh_auth "$primary" || true
 
         echo ""
         echo -e "${GREEN}Update complete.${NC}"
@@ -454,7 +493,8 @@ cmd_scale() {
         for i in $(seq $((current_count + 1)) "$new_count"); do
             local letter
             letter=$(_index_to_letter "$i")
-            local state_dir="$HOME/.claude-state/account-${letter}"
+            local state_dir
+            state_dir="$(agent_state_root)/account-${letter}"
             if [[ ! -d "$state_dir" ]]; then
                 mkdir -p "$state_dir"
                 chmod 700 "$state_dir"
@@ -510,6 +550,11 @@ cmd_compose() {
 }
 
 cmd_usage() {
+    if [[ "$(agent_runtime)" != "claude" ]]; then
+        log_error "usage is currently Claude-only; Codex usage aggregation is not supported."
+        exit 1
+    fi
+
     # Check for npx availability (runs on host, not in container)
     if ! command -v npx &>/dev/null; then
         log_error "npx not found. Node.js is required to run ccusage."
@@ -646,12 +691,13 @@ ${BOLD}LIFECYCLE${NC}
   ${GREEN}down${NC}                  Stop all containers
   ${GREEN}restart${NC}               Restart all containers
   ${GREEN}build${NC}                 Build/rebuild Docker image
-  ${GREEN}update${NC}                Rebuild with latest Claude Code and recreate
+  ${GREEN}update${NC}                Rebuild with latest agent CLI and recreate
   ${GREEN}ps${NC}                    Show container status
   ${GREEN}logs${NC}                  Follow container logs
 
 ${BOLD}INTERACTIVE${NC}
   ${GREEN}claude${NC} [service]      Start Claude Code (default: claude-a)
+  ${GREEN}codex${NC} [service]       Start OpenAI Codex CLI (default: codex-a)
   ${GREEN}tui${NC}                   Launch multi-account dashboard TUI
   ${GREEN}gh-auth${NC}               Inject GitHub token from host gh CLI into containers
   ${GREEN}exec${NC} <service>        Open shell in a service
@@ -674,9 +720,11 @@ HELP
 
     # Dynamic service list
     read -ra svc_names <<< "$(get_service_names)"
+    local prefix
+    prefix=$(agent_service_prefix)
     for idx in "${!svc_names[@]}"; do
         local svc="${svc_names[$idx]}"
-        local suffix="${svc#claude-}"
+        local suffix="${svc#${prefix}-}"
         local label
         label="Account $(printf '%s' "$suffix" | tr '[:lower:]' '[:upper:]')"
         if [[ "$idx" -eq 0 ]]; then
@@ -707,6 +755,7 @@ main() {
         ps)        cmd_ps "$@" ;;
         exec)      cmd_exec "$@" ;;
         claude)    cmd_claude "$@" ;;
+        codex)     cmd_codex "$@" ;;
         gh-auth)   cmd_gh_auth "$@" ;;
         usage)     cmd_usage "$@" ;;
         build)     cmd_build "$@" ;;

--- a/scripts/claude-docker.ps1
+++ b/scripts/claude-docker.ps1
@@ -43,7 +43,7 @@ $ProjectRoot = Split-Path $PSScriptRoot -Parent
 # --- Account Directory Helpers -----------------------------------------------
 
 function Get-AccountDirs {
-    $stateBase = Join-Path $env:USERPROFILE '.claude-state'
+    $stateBase = Get-AgentStateRoot -ProjectRoot $ProjectRoot
     if (-not (Test-Path $stateBase)) { return @() }
     Get-ChildItem $stateBase -Directory -Filter 'account-*' | Select-Object -ExpandProperty FullName
 }
@@ -85,10 +85,11 @@ function Invoke-Up {
 
     # Lightweight post-start GitHub auth check (non-blocking)
     Write-Host ''
-    $cid = Get-ContainerId -ProjectRoot $ProjectRoot -Service 'claude-a'
+    $primary = Get-PrimaryService -ProjectRoot $ProjectRoot
+    $cid = Get-ContainerId -ProjectRoot $ProjectRoot -Service $primary
     if ($cid) {
         Start-Sleep -Seconds 2  # wait for entrypoint gh auth setup
-        Test-ContainerGhAuth -Service 'claude-a' | Out-Null
+        Test-ContainerGhAuth -Service $primary | Out-Null
     }
 }
 
@@ -145,6 +146,32 @@ function Invoke-Claude {
     }
 }
 
+function Invoke-Codex {
+    if ((Get-AgentRuntime -ProjectRoot $ProjectRoot) -ne 'codex') {
+        Write-LogError 'codex command requires AGENT_RUNTIME=codex. Set it in .env, regenerate compose files, then run again.'
+        exit 1
+    }
+
+    $skipPerms = $false
+    $service = ''
+    foreach ($arg in $Arguments) {
+        if ($arg -in @('--dangerously-bypass-approvals-and-sandbox', '--dangerously-skip-permissions')) {
+            $skipPerms = $true
+        } elseif (-not $service) {
+            $service = $arg
+        }
+    }
+    if (-not $service) { $service = 'codex-a' }
+    Write-Host "Starting Codex CLI in " -ForegroundColor Cyan -NoNewline
+    Write-Host $service -ForegroundColor White -NoNewline
+    Write-Host '...' -ForegroundColor Cyan
+    $codexArgs = @('codex', '-c', 'cli_auth_credentials_store="file"')
+    if ($skipPerms) {
+        $codexArgs += '--dangerously-bypass-approvals-and-sandbox'
+    }
+    Invoke-Compose -ProjectRoot $ProjectRoot exec $service @codexArgs
+}
+
 function Invoke-GhAuth {
     if (-not (Test-Command 'gh')) {
         Write-LogError 'gh CLI not found on host.'
@@ -174,17 +201,18 @@ function Invoke-GhAuth {
     Write-Host 'GitHub token injected into .env' -ForegroundColor Green
 
     # Restart containers if running
-    $running = Get-ContainerId -ProjectRoot $ProjectRoot -Service 'claude-a'
+    $primary = Get-PrimaryService -ProjectRoot $ProjectRoot
+    $running = Get-ContainerId -ProjectRoot $ProjectRoot -Service $primary
     if ($running) {
         Write-Host 'Restarting containers to apply...' -ForegroundColor Cyan
         Invoke-Compose -ProjectRoot $ProjectRoot down
         Invoke-Compose -ProjectRoot $ProjectRoot up --detach
 
         Start-Sleep -Seconds 2
-        $cid = Get-ContainerId -ProjectRoot $ProjectRoot -Service 'claude-a'
+        $cid = Get-ContainerId -ProjectRoot $ProjectRoot -Service $primary
         if ($cid) {
             Write-Host ''
-            Write-Host 'Verifying GitHub auth in claude-a:' -ForegroundColor White
+            Write-Host "Verifying GitHub auth in ${primary}:" -ForegroundColor White
             & docker exec $cid gh auth status 2>&1
         }
     }
@@ -284,7 +312,8 @@ function Invoke-Build {
 }
 
 function Invoke-Update {
-    Write-Host 'Updating Claude Code to latest version' -ForegroundColor White
+    $binary = Get-AgentRuntime -ProjectRoot $ProjectRoot
+    Write-Host "Updating $binary CLI to latest version" -ForegroundColor White
     Write-Host ''
 
     # Pre-check and refresh GitHub auth token from host
@@ -308,15 +337,16 @@ function Invoke-Update {
 
     # Verify version and GitHub auth
     Write-Host '[5/5] Verifying...' -ForegroundColor Cyan
-    $cid = Get-ContainerId -ProjectRoot $ProjectRoot -Service 'claude-a'
+    $primary = Get-PrimaryService -ProjectRoot $ProjectRoot
+    $cid = Get-ContainerId -ProjectRoot $ProjectRoot -Service $primary
     if ($cid) {
-        $version = & docker exec $cid claude --version 2>$null
+        $version = & docker exec $cid $binary --version 2>$null
         if (-not $version) { $version = 'unknown' }
-        Write-Host "  * Claude Code version: $version" -ForegroundColor Green
+        Write-Host "  * $binary version: $version" -ForegroundColor Green
 
         # Wait briefly for entrypoint to complete gh auth setup
         Start-Sleep -Seconds 2
-        Test-ContainerGhAuth -Service 'claude-a' | Out-Null
+        Test-ContainerGhAuth -Service $primary | Out-Null
 
         Write-Host ''
         Write-Host 'Update complete.' -ForegroundColor Green
@@ -355,8 +385,8 @@ function Invoke-Scale {
     if ($newCount -gt $currentCount) {
         Write-Host 'Creating new state directories...' -ForegroundColor Cyan
         for ($i = $currentCount + 1; $i -le $newCount; $i++) {
-            $letter = [char](96 + $i)
-            $stateDir = Join-Path $env:USERPROFILE ".claude-state\account-$letter"
+            $letter = ConvertTo-AccountLetter -Index $i
+            $stateDir = Join-Path (Get-AgentStateRoot -ProjectRoot $ProjectRoot) "account-$letter"
             if (-not (Test-Path $stateDir)) {
                 New-Item -ItemType Directory -Path $stateDir -Force | Out-Null
                 Write-Host "  + account-$letter" -ForegroundColor Green
@@ -375,7 +405,8 @@ function Invoke-Scale {
     & "$PSScriptRoot\generate-compose.ps1" -NumAccounts $newCount
 
     # Restart containers if running
-    $running = Get-ContainerId -ProjectRoot $ProjectRoot -Service 'claude-a'
+    $primary = Get-PrimaryService -ProjectRoot $ProjectRoot
+    $running = Get-ContainerId -ProjectRoot $ProjectRoot -Service $primary
     if ($running) {
         Write-Host 'Restarting containers...' -ForegroundColor Cyan
         Invoke-Compose -ProjectRoot $ProjectRoot down
@@ -404,6 +435,11 @@ function Invoke-ComposePass {
 }
 
 function Invoke-Usage {
+    if ((Get-AgentRuntime -ProjectRoot $ProjectRoot) -ne 'claude') {
+        Write-LogError 'usage is currently Claude-only; Codex usage aggregation is not supported.'
+        exit 1
+    }
+
     if (-not (Test-Command 'npx')) {
         Write-LogError 'npx not found. Node.js is required to run ccusage.'
         Write-Host '  Install Node.js 20+: https://nodejs.org/' -ForegroundColor Cyan
@@ -486,12 +522,13 @@ function Show-Help {
     Write-Host '  down                  ' -ForegroundColor Green -NoNewline; Write-Host 'Stop all containers'
     Write-Host '  restart               ' -ForegroundColor Green -NoNewline; Write-Host 'Restart all containers'
     Write-Host '  build                 ' -ForegroundColor Green -NoNewline; Write-Host 'Build/rebuild Docker image'
-    Write-Host '  update                ' -ForegroundColor Green -NoNewline; Write-Host 'Rebuild with latest Claude Code and recreate'
+    Write-Host '  update                ' -ForegroundColor Green -NoNewline; Write-Host 'Rebuild with latest agent CLI and recreate'
     Write-Host '  ps                    ' -ForegroundColor Green -NoNewline; Write-Host 'Show container status'
     Write-Host '  logs                  ' -ForegroundColor Green -NoNewline; Write-Host 'Follow container logs'
     Write-Host ''
     Write-Host 'INTERACTIVE' -ForegroundColor White
     Write-Host '  claude [service]      ' -ForegroundColor Green -NoNewline; Write-Host 'Start Claude Code (default: claude-a)'
+    Write-Host '  codex [service]       ' -ForegroundColor Green -NoNewline; Write-Host 'Start OpenAI Codex CLI (default: codex-a)'
     Write-Host '  gh-auth               ' -ForegroundColor Green -NoNewline; Write-Host 'Inject GitHub token from host gh CLI'
     Write-Host '  exec <service>        ' -ForegroundColor Green -NoNewline; Write-Host 'Open shell in a service'
     Write-Host ''
@@ -511,7 +548,8 @@ function Show-Help {
     $svcNames = @(Get-ServiceNames -ProjectRoot $ProjectRoot)
     for ($idx = 0; $idx -lt $svcNames.Count; $idx++) {
         $svc = $svcNames[$idx]
-        $suffix = ($svc -replace '^claude-', '').ToUpper()
+        $prefix = Get-ServicePrefix -ProjectRoot $ProjectRoot
+        $suffix = ($svc -replace "^$([regex]::Escape($prefix))-", '').ToUpper()
         $label = "Account $suffix"
         if ($idx -eq 0) { $label += ' (default)' }
         Write-Host "  $($svc.PadRight(22))" -ForegroundColor Green -NoNewline; Write-Host $label
@@ -584,6 +622,7 @@ switch ($Command) {
     'ps'         { Invoke-Ps }
     'exec'       { Invoke-Exec }
     'claude'     { Invoke-Claude }
+    'codex'      { Invoke-Codex }
     'tui'        { Invoke-Tui }
     'dashboard'  { Invoke-Tui }
     'gh-auth'    { Invoke-GhAuth }

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,13 +1,22 @@
 #!/bin/bash
-# Entrypoint: symlink host claude-config into the account state directory.
-# Host config is mounted read-only at /home/node/.claude-host/
-# Account state is at /home/node/.claude/ (writable)
+# Entrypoint: prepare per-account agent state before running the requested
+# command. Claude remains the default runtime; Codex is selected by setting
+# AGENT_RUNTIME=codex in the generated compose file.
+AGENT_RUNTIME="${AGENT_RUNTIME:-claude}"
+case "$AGENT_RUNTIME" in
+    claude|codex) ;;
+    *)
+        echo "[entrypoint] ERROR: AGENT_RUNTIME must be 'claude' or 'codex' (got: $AGENT_RUNTIME)" >&2
+        exit 1
+        ;;
+esac
 
-# Config source: CLAUDE_CONFIG_SOURCE overrides the default host config path.
-# Set CLAUDE_CONFIG_SOURCE to a path inside the project (e.g., /project/claude-config/global)
-# so that config changes are reflected immediately without running bootstrap on the host.
+# Claude config source: CLAUDE_CONFIG_SOURCE overrides the default host
+# config path. Set CLAUDE_CONFIG_SOURCE to a path inside the project (e.g.,
+# /project/claude-config/global) so config changes are reflected immediately
+# without running bootstrap on the host.
 CONFIG_SOURCE="${CLAUDE_CONFIG_SOURCE:-/home/node/.claude-host}"
-ACCOUNT_DIR="/home/node/.claude"
+ACCOUNT_DIR="${CLAUDE_CONFIG_DIR:-/home/node/.claude}"
 
 # --- Settings transformation ---------------------------------------------------
 # Generate a container-local settings.json from the host settings.
@@ -62,7 +71,7 @@ generate_container_settings() {
     ' "$src" > "${dst}.tmp" && mv "${dst}.tmp" "$dst"
 }
 
-if [ -d "$CONFIG_SOURCE" ]; then
+if [ "$AGENT_RUNTIME" = "claude" ] && [ -d "$CONFIG_SOURCE" ]; then
     # Fix Windows CRLF line endings in shell scripts (bind mounts from Windows
     # hosts may have \r\n even with .gitattributes if the repo lacks one).
     if [ -n "$CLAUDE_CONFIG_SOURCE" ]; then
@@ -278,6 +287,84 @@ if [ -d "$CONFIG_SOURCE" ]; then
                     echo "[entrypoint]   Fix: rebuild base image so Dockerfile's chmod -R a+rwX takes effect" >&2
                 fi
             fi
+        fi
+    fi
+fi
+
+# --- Codex config --------------------------------------------------------------
+# Codex stores mutable auth/session state under CODEX_HOME. Host-managed
+# configuration is mounted separately at /home/node/.codex-host and only
+# non-secret config is linked or copied into CODEX_HOME. auth.json, sessions,
+# caches, and logs are intentionally left in the writable per-account state
+# directory.
+copy_codex_dir() {
+    local src="$1"
+    local dst="$2"
+    rm -rf "$dst" 2>/dev/null
+    mkdir -p "$dst"
+    (cd "$src" && find . -type f 2>/dev/null) | while IFS= read -r rel; do
+        mkdir -p "$dst/$(dirname "$rel")" 2>/dev/null
+        case "$rel" in
+            *.sh)
+                sed 's/\r$//' "$src/$rel" > "$dst/$rel"
+                chmod +x "$dst/$rel" 2>/dev/null || true
+                ;;
+            *)
+                cp "$src/$rel" "$dst/$rel"
+                ;;
+        esac
+    done
+}
+
+link_codex_item() {
+    local src="$1"
+    local dst="$2"
+    local force="$3"
+    if [ "$force" = "true" ] || [ ! -e "$dst" ] || [ ! -L "$dst" ]; then
+        if [ -e "$dst" ] && [ ! -L "$dst" ]; then
+            local backup
+            backup="${dst}.stale.$(date +%s)"
+            mv "$dst" "$backup"
+            echo "[entrypoint] codex: backed up stale $(basename "$dst") to $backup"
+        fi
+        ln -sfn "$src" "$dst"
+    fi
+}
+
+if [ "$AGENT_RUNTIME" = "codex" ]; then
+    CODEX_ACCOUNT_DIR="${CODEX_HOME:-/home/node/.codex}"
+    CODEX_SOURCE="${CODEX_CONFIG_SOURCE:-/home/node/.codex-host}"
+    mkdir -p "$CODEX_ACCOUNT_DIR" /home/node/.agents/skills 2>/dev/null || true
+    chmod 700 "$CODEX_ACCOUNT_DIR" 2>/dev/null || true
+
+    if [ -d "$CODEX_SOURCE" ]; then
+        FORCE_CODEX_LINK="${CODEX_CONFIG_SOURCE:+true}"
+
+        if [ -f "$CODEX_SOURCE/config.toml" ]; then
+            link_codex_item "$CODEX_SOURCE/config.toml" "$CODEX_ACCOUNT_DIR/config.toml" "$FORCE_CODEX_LINK"
+        elif [ -f "$CODEX_SOURCE/config.codex-config.toml" ]; then
+            link_codex_item "$CODEX_SOURCE/config.codex-config.toml" "$CODEX_ACCOUNT_DIR/config.toml" "$FORCE_CODEX_LINK"
+        fi
+
+        if [ -f "$CODEX_SOURCE/AGENTS.md" ]; then
+            link_codex_item "$CODEX_SOURCE/AGENTS.md" "$CODEX_ACCOUNT_DIR/AGENTS.md" "$FORCE_CODEX_LINK"
+        fi
+
+        if [ -d "$CODEX_SOURCE/hooks" ]; then
+            target="$CODEX_ACCOUNT_DIR/hooks"
+            if [ "$FORCE_CODEX_LINK" = "true" ] || [ ! -e "$target" ] || [ ! -L "$target" ]; then
+                if [ -e "$target" ] && [ ! -L "$target" ]; then
+                    backup="${target}.stale.$(date +%s)"
+                    mv "$target" "$backup"
+                    echo "[entrypoint] codex hooks: backed up stale copy to $backup"
+                fi
+                copy_codex_dir "$CODEX_SOURCE/hooks" "$target"
+                echo "[entrypoint] codex hooks: copied and CRLF-normalized"
+            fi
+        fi
+
+        if [ -d "$CODEX_SOURCE/rules" ]; then
+            link_codex_item "$CODEX_SOURCE/rules" "$CODEX_ACCOUNT_DIR/rules" "$FORCE_CODEX_LINK"
         fi
     fi
 fi

--- a/scripts/generate-compose.ps1
+++ b/scripts/generate-compose.ps1
@@ -65,6 +65,10 @@ if ($NumAccounts -lt 1 -or $NumAccounts -gt 702) {
     exit 1
 }
 
+$AgentRuntime = Get-AgentRuntime -ProjectRoot $ProjectRoot
+$ServicePrefix = Get-ServicePrefix -ProjectRoot $ProjectRoot
+$PrimaryService = Get-PrimaryService -ProjectRoot $ProjectRoot
+
 # Container resource envelope (override via .env or host env). Defaults
 # reproduce the historical hardcoded values so existing installs see no
 # behavior change after regenerating.
@@ -107,7 +111,7 @@ function New-BaseCompose {
     for ($i = 1; $i -le $NumAccounts; $i++) {
         $letter = ConvertTo-Letter $i
         $upper  = ConvertTo-UpperLetter $i
-        $svc    = "claude-$letter"
+        $svc    = "$ServicePrefix-$letter"
 
         [void]$sb.AppendLine("  ${svc}:")
 
@@ -115,14 +119,18 @@ function New-BaseCompose {
             [void]$sb.AppendLine('    build:')
             [void]$sb.AppendLine('      context: .')
             [void]$sb.AppendLine('      args:')
-            [void]$sb.AppendLine('        CLAUDE_CODE_VERSION: ${CLAUDE_CODE_VERSION:-}')
+            if ($AgentRuntime -eq 'codex') {
+                [void]$sb.AppendLine('        CODEX_CLI_VERSION: ${CODEX_CLI_VERSION:-}')
+            } else {
+                [void]$sb.AppendLine('        CLAUDE_CODE_VERSION: ${CLAUDE_CODE_VERSION:-}')
+            }
         }
 
         [void]$sb.AppendLine("    image: claude-code-base:`${IMAGE_TAG:-$ImageTag}")
 
         if ($i -gt 1) {
             [void]$sb.AppendLine('    depends_on:')
-            [void]$sb.AppendLine('      - claude-a')
+            [void]$sb.AppendLine("      - $PrimaryService")
         }
 
         [void]$sb.AppendLine('    working_dir: ${CONTAINER_PROJECT_DIR:-/project}')
@@ -130,7 +138,11 @@ function New-BaseCompose {
         # the committed file see why the user line falls back to 1000:1000.
         # The bash generator emits the same four lines verbatim.
         [void]$sb.AppendLine("    # Match the host user's UID/GID so bind-mounted paths")
-        [void]$sb.AppendLine('    # (${HOME}/.claude-state/account-*) stay writable from')
+        if ($AgentRuntime -eq 'codex') {
+            [void]$sb.AppendLine('    # (${HOME}/.codex-state/account-*) stay writable from')
+        } else {
+            [void]$sb.AppendLine('    # (${HOME}/.claude-state/account-*) stay writable from')
+        }
         [void]$sb.AppendLine('    # inside the container. Falls back to 1000:1000 (the')
         [void]$sb.AppendLine('    # upstream node:20-slim default) when UID/GID are unset.')
         [void]$sb.AppendLine('    user: "${UID:-1000}:${GID:-1000}"')
@@ -138,8 +150,14 @@ function New-BaseCompose {
         [void]$sb.AppendLine('    tty: true')
         [void]$sb.AppendLine('    volumes:')
         [void]$sb.AppendLine('      - ${PROJECT_DIR}:${CONTAINER_PROJECT_DIR:-/project}')
-        [void]$sb.AppendLine("      - `${HOME}/.claude-state/account-${letter}:/home/node/.claude")
-        [void]$sb.AppendLine('      - ${HOME}/.claude:/home/node/.claude-host:ro')
+        if ($AgentRuntime -eq 'codex') {
+            [void]$sb.AppendLine("      - `${HOME}/.codex-state/account-${letter}:/home/node/.codex")
+            [void]$sb.AppendLine('      - ${HOME}/.codex:/home/node/.codex-host:ro')
+            [void]$sb.AppendLine('      - ${AGENTS_SKILLS_DIR:-${HOME}/.agents/skills}:/home/node/.agents/skills:ro')
+        } else {
+            [void]$sb.AppendLine("      - `${HOME}/.claude-state/account-${letter}:/home/node/.claude")
+            [void]$sb.AppendLine('      - ${HOME}/.claude:/home/node/.claude-host:ro')
+        }
         [void]$sb.AppendLine('      - ${GH_CONFIG_DIR:-${HOME}/.config/gh}:/home/node/.config/gh:ro')
         [void]$sb.AppendLine("      - node_modules_${letter}:`${CONTAINER_PROJECT_DIR:-/project}/node_modules")
         [void]$sb.AppendLine('    environment:')
@@ -147,20 +165,32 @@ function New-BaseCompose {
         [void]$sb.AppendLine('      - TZ=${TZ:-UTC}')
         # When the container runs as the host UID instead of node(1000),
         # the passwd entry for that UID is missing, so $HOME defaults to
-        # /. Pinning HOME keeps ~/.claude, ~/.config, etc. resolvable.
+        # /. Pinning HOME keeps runtime state, ~/.config, etc. resolvable.
         [void]$sb.AppendLine('      - HOME=/home/node')
-        [void]$sb.AppendLine('      - CLAUDE_CONFIG_DIR=/home/node/.claude')
-        [void]$sb.AppendLine('      - CLAUDE_CONFIG_SOURCE=${CLAUDE_CONFIG_SOURCE:-}')
-        [void]$sb.AppendLine('      - CLAUDE_NORMALIZE_CRLF=${CLAUDE_NORMALIZE_CRLF:-}')
+        if ($AgentRuntime -eq 'codex') {
+            [void]$sb.AppendLine('      - AGENT_RUNTIME=codex')
+            [void]$sb.AppendLine('      - CODEX_HOME=/home/node/.codex')
+            [void]$sb.AppendLine('      - CODEX_CONFIG_SOURCE=${CODEX_CONFIG_SOURCE:-}')
+        } else {
+            [void]$sb.AppendLine('      - CLAUDE_CONFIG_DIR=/home/node/.claude')
+            [void]$sb.AppendLine('      - CLAUDE_CONFIG_SOURCE=${CLAUDE_CONFIG_SOURCE:-}')
+            [void]$sb.AppendLine('      - CLAUDE_NORMALIZE_CRLF=${CLAUDE_NORMALIZE_CRLF:-}')
+        }
         [void]$sb.AppendLine('      - NODE_OPTIONS=--max-old-space-size=4096')
-        # Only emit ANTHROPIC_API_KEY when CLAUDE_API_KEY_<LETTER> is set at
-        # generate time. Path A (OAuth) users have no value; emitting
-        # ANTHROPIC_API_KEY= with an empty string makes the SDK prefer the
-        # empty env var over .credentials.json in the mounted state dir.
-        $keyVarName = "CLAUDE_API_KEY_${upper}"
+        # Only emit provider API keys when a per-account key is set at
+        # generate time. Emitting an empty key makes SDKs prefer the blank env
+        # var over persisted credentials in the mounted state dir.
+        $keyVarName = if ($AgentRuntime -eq 'codex') { "CODEX_API_KEY_${upper}" } else { "CLAUDE_API_KEY_${upper}" }
         $keyValue = [Environment]::GetEnvironmentVariable($keyVarName)
+        if ([string]::IsNullOrEmpty($keyValue) -and $envData.ContainsKey($keyVarName)) {
+            $keyValue = $envData[$keyVarName]
+        }
         if (-not [string]::IsNullOrEmpty($keyValue)) {
-            [void]$sb.AppendLine("      - ANTHROPIC_API_KEY=`${CLAUDE_API_KEY_${upper}}")
+            if ($AgentRuntime -eq 'codex') {
+                [void]$sb.AppendLine("      - OPENAI_API_KEY=`${CODEX_API_KEY_${upper}}")
+            } else {
+                [void]$sb.AppendLine("      - ANTHROPIC_API_KEY=`${CLAUDE_API_KEY_${upper}}")
+            }
         }
         [void]$sb.AppendLine('      - GH_TOKEN=${GH_TOKEN:-}')
         [void]$sb.AppendLine('      - GIT_USER_NAME=${GIT_USER_NAME:-}')
@@ -206,7 +236,7 @@ function New-WorktreeCompose {
     for ($i = 1; $i -le $NumAccounts; $i++) {
         $letter = ConvertTo-Letter $i
         $upper  = ConvertTo-UpperLetter $i
-        $svc    = "claude-$letter"
+        $svc    = "$ServicePrefix-$letter"
 
         [void]$sb.AppendLine("  ${svc}:")
         [void]$sb.AppendLine("    working_dir: `${CONTAINER_PROJECT_DIR_${upper}:-/project-$letter}")
@@ -237,7 +267,7 @@ function New-LinuxCompose {
 
     for ($i = 1; $i -le $NumAccounts; $i++) {
         $letter = ConvertTo-Letter $i
-        $svc    = "claude-$letter"
+        $svc    = "$ServicePrefix-$letter"
 
         [void]$sb.AppendLine("  ${svc}:")
         [void]$sb.AppendLine('    user: "${UID}:${GID}"')

--- a/scripts/generate-compose.sh
+++ b/scripts/generate-compose.sh
@@ -18,6 +18,8 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 . "$SCRIPT_DIR/lib/parse_env.sh"
 # shellcheck source=lib/index.sh
 . "$SCRIPT_DIR/lib/index.sh"
+# shellcheck source=lib/runtime.sh
+. "$SCRIPT_DIR/lib/runtime.sh"
 
 # --- Read configuration -------------------------------------------------------
 
@@ -25,6 +27,9 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 load_env_file "$PROJECT_ROOT/.env"
 
 NUM_ACCOUNTS="${NUM_ACCOUNTS:-2}"
+AGENT_RUNTIME="$(agent_runtime)"
+SERVICE_PREFIX="$(agent_service_prefix)"
+PRIMARY_SERVICE="${SERVICE_PREFIX}-a"
 
 # IMAGE_TAG defaults come from the repo-root VERSION file — single source of
 # truth shared with install.sh and the "Bumping the Base Image" README
@@ -70,7 +75,7 @@ generate_base() {
             letter=$(index_to_letter "$i")
             local upper
             upper=$(index_to_upper "$i")
-            local svc="claude-${letter}"
+            local svc="${SERVICE_PREFIX}-${letter}"
 
             echo "  ${svc}:"
 
@@ -79,20 +84,29 @@ generate_base() {
                 echo "    build:"
                 echo "      context: ."
                 echo "      args:"
-                echo "        CLAUDE_CODE_VERSION: \${CLAUDE_CODE_VERSION:-}"
+                if [[ "$AGENT_RUNTIME" == "codex" ]]; then
+                    echo "        CODEX_CLI_VERSION: \${CODEX_CLI_VERSION:-}"
+                else
+                    echo "        CLAUDE_CODE_VERSION: \${CLAUDE_CODE_VERSION:-}"
+                fi
             fi
 
             echo "    image: claude-code-base:\${IMAGE_TAG:-${IMAGE_TAG}}"
 
-            # All services after the first depend on claude-a (for build ordering)
+            # All services after the first depend on the first account service
+            # for build ordering.
             if [[ "$i" -gt 1 ]]; then
                 echo "    depends_on:"
-                echo "      - claude-a"
+                echo "      - ${PRIMARY_SERVICE}"
             fi
 
             echo "    working_dir: \${CONTAINER_PROJECT_DIR:-/project}"
             echo "    # Match the host user's UID/GID so bind-mounted paths"
-            echo "    # (\${HOME}/.claude-state/account-*) stay writable from"
+            if [[ "$AGENT_RUNTIME" == "codex" ]]; then
+                echo "    # (\${HOME}/.codex-state/account-*) stay writable from"
+            else
+                echo "    # (\${HOME}/.claude-state/account-*) stay writable from"
+            fi
             echo "    # inside the container. Falls back to 1000:1000 (the"
             echo "    # upstream node:20-slim default) when UID/GID are unset."
             echo "    user: \"\${UID:-1000}:\${GID:-1000}\""
@@ -100,8 +114,14 @@ generate_base() {
             echo "    tty: true"
             echo "    volumes:"
             echo "      - \${PROJECT_DIR}:\${CONTAINER_PROJECT_DIR:-/project}"
-            echo "      - \${HOME}/.claude-state/account-${letter}:/home/node/.claude"
-            echo "      - \${HOME}/.claude:/home/node/.claude-host:ro"
+            if [[ "$AGENT_RUNTIME" == "codex" ]]; then
+                echo "      - \${HOME}/.codex-state/account-${letter}:/home/node/.codex"
+                echo "      - \${HOME}/.codex:/home/node/.codex-host:ro"
+                echo '      - ${AGENTS_SKILLS_DIR:-${HOME}/.agents/skills}:/home/node/.agents/skills:ro'
+            else
+                echo "      - \${HOME}/.claude-state/account-${letter}:/home/node/.claude"
+                echo "      - \${HOME}/.claude:/home/node/.claude-host:ro"
+            fi
             echo "      - \${GH_CONFIG_DIR:-\${HOME}/.config/gh}:/home/node/.config/gh:ro"
             echo "      - node_modules_${letter}:\${CONTAINER_PROJECT_DIR:-/project}/node_modules"
             echo "    environment:"
@@ -109,19 +129,34 @@ generate_base() {
             echo "      - TZ=\${TZ:-UTC}"
             # When the container runs as the host UID instead of node(1000),
             # the passwd entry for that UID is missing, so \$HOME defaults
-            # to /. Pinning HOME keeps ~/.claude, ~/.config, etc. resolvable.
+            # to /. Pinning HOME keeps runtime state, ~/.config, etc.
+            # resolvable.
             echo "      - HOME=/home/node"
-            echo "      - CLAUDE_CONFIG_DIR=/home/node/.claude"
-            echo "      - CLAUDE_CONFIG_SOURCE=\${CLAUDE_CONFIG_SOURCE:-}"
-            echo "      - CLAUDE_NORMALIZE_CRLF=\${CLAUDE_NORMALIZE_CRLF:-}"
+            if [[ "$AGENT_RUNTIME" == "codex" ]]; then
+                echo "      - AGENT_RUNTIME=codex"
+                echo "      - CODEX_HOME=/home/node/.codex"
+                echo "      - CODEX_CONFIG_SOURCE=\${CODEX_CONFIG_SOURCE:-}"
+            else
+                echo "      - CLAUDE_CONFIG_DIR=/home/node/.claude"
+                echo "      - CLAUDE_CONFIG_SOURCE=\${CLAUDE_CONFIG_SOURCE:-}"
+                echo "      - CLAUDE_NORMALIZE_CRLF=\${CLAUDE_NORMALIZE_CRLF:-}"
+            fi
             echo "      - NODE_OPTIONS=--max-old-space-size=4096"
-            # Only emit ANTHROPIC_API_KEY when CLAUDE_API_KEY_<LETTER> is
-            # set at generate time. Path A (OAuth) users have no value;
-            # emitting ANTHROPIC_API_KEY= with an empty string makes the
-            # SDK prefer the empty env var over .credentials.json.
-            local key_var="CLAUDE_API_KEY_${upper}"
+            # Only emit provider API keys when a per-account key is set at
+            # generate time. Emitting an empty key makes SDKs prefer the
+            # blank env var over persisted credentials.
+            local key_var
+            if [[ "$AGENT_RUNTIME" == "codex" ]]; then
+                key_var="CODEX_API_KEY_${upper}"
+            else
+                key_var="CLAUDE_API_KEY_${upper}"
+            fi
             if [[ -n "${!key_var:-}" ]]; then
-                echo "      - ANTHROPIC_API_KEY=\${CLAUDE_API_KEY_${upper}}"
+                if [[ "$AGENT_RUNTIME" == "codex" ]]; then
+                    echo "      - OPENAI_API_KEY=\${CODEX_API_KEY_${upper}}"
+                else
+                    echo "      - ANTHROPIC_API_KEY=\${CLAUDE_API_KEY_${upper}}"
+                fi
             fi
             echo "      - GH_TOKEN=\${GH_TOKEN:-}"
             echo "      - GIT_USER_NAME=\${GIT_USER_NAME:-}"
@@ -170,7 +205,7 @@ generate_worktree() {
             letter=$(index_to_letter "$i")
             local upper
             upper=$(index_to_upper "$i")
-            local svc="claude-${letter}"
+            local svc="${SERVICE_PREFIX}-${letter}"
 
             echo "  ${svc}:"
             echo "    working_dir: \${CONTAINER_PROJECT_DIR_${upper}:-/project-${letter}}"
@@ -201,7 +236,7 @@ generate_linux() {
         for i in $(seq 1 "$NUM_ACCOUNTS"); do
             local letter
             letter=$(index_to_letter "$i")
-            local svc="claude-${letter}"
+            local svc="${SERVICE_PREFIX}-${letter}"
 
             echo "  ${svc}:"
             echo "    user: \"\${UID}:\${GID}\""

--- a/scripts/lib/runtime.sh
+++ b/scripts/lib/runtime.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# runtime.sh — Shared agent-runtime helpers for bash callers.
+#
+# Runtime selection is opt-in via AGENT_RUNTIME=codex. The default remains
+# Claude so existing generated compose files and wrapper commands keep their
+# historical behavior.
+
+if [[ -n "${_CLAUDE_DOCKER_RUNTIME_SH_SOURCED:-}" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+_CLAUDE_DOCKER_RUNTIME_SH_SOURCED=1
+
+agent_runtime() {
+    local runtime="${AGENT_RUNTIME:-}"
+    if [[ -z "$runtime" && -n "${PROJECT_ROOT:-}" ]]; then
+        runtime=$(parse_env_value "${PROJECT_ROOT}/.env" "AGENT_RUNTIME")
+    fi
+    runtime="${runtime:-claude}"
+    runtime="${runtime,,}"
+    case "$runtime" in
+        claude|codex) printf '%s' "$runtime" ;;
+        *)
+            echo "Error: AGENT_RUNTIME must be 'claude' or 'codex' (got: $runtime)" >&2
+            return 1
+            ;;
+    esac
+}
+
+agent_service_prefix() {
+    agent_runtime
+}
+
+agent_state_root() {
+    case "$(agent_runtime)" in
+        codex) printf '%s/.codex-state' "$HOME" ;;
+        *)     printf '%s/.claude-state' "$HOME" ;;
+    esac
+}
+
+agent_binary() {
+    agent_runtime
+}
+
+agent_skip_permissions_flag() {
+    case "$(agent_runtime)" in
+        codex) printf '%s' "--dangerously-bypass-approvals-and-sandbox" ;;
+        *)     printf '%s' "--dangerously-skip-permissions" ;;
+    esac
+}

--- a/tui/internal/account/account.go
+++ b/tui/internal/account/account.go
@@ -7,7 +7,8 @@ type AuthType int
 const (
 	AuthNone   AuthType = iota
 	AuthOAuth           // .credentials.json present
-	AuthAPIKey          // CLAUDE_API_KEY_* set in .env
+	AuthAPIKey          // provider API key set in .env
+	AuthLogin           // runtime-specific login state present
 )
 
 func (a AuthType) String() string {
@@ -16,6 +17,8 @@ func (a AuthType) String() string {
 		return "OAuth"
 	case AuthAPIKey:
 		return "Key"
+	case AuthLogin:
+		return "Login"
 	default:
 		return "--"
 	}

--- a/tui/internal/account/manager.go
+++ b/tui/internal/account/manager.go
@@ -48,6 +48,15 @@ func (m *Manager) ListAccounts() ([]Account, error) {
 }
 
 func detectAuthType(sd config.StateDir, env *config.Env, letter string) AuthType {
+	if env != nil && env.AgentRuntime() == config.RuntimeCodex {
+		if env.APIKey(letter) != "" {
+			return AuthAPIKey
+		}
+		if sd.HasCodexAuth() {
+			return AuthLogin
+		}
+		return AuthNone
+	}
 	if sd.HasCredentials() {
 		return AuthOAuth
 	}
@@ -181,7 +190,10 @@ func writeAPICooldown(stateDirPath string) {
 
 // ClearAPICooldowns removes all API cooldown files so the next refresh retries the API.
 func (m *Manager) ClearAPICooldowns() {
-	stateDirs, _ := config.DiscoverStateDirs()
+	if m.env != nil && !m.env.SupportsClaudeUsage() {
+		return
+	}
+	stateDirs, _ := config.DiscoverStateDirsForRuntime(config.RuntimeClaude)
 	for _, sd := range stateDirs {
 		os.Remove(filepath.Join(sd.Path, apiCooldownFile))
 	}

--- a/tui/internal/account/manager_helpers.go
+++ b/tui/internal/account/manager_helpers.go
@@ -22,7 +22,7 @@ import (
 // the highest discovered letter index, whichever is larger).
 func (m *Manager) discoverStateDirs() (map[string]config.StateDir, int) {
 	n := m.env.NumAccounts()
-	dirs, _ := config.DiscoverStateDirs()
+	dirs, _ := config.DiscoverStateDirsForRuntime(m.env.AgentRuntime())
 	stateDirMap := make(map[string]config.StateDir, len(dirs))
 	for _, sd := range dirs {
 		stateDirMap[sd.Letter] = sd
@@ -51,9 +51,11 @@ func (m *Manager) fetchContainerStatus() map[string]docker.ContainerInfo {
 // and container status applied.
 func (m *Manager) buildAccounts(n int, stateDirs map[string]config.StateDir, containerMap map[string]docker.ContainerInfo) []Account {
 	accounts := make([]Account, n)
+	servicePrefix := m.env.ServicePrefix()
+	claudeUsage := m.env.SupportsClaudeUsage()
 	for i := 1; i <= n; i++ {
 		letter := config.IndexToLetter(i)
-		svcName := "claude-" + letter
+		svcName := servicePrefix + "-" + letter
 
 		acct := Account{
 			Letter:      letter,
@@ -64,23 +66,25 @@ func (m *Manager) buildAccounts(n int, stateDirs map[string]config.StateDir, con
 			acct.StateDirPath = sd.Path
 			acct.AuthType = detectAuthType(sd, m.env, letter)
 
-			// Parse limitline cache for usage data (this account's own cache).
-			if sd.HasLimitlineCache() {
+			// Parse Claude limitline cache for usage data (this account's own cache).
+			if claudeUsage && sd.HasLimitlineCache() {
 				acct.FiveHourUsage, acct.SevenDayUsage = parseLimitlineCache(sd.LimitlineCachePath())
 			}
 
 			// JSONL token summary (always populated when session data exists).
 			// Uses the manager-scoped cache so unchanged session files are
 			// not re-read and re-decoded on every dashboard refresh.
-			if sessions, err := usage.ScanAccountSessionsWithCache(sd.ProjectsDir(), m.usageCache); err == nil && len(sessions) > 0 {
-				opts := usage.AllTimeOptions()
-				tokens := usage.AggregateSessions(sessions, opts)
-				count := usage.CountFilteredSessions(sessions, opts)
-				acct.Tokens = &TokenSummary{
-					InputTokens:  tokens.InputTokens,
-					OutputTokens: tokens.OutputTokens,
-					CacheTokens:  tokens.CacheCreationInputTokens + tokens.CacheReadInputTokens,
-					SessionCount: count,
+			if claudeUsage {
+				if sessions, err := usage.ScanAccountSessionsWithCache(sd.ProjectsDir(), m.usageCache); err == nil && len(sessions) > 0 {
+					opts := usage.AllTimeOptions()
+					tokens := usage.AggregateSessions(sessions, opts)
+					count := usage.CountFilteredSessions(sessions, opts)
+					acct.Tokens = &TokenSummary{
+						InputTokens:  tokens.InputTokens,
+						OutputTokens: tokens.OutputTokens,
+						CacheTokens:  tokens.CacheCreationInputTokens + tokens.CacheReadInputTokens,
+						SessionCount: count,
+					}
 				}
 			}
 		}
@@ -147,6 +151,9 @@ func (m *Manager) enrichGHAuth(a *Account, wg *sync.WaitGroup) {
 // cooldown so we don't hammer the API after a 429. Successful responses
 // are recorded in results for writeCacheUpdates to persist.
 func (m *Manager) enrichAPIUsage(a *Account, results map[string]apiResult, mu *sync.Mutex, wg *sync.WaitGroup) {
+	if m.env != nil && !m.env.SupportsClaudeUsage() {
+		return
+	}
 	if a.AuthType != AuthOAuth || a.StateDirPath == "" {
 		return
 	}

--- a/tui/internal/account/manager_helpers_test.go
+++ b/tui/internal/account/manager_helpers_test.go
@@ -84,6 +84,33 @@ func TestDiscoverStateDirs_EmptyHome(t *testing.T) {
 	}
 }
 
+func TestDiscoverStateDirs_CodexRuntime(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	stateBase := filepath.Join(tmp, ".codex-state")
+	if err := os.MkdirAll(filepath.Join(stateBase, "account-a"), 0755); err != nil {
+		t.Fatalf("mkdir codex state: %v", err)
+	}
+
+	env := config.NewEmptyEnv(filepath.Join(tmp, ".env"))
+	env.Set("AGENT_RUNTIME", "codex")
+	env.Set("NUM_ACCOUNTS", "1")
+	m := newTestManager(t, env)
+
+	stateDirs, n := m.discoverStateDirs()
+	if n != 1 {
+		t.Errorf("n = %d, want 1", n)
+	}
+	sd, ok := stateDirs["a"]
+	if !ok {
+		t.Fatal("missing codex state dir for account a")
+	}
+	if got, want := sd.Path, filepath.Join(stateBase, "account-a"); got != want {
+		t.Errorf("codex state path = %q, want %q", got, want)
+	}
+}
+
 // TestFetchContainerStatus confirms the helper returns an empty map when
 // the docker client cannot enumerate containers (no compose project, no
 // daemon). The orchestrator must continue to function in this degraded
@@ -143,6 +170,26 @@ func TestEnrichAPIUsage_NonOAuthIsNoop(t *testing.T) {
 	}
 	if len(results) != 0 {
 		t.Errorf("results len = %d, want 0", len(results))
+	}
+}
+
+func TestBuildAccounts_CodexRuntime(t *testing.T) {
+	tmp := t.TempDir()
+	env := config.NewEmptyEnv(filepath.Join(tmp, ".env"))
+	env.Set("AGENT_RUNTIME", "codex")
+	env.Set("CODEX_API_KEY_A", "sk-openai")
+	m := newTestManager(t, env)
+
+	stateDir := config.StateDir{Letter: "a", Path: t.TempDir()}
+	accounts := m.buildAccounts(1, map[string]config.StateDir{"a": stateDir}, map[string]docker.ContainerInfo{})
+	if len(accounts) != 1 {
+		t.Fatalf("len(accounts) = %d, want 1", len(accounts))
+	}
+	if got := accounts[0].ServiceName; got != "codex-a" {
+		t.Errorf("ServiceName = %q, want codex-a", got)
+	}
+	if got := accounts[0].AuthType; got != AuthAPIKey {
+		t.Errorf("AuthType = %v, want AuthAPIKey", got)
 	}
 }
 

--- a/tui/internal/account/manager_test.go
+++ b/tui/internal/account/manager_test.go
@@ -132,6 +132,9 @@ func TestStateDir_PathHelpers(t *testing.T) {
 	if got, want := sd.CredentialsPath(), filepath.Join(base, ".credentials.json"); got != want {
 		t.Errorf("CredentialsPath = %q, want %q", got, want)
 	}
+	if got, want := sd.CodexAuthPath(), filepath.Join(base, "auth.json"); got != want {
+		t.Errorf("CodexAuthPath = %q, want %q", got, want)
+	}
 	if got, want := sd.LimitlineCachePath(), filepath.Join(base, "limitline-usage-cache.json"); got != want {
 		t.Errorf("LimitlineCachePath = %q, want %q", got, want)
 	}
@@ -140,6 +143,9 @@ func TestStateDir_PathHelpers(t *testing.T) {
 	}
 	if sd.HasCredentials() {
 		t.Error("HasCredentials should be false for non-existent path")
+	}
+	if sd.HasCodexAuth() {
+		t.Error("HasCodexAuth should be false for non-existent path")
 	}
 	if sd.HasLimitlineCache() {
 		t.Error("HasLimitlineCache should be false for non-existent path")

--- a/tui/internal/config/env.go
+++ b/tui/internal/config/env.go
@@ -10,6 +10,11 @@ import (
 	"strings"
 )
 
+const (
+	RuntimeClaude = "claude"
+	RuntimeCodex  = "codex"
+)
+
 // Env holds parsed .env configuration with order-preserving entries.
 type Env struct {
 	path    string
@@ -142,9 +147,70 @@ func (e *Env) NumAccounts() int {
 	return n
 }
 
-// APIKey returns CLAUDE_API_KEY_<LETTER> if set.
+// AgentRuntime returns the selected agent runtime. Claude is the default.
+func (e *Env) AgentRuntime() string {
+	if e == nil {
+		return RuntimeClaude
+	}
+	v := strings.ToLower(strings.TrimSpace(e.Get("AGENT_RUNTIME")))
+	switch v {
+	case RuntimeCodex:
+		return RuntimeCodex
+	default:
+		return RuntimeClaude
+	}
+}
+
+// ServicePrefix returns the docker compose service prefix for the runtime.
+func (e *Env) ServicePrefix() string {
+	return e.AgentRuntime()
+}
+
+// StateDirName returns the host-side state directory name for the runtime.
+func (e *Env) StateDirName() string {
+	return StateDirNameForRuntime(e.AgentRuntime())
+}
+
+// RuntimeBinary returns the executable used inside the container.
+func (e *Env) RuntimeBinary() string {
+	return e.AgentRuntime()
+}
+
+// SkipPermissionsFlag returns the runtime-specific unsafe permission bypass flag.
+func (e *Env) SkipPermissionsFlag() string {
+	if e.AgentRuntime() == RuntimeCodex {
+		return "--dangerously-bypass-approvals-and-sandbox"
+	}
+	return "--dangerously-skip-permissions"
+}
+
+// RuntimeCommandArgs returns the command used to attach to the selected agent.
+func (e *Env) RuntimeCommandArgs(skipPermissions bool) []string {
+	args := []string{e.RuntimeBinary()}
+	if e.AgentRuntime() == RuntimeCodex {
+		args = append(args, "-c", `cli_auth_credentials_store="file"`)
+	}
+	if skipPermissions {
+		args = append(args, e.SkipPermissionsFlag())
+	}
+	return args
+}
+
+// SupportsClaudeUsage reports whether Claude-specific usage integrations apply.
+func (e *Env) SupportsClaudeUsage() bool {
+	return e.AgentRuntime() == RuntimeClaude
+}
+
+// APIKey returns the per-account provider API key if set.
 func (e *Env) APIKey(letter string) string {
-	return e.Get("CLAUDE_API_KEY_" + strings.ToUpper(letter))
+	if e == nil {
+		return ""
+	}
+	prefix := "CLAUDE_API_KEY_"
+	if e.AgentRuntime() == RuntimeCodex {
+		prefix = "CODEX_API_KEY_"
+	}
+	return e.Get(prefix + strings.ToUpper(letter))
 }
 
 // HasWorktrees returns true if PROJECT_DIR_A is set (worktree mode).

--- a/tui/internal/config/env_test.go
+++ b/tui/internal/config/env_test.go
@@ -225,3 +225,49 @@ func TestAPIKey_CaseInsensitiveLetter(t *testing.T) {
 		t.Errorf("APIKey(z) missing should be empty, got %q", v)
 	}
 }
+
+func TestAgentRuntime_DefaultAndCodex(t *testing.T) {
+	cases := []struct {
+		content string
+		want    string
+	}{
+		{"", RuntimeClaude},
+		{"AGENT_RUNTIME=claude\n", RuntimeClaude},
+		{"AGENT_RUNTIME=codex\n", RuntimeCodex},
+		{"AGENT_RUNTIME=invalid\n", RuntimeClaude},
+	}
+	for _, c := range cases {
+		path := writeTempEnv(t, c.content)
+		e, err := LoadEnv(path)
+		if err != nil {
+			t.Fatalf("LoadEnv(%q): %v", c.content, err)
+		}
+		if got := e.AgentRuntime(); got != c.want {
+			t.Errorf("content=%q: AgentRuntime() = %q, want %q", c.content, got, c.want)
+		}
+	}
+}
+
+func TestCodexRuntimeAPIKeyAndCommandArgs(t *testing.T) {
+	path := writeTempEnv(t, "AGENT_RUNTIME=codex\nCODEX_API_KEY_A=sk-openai\nCLAUDE_API_KEY_A=sk-ant\n")
+	e, err := LoadEnv(path)
+	if err != nil {
+		t.Fatalf("LoadEnv: %v", err)
+	}
+	if got := e.APIKey("a"); got != "sk-openai" {
+		t.Errorf("APIKey(a) = %q, want codex key", got)
+	}
+	if got := e.StateDirName(); got != ".codex-state" {
+		t.Errorf("StateDirName() = %q, want .codex-state", got)
+	}
+	wantArgs := []string{"codex", "-c", `cli_auth_credentials_store="file"`, "--dangerously-bypass-approvals-and-sandbox"}
+	gotArgs := e.RuntimeCommandArgs(true)
+	if len(gotArgs) != len(wantArgs) {
+		t.Fatalf("RuntimeCommandArgs len = %d, want %d (%v)", len(gotArgs), len(wantArgs), gotArgs)
+	}
+	for i := range wantArgs {
+		if gotArgs[i] != wantArgs[i] {
+			t.Errorf("RuntimeCommandArgs[%d] = %q, want %q", i, gotArgs[i], wantArgs[i])
+		}
+	}
+}

--- a/tui/internal/config/state.go
+++ b/tui/internal/config/state.go
@@ -33,6 +33,11 @@ func (s StateDir) CredentialsPath() string {
 	return filepath.Join(s.Path, ".credentials.json")
 }
 
+// CodexAuthPath returns the path to Codex auth.json in this state dir.
+func (s StateDir) CodexAuthPath() string {
+	return filepath.Join(s.Path, "auth.json")
+}
+
 // LimitlineCachePath returns the path to the limitline usage cache.
 func (s StateDir) LimitlineCachePath() string {
 	return filepath.Join(s.Path, "limitline-usage-cache.json")
@@ -49,6 +54,12 @@ func (s StateDir) HasCredentials() bool {
 	return err == nil
 }
 
+// HasCodexAuth returns true if Codex auth.json exists.
+func (s StateDir) HasCodexAuth() bool {
+	_, err := os.Stat(s.CodexAuthPath())
+	return err == nil
+}
+
 // HasLimitlineCache returns true if limitline-usage-cache.json exists.
 func (s StateDir) HasLimitlineCache() bool {
 	_, err := os.Stat(s.LimitlineCachePath())
@@ -57,11 +68,31 @@ func (s StateDir) HasLimitlineCache() bool {
 
 // DiscoverStateDirs finds all account state directories under ~/.claude-state/.
 func DiscoverStateDirs() ([]StateDir, error) {
-	home, err := os.UserHomeDir()
+	return DiscoverStateDirsForRuntime(RuntimeClaude)
+}
+
+// StateDirNameForRuntime returns the host-side state directory name.
+func StateDirNameForRuntime(runtime string) string {
+	if runtime == RuntimeCodex {
+		return ".codex-state"
+	}
+	return ".claude-state"
+}
+
+// DiscoverStateDirsForRuntime finds all account state directories for runtime.
+func DiscoverStateDirsForRuntime(runtime string) ([]StateDir, error) {
+	home, err := userHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("resolve home dir: %w", err)
 	}
-	return DiscoverStateDirsAt(filepath.Join(home, ".claude-state"))
+	return DiscoverStateDirsAt(filepath.Join(home, StateDirNameForRuntime(runtime)))
+}
+
+func userHomeDir() (string, error) {
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+	return os.UserHomeDir()
 }
 
 // DiscoverStateDirsAt finds account state directories under the given base path.

--- a/tui/internal/docker/client.go
+++ b/tui/internal/docker/client.go
@@ -136,12 +136,14 @@ func (c *Client) HasRunningContainers() bool {
 // ServiceNames returns the expected service names based on NUM_ACCOUNTS.
 func (c *Client) ServiceNames() []string {
 	n := 1
+	prefix := config.RuntimeClaude
 	if c.env != nil {
 		n = c.env.NumAccounts()
+		prefix = c.env.ServicePrefix()
 	}
 	names := make([]string, n)
 	for i := 1; i <= n; i++ {
-		names[i-1] = "claude-" + config.IndexToLetter(i)
+		names[i-1] = prefix + "-" + config.IndexToLetter(i)
 	}
 	return names
 }

--- a/tui/internal/docker/docker_test.go
+++ b/tui/internal/docker/docker_test.go
@@ -152,6 +152,24 @@ func TestExecArgs(t *testing.T) {
 	}
 }
 
+func TestServiceNames_CodexRuntime(t *testing.T) {
+	env := config.NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+	env.Set("AGENT_RUNTIME", "codex")
+	env.Set("NUM_ACCOUNTS", "2")
+	c := NewClient("/tmp/proj", env)
+
+	got := c.ServiceNames()
+	want := []string{"codex-a", "codex-b"}
+	if len(got) != len(want) {
+		t.Fatalf("ServiceNames len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("ServiceNames[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 // TestBuildArgs verifies the binary is "docker", "build" is always present,
 // and "--no-cache" is added only when noCache is true.
 func TestBuildArgs(t *testing.T) {

--- a/tui/internal/ui/app.go
+++ b/tui/internal/ui/app.go
@@ -77,7 +77,7 @@ func (a App) View() string {
 	title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#06B6D4")).
 		Render(fmt.Sprintf(" claude-docker %s", a.version))
 	summary := lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280")).
-		Render(fmt.Sprintf("  %d accounts", count))
+		Render(fmt.Sprintf("  %s  %d accounts", a.env.AgentRuntime(), count))
 	b.WriteString(title + summary + "\n\n")
 
 	// Dashboard

--- a/tui/internal/ui/dashboard/model.go
+++ b/tui/internal/ui/dashboard/model.go
@@ -20,7 +20,7 @@ const (
 	opDown
 	opBuild
 	opBuildNoCache
-	opUpdateBuild   // step 1 of update chain
+	opUpdateBuild    // step 1 of update chain
 	opUpdateRecreate // step 2 of update chain
 	opRestart
 	opGHAuthRecreate
@@ -48,8 +48,8 @@ type Model struct {
 	width         int
 	height        int
 	loading       bool
-	refreshing    bool      // true while Refresh is in-flight
-	tickActive    bool      // true while a 1s tick chain is running (prevents duplicates)
+	refreshing    bool // true while Refresh is in-flight
+	tickActive    bool // true while a 1s tick chain is running (prevents duplicates)
 	err           error
 	retryCount    int       // number of auto-retries since TUI started
 	lastRefreshAt time.Time // time of last refresh completion
@@ -58,7 +58,7 @@ type Model struct {
 	// Action state (Docker rebuild / gh-auth / restart).
 	busy            bool        // true while a background op is running
 	showHelp        bool        // ? toggles a key-map overlay
-	skipPermissions bool        // pass --dangerously-skip-permissions to claude
+	skipPermissions bool        // pass the runtime-specific permission bypass flag
 	statusText      string      // last toast message
 	statusLevel     statusLevel // toast color
 	statusExpiry    time.Time   // when the toast should disappear

--- a/tui/internal/ui/dashboard/update.go
+++ b/tui/internal/ui/dashboard/update.go
@@ -63,7 +63,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		return m, nil
 
 	case sessionFinishedMsg:
-		// After Claude session ends, refresh account list
+		// After an attached agent session ends, refresh account list.
 		return m, m.Refresh()
 
 	case dockerOpDoneMsg:
@@ -144,15 +144,11 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				m.cursor--
 			}
 		case "enter", "c":
-			// Attach to selected account's Claude session
+			// Attach to selected account's agent session.
 			if m.cursor < len(m.accounts) {
 				acct := m.accounts[m.cursor]
 				if acct.IsRunning() {
-					claudeArgs := []string{"claude"}
-					if m.skipPermissions {
-						claudeArgs = append(claudeArgs, "--dangerously-skip-permissions")
-					}
-					bin, args := m.client.ExecArgs(acct.ServiceName, claudeArgs...)
+					bin, args := m.client.ExecArgs(acct.ServiceName, m.env.RuntimeCommandArgs(m.skipPermissions)...)
 					cmd := exec.Command(bin, args...)
 					return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
 						return sessionFinishedMsg{err: err}
@@ -223,10 +219,11 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 		case "p":
 			m.skipPermissions = !m.skipPermissions
+			flag := m.env.SkipPermissionsFlag()
 			if m.skipPermissions {
-				m = m.toast("--dangerously-skip-permissions ON", statusInfo)
+				m = m.toast(flag+" ON", statusInfo)
 			} else {
-				m = m.toast("--dangerously-skip-permissions OFF", statusInfo)
+				m = m.toast(flag+" OFF", statusInfo)
 			}
 			return m, m.toastExpireCmd()
 

--- a/tui/internal/ui/dashboard/view.go
+++ b/tui/internal/ui/dashboard/view.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/kcenon/claude-docker/tui/internal/config"
 )
 
 // View renders the dashboard.
@@ -21,7 +22,7 @@ func (m Model) View() string {
 	}
 
 	if m.showHelp {
-		return renderHelp()
+		return renderHelp(m.env)
 	}
 
 	var b strings.Builder
@@ -64,7 +65,6 @@ func (m Model) View() string {
 		b.WriteString("\n" + toast)
 	}
 
-
 	// API retry status: visible when any account is rate-limited or currently refreshing
 	if m.hasRateLimitedAccounts() || m.refreshing {
 		var statusText string
@@ -101,16 +101,18 @@ func (m Model) View() string {
 }
 
 // renderHelp shows the key-map overlay (dismissed by any key).
-func renderHelp() string {
+func renderHelp(env *config.Env) string {
 	title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#06B6D4")).
 		Render("  Keybindings")
 	key := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#E5E7EB"))
 	desc := lipgloss.NewStyle().Foreground(lipgloss.Color("#9CA3AF"))
+	runtime := env.RuntimeBinary()
+	skipFlag := env.SkipPermissionsFlag()
 
 	rows := [][2]string{
 		{"j / k", "Move cursor down / up"},
-		{"Enter / c", "Attach to selected account's claude session"},
-		{"p", "Toggle --dangerously-skip-permissions"},
+		{"Enter / c", "Attach to selected account's " + runtime + " session"},
+		{"p", "Toggle " + skipFlag},
 		{"r", "Refresh dashboard"},
 		{"u / d", "docker compose up -d / down (all)"},
 		{"b", "docker compose build (cached)"},

--- a/tui/main.go
+++ b/tui/main.go
@@ -19,7 +19,7 @@ func main() {
 	var filteredArgs []string
 	for _, arg := range os.Args[1:] {
 		switch arg {
-		case "--dangerously-skip-permissions":
+		case "--dangerously-skip-permissions", "--dangerously-bypass-approvals-and-sandbox":
 			skipPermissions = true
 		default:
 			filteredArgs = append(filteredArgs, arg)
@@ -127,6 +127,7 @@ func runJSON() error {
 
 	fmt.Printf("{\n")
 	fmt.Printf("  \"project_root\": %q,\n", projectRoot)
+	fmt.Printf("  \"runtime\": %q,\n", env.AgentRuntime())
 	fmt.Printf("  \"num_accounts\": %d,\n", len(accounts))
 	fmt.Printf("  \"accounts\": [\n")
 	for i, a := range accounts {


### PR DESCRIPTION
## What
- Adds an opt-in `AGENT_RUNTIME=codex` runtime path alongside the existing Claude default.
- Installs `@openai/codex` in the base image and adds `codex` wrapper commands for bash and PowerShell.
- Generates `codex-*` services with `.codex-state`, `CODEX_HOME`, `CODEX_CONFIG_SOURCE`, and `CODEX_API_KEY_* -> OPENAI_API_KEY` wiring.
- Teaches the entrypoint and TUI to keep Codex state/config separate while keeping Claude usage APIs Claude-only.
- Documents Codex setup and current usage-tracking limitation.

## Why
Codex needs separate state, config, auth, and service naming so it can run without mutating Claude account state or importing Claude-specific usage integrations.

## Scope
- Default Claude compose generation remains unchanged; verified against the checked-in `docker-compose.yml`.
- Installer/remove flows remain Claude-first and were not broadened in this PR.
- Codex usage aggregation is explicitly not implemented.

## Verification
- `go test ./...` from `tui/`
- `bash -n scripts/claude-docker scripts/generate-compose.sh scripts/entrypoint.sh scripts/lib/runtime.sh`
- PowerShell scriptblock parse for `scripts/ClaudeDocker.psm1`, `scripts/claude-docker.ps1`, `scripts/generate-compose.ps1`
- Bash default compose generation matches checked-in `docker-compose.yml`
- Bash and PowerShell Codex compose generation smoke checks
- `git diff --check`
- `npm view @openai/codex engines version --json`

## Risk
- Codex support is opt-in via `AGENT_RUNTIME=codex`; default Claude behavior is intended to stay unchanged.
- Base image size/build time may increase because Codex CLI is now installed globally.

Refs #264