### PR TITLE
feat(runtime): add JSON runtime registry as cross-language SSOT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
           - tests/test_ccstatusline_xdg_symlink.sh
           - tests/test_parse_env.sh
           - tests/test_parse_env_equivalence.sh
+          - tests/test_runtime_registry_equivalence.sh
           - tests/test_transform_syntax_check.sh
           - tests/test_cleanup_backups.sh
           - scripts/test-entrypoint-settings.sh

--- a/scripts/ClaudeDocker.psm1
+++ b/scripts/ClaudeDocker.psm1
@@ -313,6 +313,68 @@ function Get-NumAccounts {
     return 2
 }
 
+# --- Runtime registry --------------------------------------------------------
+# Runtime-specific values are resolved from the JSON registry at
+# tui/internal/config/runtimes.json — the cross-language single source of
+# truth (see #267). The registry lives under tui/ so Go's go:embed can reach
+# it; this module finds it relative to $ProjectRoot. The parsed registry is
+# cached in a module-scoped variable so ConvertFrom-Json runs only once.
+
+$script:RuntimeRegistryCache = $null
+
+function Get-RuntimeRegistry {
+    <#
+    .SYNOPSIS
+    Parse and cache runtimes.json from the project tree. Returns the parsed
+    PSCustomObject. Parses once per module load.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$ProjectRoot)
+
+    if ($null -ne $script:RuntimeRegistryCache) {
+        return $script:RuntimeRegistryCache
+    }
+    $registryPath = Join-Path $ProjectRoot 'tui/internal/config/runtimes.json'
+    if (-not (Test-Path $registryPath)) {
+        throw "Runtime registry not found: $registryPath"
+    }
+    $script:RuntimeRegistryCache = Get-Content -Raw -Path $registryPath | ConvertFrom-Json
+    return $script:RuntimeRegistryCache
+}
+
+function Get-RuntimeField {
+    <#
+    .SYNOPSIS
+    Return the value of a single field for the named runtime from the
+    registry. Returns $null if the runtime or field is absent.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot,
+        [Parameter(Mandatory)][string]$Runtime,
+        [Parameter(Mandatory)][string]$Field
+    )
+
+    $registry = Get-RuntimeRegistry -ProjectRoot $ProjectRoot
+    $entry = $registry.runtimes.$Runtime
+    if ($null -eq $entry) {
+        return $null
+    }
+    return $entry.$Field
+}
+
+function Get-RuntimeList {
+    <#
+    .SYNOPSIS
+    Return the registered runtime names from the registry, sorted.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$ProjectRoot)
+
+    $registry = Get-RuntimeRegistry -ProjectRoot $ProjectRoot
+    return @($registry.runtimes.PSObject.Properties.Name | Sort-Object)
+}
+
 function Get-AgentRuntime {
     <#
     .SYNOPSIS
@@ -332,8 +394,10 @@ function Get-AgentRuntime {
         $runtime = 'claude'
     }
     $runtime = $runtime.ToLowerInvariant()
-    if ($runtime -notin @('claude', 'codex')) {
-        throw "AGENT_RUNTIME must be 'claude' or 'codex' (got: $runtime)"
+    # Validate against the registry rather than a hardcoded allowlist.
+    $known = Get-RuntimeList -ProjectRoot $ProjectRoot
+    if ($runtime -notin $known) {
+        throw "AGENT_RUNTIME is not a known runtime (got: $runtime)"
     }
     return $runtime
 }
@@ -342,7 +406,8 @@ function Get-ServicePrefix {
     [CmdletBinding()]
     param([Parameter(Mandatory)][string]$ProjectRoot)
 
-    return Get-AgentRuntime -ProjectRoot $ProjectRoot
+    $runtime = Get-AgentRuntime -ProjectRoot $ProjectRoot
+    return Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $runtime -Field 'servicePrefix'
 }
 
 function Get-PrimaryService {
@@ -356,7 +421,8 @@ function Get-AgentStateRoot {
     [CmdletBinding()]
     param([Parameter(Mandatory)][string]$ProjectRoot)
 
-    $dirName = if ((Get-AgentRuntime -ProjectRoot $ProjectRoot) -eq 'codex') { '.codex-state' } else { '.claude-state' }
+    $runtime = Get-AgentRuntime -ProjectRoot $ProjectRoot
+    $dirName = Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $runtime -Field 'stateDir'
     return Join-Path $env:USERPROFILE $dirName
 }
 
@@ -505,6 +571,8 @@ Export-ModuleMember -Function @(
     'Get-NumAccounts', 'Get-AgentRuntime', 'Get-ServicePrefix',
     'Get-PrimaryService', 'Get-AgentStateRoot', 'Get-ServiceNames',
     'ConvertTo-AccountLetter',
+    # Runtime registry
+    'Get-RuntimeField', 'Get-RuntimeList',
     # .env
     'Read-EnvFile', 'Get-EnvValue', 'Write-EnvContent', 'Set-EnvValue',
     # Docker Compose

--- a/scripts/lib/runtime.sh
+++ b/scripts/lib/runtime.sh
@@ -4,11 +4,132 @@
 # Runtime selection is opt-in via AGENT_RUNTIME=codex. The default remains
 # Claude so existing generated compose files and wrapper commands keep their
 # historical behavior.
+#
+# Runtime-specific values are resolved from the JSON registry at
+# tui/internal/config/runtimes.json — the cross-language single source of
+# truth (see #267). The registry lives under tui/ so Go's go:embed can reach
+# it; this file finds it relative to PROJECT_ROOT. Reads use `jq` when it is
+# available (guaranteed inside the container image) and an `awk` state-machine
+# fallback otherwise (the host is not guaranteed to have `jq`).
 
 if [[ -n "${_CLAUDE_DOCKER_RUNTIME_SH_SOURCED:-}" ]]; then
     return 0 2>/dev/null || exit 0
 fi
 _CLAUDE_DOCKER_RUNTIME_SH_SOURCED=1
+
+# _runtime_registry_path
+# Print the path to runtimes.json. Resolves relative to PROJECT_ROOT when set,
+# otherwise relative to this library file's own location.
+_runtime_registry_path() {
+    if [[ -n "${PROJECT_ROOT:-}" ]]; then
+        printf '%s/tui/internal/config/runtimes.json' "$PROJECT_ROOT"
+        return 0
+    fi
+    local self_dir
+    self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    printf '%s/../../tui/internal/config/runtimes.json' "$self_dir"
+}
+
+# _runtime_field_awk FILE RUNTIME FIELD
+# awk fallback reader for the flat per-runtime registry schema. Walks the
+# JSON line by line, tracking which runtime object is currently open, and
+# prints the value of FIELD inside RUNTIME's object. The registry schema is
+# intentionally flat (one depth per runtime) so this reader stays simple.
+# Prints nothing if the (runtime, field) pair is absent.
+_runtime_field_awk() {
+    local file="$1" runtime="$2" field="$3"
+    [[ -r "$file" ]] || return 0
+    awk -v runtime="$runtime" -v field="$field" '
+        BEGIN { in_runtimes = 0; cur = "" }
+        # Track entry into the top-level "runtimes" object.
+        /"runtimes"[[:space:]]*:[[:space:]]*\{/ { in_runtimes = 1; next }
+        in_runtimes == 0 { next }
+        {
+            line = $0
+            # A runtime object opens with  "<name>": {
+            if (cur == "" && match(line, /"[^"]+"[[:space:]]*:[[:space:]]*\{/)) {
+                name = line
+                sub(/^[[:space:]]*"/, "", name)
+                sub(/"[[:space:]]*:.*$/, "", name)
+                if (name == runtime) { cur = name }
+                next
+            }
+            if (cur != "") {
+                # A closing brace ends the current runtime object.
+                if (match(line, /^[[:space:]]*\}/)) { cur = ""; next }
+                # Match  "field": <value>
+                pat = "\"" field "\"[[:space:]]*:[[:space:]]*"
+                if (match(line, pat)) {
+                    val = substr(line, RSTART + RLENGTH)
+                    # Drop a trailing comma.
+                    sub(/,[[:space:]]*$/, "", val)
+                    sub(/[[:space:]]+$/, "", val)
+                    # Unquote string values; leave booleans/numbers as-is.
+                    if (match(val, /^".*"$/)) {
+                        val = substr(val, 2, length(val) - 2)
+                        # Unescape the JSON escapes the registry actually uses.
+                        gsub(/\\"/, "\"", val)
+                        gsub(/\\\\/, "\\", val)
+                    }
+                    print val
+                    exit 0
+                }
+            }
+        }
+    ' "$file"
+}
+
+# runtime_field RUNTIME FIELD
+# Print the value of FIELD for RUNTIME from the registry. Uses `jq` when
+# available, the awk fallback otherwise. Prints nothing if absent. Exit
+# status is always 0 so callers can capture via command substitution.
+#
+# An absent key is distinguished from a present boolean `false` explicitly:
+# `// empty` would treat `false` as missing, so the awk fallback (which
+# prints `false`) and the jq path would disagree. The `if` form keeps both
+# readers byte-identical for every field, including booleans.
+runtime_field() {
+    local runtime="$1" field="$2"
+    local file
+    file="$(_runtime_registry_path)"
+    [[ -r "$file" ]] || return 0
+    if command -v jq >/dev/null 2>&1; then
+        jq -r --arg r "$runtime" --arg f "$field" \
+            'if (.runtimes[$r][$f]) == null then empty else .runtimes[$r][$f] end' \
+            "$file" 2>/dev/null
+        return 0
+    fi
+    _runtime_field_awk "$file" "$runtime" "$field"
+}
+
+# runtime_list
+# Print one registered runtime name per line. Uses `jq` when available,
+# the awk fallback otherwise.
+runtime_list() {
+    local file
+    file="$(_runtime_registry_path)"
+    [[ -r "$file" ]] || return 0
+    if command -v jq >/dev/null 2>&1; then
+        jq -r '.runtimes | keys[]' "$file" 2>/dev/null
+        return 0
+    fi
+    awk '
+        BEGIN { in_runtimes = 0; cur = "" }
+        /"runtimes"[[:space:]]*:[[:space:]]*\{/ { in_runtimes = 1; next }
+        in_runtimes == 0 { next }
+        {
+            if (cur == "" && match($0, /"[^"]+"[[:space:]]*:[[:space:]]*\{/)) {
+                name = $0
+                sub(/^[[:space:]]*"/, "", name)
+                sub(/"[[:space:]]*:.*$/, "", name)
+                print name
+                cur = name
+                next
+            }
+            if (cur != "" && match($0, /^[[:space:]]*\}/)) { cur = "" }
+        }
+    ' "$file"
+}
 
 agent_runtime() {
     local runtime="${AGENT_RUNTIME:-}"
@@ -17,33 +138,39 @@ agent_runtime() {
     fi
     runtime="${runtime:-claude}"
     runtime="${runtime,,}"
-    case "$runtime" in
-        claude|codex) printf '%s' "$runtime" ;;
-        *)
-            echo "Error: AGENT_RUNTIME must be 'claude' or 'codex' (got: $runtime)" >&2
-            return 1
-            ;;
-    esac
+    # Validate against the registry rather than a hardcoded allowlist.
+    local known
+    while IFS= read -r known; do
+        if [[ "$known" == "$runtime" ]]; then
+            printf '%s' "$runtime"
+            return 0
+        fi
+    done < <(runtime_list)
+    echo "Error: AGENT_RUNTIME is not a known runtime (got: $runtime)" >&2
+    return 1
 }
 
 agent_service_prefix() {
-    agent_runtime
+    local runtime
+    runtime="$(agent_runtime)" || return 1
+    runtime_field "$runtime" "servicePrefix"
 }
 
 agent_state_root() {
-    case "$(agent_runtime)" in
-        codex) printf '%s/.codex-state' "$HOME" ;;
-        *)     printf '%s/.claude-state' "$HOME" ;;
-    esac
+    local runtime dir
+    runtime="$(agent_runtime)" || return 1
+    dir="$(runtime_field "$runtime" "stateDir")"
+    printf '%s/%s' "$HOME" "$dir"
 }
 
 agent_binary() {
-    agent_runtime
+    local runtime
+    runtime="$(agent_runtime)" || return 1
+    runtime_field "$runtime" "binary"
 }
 
 agent_skip_permissions_flag() {
-    case "$(agent_runtime)" in
-        codex) printf '%s' "--dangerously-bypass-approvals-and-sandbox" ;;
-        *)     printf '%s' "--dangerously-skip-permissions" ;;
-    esac
+    local runtime
+    runtime="$(agent_runtime)" || return 1
+    runtime_field "$runtime" "skipPermissionsFlag"
 }

--- a/tests/test_runtime_registry_equivalence.sh
+++ b/tests/test_runtime_registry_equivalence.sh
@@ -48,14 +48,22 @@ PASS=0
 FAIL=0
 
 # pwsh_runtime_field RUNTIME FIELD
-# Invoke pwsh Get-RuntimeField and normalize $null -> '' to match the
-# empty-string convention of the bash readers for absent values.
+# Invoke pwsh Get-RuntimeField and normalize the result to the convention
+# the bash readers use:
+#   - $null            -> ''     (absent value; matches bash empty string)
+#   - [bool] $true/$false -> 'true'/'false'  (ConvertFrom-Json yields a
+#     [bool]; its default ToString() is "True"/"False", but jq -r and the
+#     awk fallback both emit lowercase JSON literals)
+# String values pass through unchanged. This normalization is the pwsh
+# analogue of the $null -> '' step in test_parse_env_equivalence.sh.
 pwsh_runtime_field() {
     local runtime="$1" field="$2"
     pwsh -NoProfile -Command "
         Import-Module '$PROJECT_ROOT/scripts/ClaudeDocker.psm1' -Force
         \$v = Get-RuntimeField -ProjectRoot '$PROJECT_ROOT' -Runtime '$runtime' -Field '$field'
-        if (\$null -eq \$v) { '' } else { \$v }
+        if (\$null -eq \$v) { '' }
+        elseif (\$v -is [bool]) { \$v.ToString().ToLowerInvariant() }
+        else { \$v }
     "
 }
 

--- a/tests/test_runtime_registry_equivalence.sh
+++ b/tests/test_runtime_registry_equivalence.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# test_runtime_registry_equivalence.sh -- Verify the three runtime-registry
+# readers produce byte-identical output for every (runtime, field) pair.
+#
+# The registry tui/internal/config/runtimes.json is the cross-language
+# single source of truth (see #267). It is read three ways:
+#
+#   1. bash runtime_field()      -- jq when available (the path CI exercises,
+#                                   since ubuntu-latest ships jq).
+#   2. bash _runtime_field_awk() -- the awk state-machine fallback used on
+#                                   hosts without jq.
+#   3. pwsh Get-RuntimeField     -- the PowerShell ConvertFrom-Json reader.
+#
+# All three must agree exactly; any drift between them fails CI loudly.
+# This is the test that makes the registry an actual SSOT rather than three
+# parsers that happen to agree today.
+#
+# Run:  bash tests/test_runtime_registry_equivalence.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+export PROJECT_ROOT
+
+REGISTRY="$PROJECT_ROOT/tui/internal/config/runtimes.json"
+
+# shellcheck source=../scripts/lib/parse_env.sh
+. "$PROJECT_ROOT/scripts/lib/parse_env.sh"
+# shellcheck source=../scripts/lib/runtime.sh
+. "$PROJECT_ROOT/scripts/lib/runtime.sh"
+
+if [[ ! -r "$REGISTRY" ]]; then
+    echo "FAIL: runtime registry not found at $REGISTRY" >&2
+    exit 1
+fi
+
+# The set of fields every runtime entry carries (see #268 / #267).
+FIELDS=(
+    binary servicePrefix stateDir containerHome hostConfigMount
+    containerConfigMount configDirEnv configSourceEnv apiKeyVarPrefix
+    sdkApiKeyVar buildArg installMethod skipPermissionsFlag configFormat
+    bootstrapModule extraEnv extraRunArgs supportsUsage mountsAgentsSkills
+    credentialFiles oauthCredentialFile
+)
+
+PASS=0
+FAIL=0
+
+# pwsh_runtime_field RUNTIME FIELD
+# Invoke pwsh Get-RuntimeField and normalize $null -> '' to match the
+# empty-string convention of the bash readers for absent values.
+pwsh_runtime_field() {
+    local runtime="$1" field="$2"
+    pwsh -NoProfile -Command "
+        Import-Module '$PROJECT_ROOT/scripts/ClaudeDocker.psm1' -Force
+        \$v = Get-RuntimeField -ProjectRoot '$PROJECT_ROOT' -Runtime '$runtime' -Field '$field'
+        if (\$null -eq \$v) { '' } else { \$v }
+    "
+}
+
+# assert_field RUNTIME FIELD
+# Read (RUNTIME, FIELD) via the jq path, the awk fallback, and -- when pwsh
+# is available -- the PowerShell reader, and assert all readers agree.
+assert_field() {
+    local runtime="$1" field="$2"
+    local jq_val awk_val pwsh_val
+    jq_val=$(runtime_field "$runtime" "$field")
+    awk_val=$(_runtime_field_awk "$REGISTRY" "$runtime" "$field")
+
+    local ok=1
+    if [[ "$jq_val" != "$awk_val" ]]; then
+        ok=0
+    fi
+    if [[ "$HAVE_PWSH" -eq 1 ]]; then
+        pwsh_val=$(pwsh_runtime_field "$runtime" "$field")
+        if [[ "$jq_val" != "$pwsh_val" ]]; then
+            ok=0
+        fi
+    fi
+
+    if [[ "$ok" -eq 1 ]]; then
+        printf '  PASS  %s.%s = %q\n' "$runtime" "$field" "$jq_val"
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        if [[ "$HAVE_PWSH" -eq 1 ]]; then
+            printf '  FAIL  %s.%s\n        jq:   %q\n        awk:  %q\n        pwsh: %q\n' \
+                "$runtime" "$field" "$jq_val" "$awk_val" "${pwsh_val-}"
+        else
+            printf '  FAIL  %s.%s\n        jq:   %q\n        awk:  %q\n' \
+                "$runtime" "$field" "$jq_val" "$awk_val"
+        fi
+    fi
+}
+
+# pwsh is preinstalled on ubuntu-latest runners; require it in CI but skip
+# the pwsh leg locally so the test still exercises jq-vs-awk on dev hosts.
+HAVE_PWSH=0
+if command -v pwsh >/dev/null 2>&1; then
+    HAVE_PWSH=1
+elif [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    echo "FAIL: pwsh unavailable in CI (was preinstalled on ubuntu-latest)" >&2
+    exit 1
+else
+    echo "NOTE: pwsh not installed locally; comparing jq vs awk only" >&2
+fi
+
+# Likewise, jq is guaranteed inside the container image and on CI runners.
+# Locally its absence just means runtime_field() already used the awk path,
+# which still makes the jq-vs-awk assertion meaningful (it compares awk to
+# awk -- harmless) but we surface a note for transparency.
+if ! command -v jq >/dev/null 2>&1; then
+    echo "NOTE: jq not installed; runtime_field() uses the awk fallback" >&2
+fi
+
+# Compare every (runtime, field) pair across all known runtimes.
+while IFS= read -r runtime; do
+    [[ -z "$runtime" ]] && continue
+    echo "== $runtime =="
+    for field in "${FIELDS[@]}"; do
+        assert_field "$runtime" "$field"
+    done
+done < <(runtime_list)
+
+# runtime_list itself must agree between bash and pwsh.
+echo "== runtime_list =="
+bash_list=$(runtime_list | sort | tr '\n' ' ')
+if [[ "$HAVE_PWSH" -eq 1 ]]; then
+    pwsh_list=$(pwsh -NoProfile -Command "
+        Import-Module '$PROJECT_ROOT/scripts/ClaudeDocker.psm1' -Force
+        (Get-RuntimeList -ProjectRoot '$PROJECT_ROOT' | Sort-Object) -join ' '
+    ")
+    pwsh_list="${pwsh_list% } "
+    if [[ "$bash_list" == "$pwsh_list" ]]; then
+        printf '  PASS  runtime_list = %s\n' "$bash_list"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL  runtime_list\n        bash: %q\n        pwsh: %q\n' \
+            "$bash_list" "$pwsh_list"
+        FAIL=$((FAIL + 1))
+    fi
+else
+    printf '  PASS  runtime_list (bash only) = %s\n' "$bash_list"
+    PASS=$((PASS + 1))
+fi
+
+echo
+printf '== Summary: PASS=%d FAIL=%d ==\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tui/internal/config/env.go
+++ b/tui/internal/config/env.go
@@ -13,6 +13,7 @@ import (
 const (
 	RuntimeClaude = "claude"
 	RuntimeCodex  = "codex"
+	RuntimeGemini = "gemini"
 )
 
 // Env holds parsed .env configuration with order-preserving entries.

--- a/tui/internal/config/runtime.go
+++ b/tui/internal/config/runtime.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// runtimesJSON is the embedded runtime registry. It must live inside this
+// package tree because go:embed cannot reach files outside the embedding
+// package. The shell layers read the same file via PROJECT_ROOT. See #267.
+//
+//go:embed runtimes.json
+var runtimesJSON []byte
+
+// RuntimeSpec holds every runtime-specific value for one agent runtime.
+// The JSON tags mirror the flat field names in runtimes.json so the bash
+// awk fallback and PowerShell readers stay simple.
+type RuntimeSpec struct {
+	Binary               string `json:"binary"`
+	ServicePrefix        string `json:"servicePrefix"`
+	StateDir             string `json:"stateDir"`
+	ContainerHome        string `json:"containerHome"`
+	HostConfigMount      string `json:"hostConfigMount"`
+	ContainerConfigMount string `json:"containerConfigMount"`
+	ConfigDirEnv         string `json:"configDirEnv"`
+	ConfigSourceEnv      string `json:"configSourceEnv"`
+	APIKeyVarPrefix      string `json:"apiKeyVarPrefix"`
+	SDKAPIKeyVar         string `json:"sdkApiKeyVar"`
+	BuildArg             string `json:"buildArg"`
+	InstallMethod        string `json:"installMethod"`
+	SkipPermissionsFlag  string `json:"skipPermissionsFlag"`
+	ConfigFormat         string `json:"configFormat"`
+	BootstrapModule      string `json:"bootstrapModule"`
+	ExtraEnv             string `json:"extraEnv"`
+	ExtraRunArgs         string `json:"extraRunArgs"`
+	SupportsUsage        bool   `json:"supportsUsage"`
+	MountsAgentsSkills   bool   `json:"mountsAgentsSkills"`
+	CredentialFiles      string `json:"credentialFiles"`
+	OAuthCredentialFile  string `json:"oauthCredentialFile"`
+}
+
+// runtimeRegistry is the parsed representation of runtimes.json.
+type runtimeRegistry struct {
+	Runtimes map[string]RuntimeSpec `json:"runtimes"`
+}
+
+// registry holds the parsed registry, populated once by init().
+var registry runtimeRegistry
+
+// init parses the embedded registry. A parse failure is a build defect —
+// runtimes.json is checked into the package — so it panics rather than
+// returning an error no caller could recover from.
+func init() {
+	if err := json.Unmarshal(runtimesJSON, &registry); err != nil {
+		panic(fmt.Sprintf("config: parse embedded runtimes.json: %v", err))
+	}
+}
+
+// LookupRuntime returns the RuntimeSpec for the named runtime. The second
+// return value is false if the runtime is not in the registry.
+func LookupRuntime(name string) (RuntimeSpec, bool) {
+	spec, ok := registry.Runtimes[name]
+	return spec, ok
+}
+
+// KnownRuntimes returns the registered runtime names in sorted order.
+func KnownRuntimes() []string {
+	names := make([]string, 0, len(registry.Runtimes))
+	for name := range registry.Runtimes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/tui/internal/config/runtimes.json
+++ b/tui/internal/config/runtimes.json
@@ -1,0 +1,51 @@
+{
+  "_comment": "Cross-language runtime registry — the single source of truth for every runtime-specific value. Read by Go (go:embed), bash (jq with an awk fallback), PowerShell (ConvertFrom-Json), and the container entrypoint (jq). It lives under tui/internal/config/ because Go's go:embed requires the embedded file inside the embedding package tree; the shell layers reach it via PROJECT_ROOT. See issue #267. Do not edit field names without updating every reader.",
+  "runtimes": {
+    "claude": {
+      "binary": "claude",
+      "servicePrefix": "claude",
+      "stateDir": ".claude-state",
+      "containerHome": "/home/node/.claude",
+      "hostConfigMount": "/home/node/.claude-host",
+      "containerConfigMount": "/home/node/.claude",
+      "configDirEnv": "CLAUDE_CONFIG_DIR",
+      "configSourceEnv": "CLAUDE_CONFIG_SOURCE",
+      "apiKeyVarPrefix": "CLAUDE_API_KEY_",
+      "sdkApiKeyVar": "ANTHROPIC_API_KEY",
+      "buildArg": "CLAUDE_CODE_VERSION",
+      "installMethod": "native",
+      "skipPermissionsFlag": "--dangerously-skip-permissions",
+      "configFormat": "json",
+      "bootstrapModule": "bootstrap-claude.sh",
+      "extraEnv": "",
+      "extraRunArgs": "",
+      "supportsUsage": true,
+      "mountsAgentsSkills": true,
+      "credentialFiles": ".credentials.json",
+      "oauthCredentialFile": ".credentials.json"
+    },
+    "codex": {
+      "binary": "codex",
+      "servicePrefix": "codex",
+      "stateDir": ".codex-state",
+      "containerHome": "/home/node/.codex",
+      "hostConfigMount": "/home/node/.codex-host",
+      "containerConfigMount": "/home/node/.codex",
+      "configDirEnv": "CODEX_HOME",
+      "configSourceEnv": "CODEX_CONFIG_SOURCE",
+      "apiKeyVarPrefix": "CODEX_API_KEY_",
+      "sdkApiKeyVar": "OPENAI_API_KEY",
+      "buildArg": "CODEX_CLI_VERSION",
+      "installMethod": "npm",
+      "skipPermissionsFlag": "--dangerously-bypass-approvals-and-sandbox",
+      "configFormat": "toml",
+      "bootstrapModule": "bootstrap-codex.sh",
+      "extraEnv": "",
+      "extraRunArgs": "-c cli_auth_credentials_store=\"file\"",
+      "supportsUsage": false,
+      "mountsAgentsSkills": true,
+      "credentialFiles": "auth.json",
+      "oauthCredentialFile": "auth.json"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Introduces `tui/internal/config/runtimes.json` — a single JSON registry
holding every runtime-specific value — and rewrites the bash, PowerShell,
and Go accessor layers to resolve values from it. This is the foundation
sub-issue of the runtime-generalization epic (#267).

The change is **behavior-preserving**: the `claude` and `codex` registry
entries reproduce today's hardcoded values verbatim, so every existing
test passes unchanged.

- **`runtimes.json`** (new) — registry with `claude` and `codex` entries
  carrying all 21 runtime fields (`binary`, `servicePrefix`, `stateDir`,
  `containerHome`, `configDirEnv`, `sdkApiKeyVar`, `skipPermissionsFlag`,
  etc.). Placed inside the Go package tree so `go:embed` can reach it; the
  shell layers read the same path via `PROJECT_ROOT`.
- **`runtime.go`** (new) — `go:embed` of the registry, `RuntimeSpec`
  struct, `LookupRuntime()` / `KnownRuntimes()` accessors, and an `init()`
  that panics on a parse failure (a build defect, not a recoverable
  runtime condition).
- **`runtime.sh`** — the five public accessors (`agent_runtime`,
  `agent_service_prefix`, `agent_state_root`, `agent_binary`,
  `agent_skip_permissions_flag`) now resolve values from the registry.
  Adds `runtime_field` and `runtime_list`. Uses `jq` when available and an
  `awk` state-machine fallback otherwise. Public signatures unchanged.
- **`ClaudeDocker.psm1`** — adds `Get-RuntimeField` / `Get-RuntimeList`
  (registry parsed once via `ConvertFrom-Json`); `Get-AgentRuntime` and
  siblings now read from the registry.
- **`env.go`** — adds the `RuntimeGemini` constant.
- **`test_runtime_registry_equivalence.sh`** (new) — asserts the `jq`
  path, the `awk` fallback, and pwsh `Get-RuntimeField` produce
  byte-identical output for every `(runtime, field)` pair.
- **`ci.yml`** — registers the new test in the `bash-tests` matrix.

## Why

Runtime differences are currently `if` / `case` branches duplicated
across 6+ files in two languages (see #267). Centralizing them in one
JSON file is the prerequisite for every other sub-issue and structurally
eliminates bash/PowerShell drift — the data lives in one place; only the
readers differ. The `claude|codex` hardcoded allowlist is replaced by a
registry-derived check, while an unknown runtime still errors.

## Test Plan

- `jq . tui/internal/config/runtimes.json` parses; all 21 fields present
  on both runtime entries.
- The five bash accessors return byte-identical output to the pre-change
  implementation for `claude` and `codex` (state roots `~/.claude-state`
  / `~/.codex-state`, skip-permissions flags, prefixes, binaries).
- `test_runtime_registry_equivalence.sh` passes: the `jq` path and `awk`
  fallback agree on all 42 `(runtime, field)` pairs locally; CI adds the
  pwsh leg.
- `generate-compose.sh` (which sources `runtime.sh`) produces the correct
  service prefix and state-directory paths for both runtimes.
- Existing bash test suite (`test_parse_env.sh`,
  `test_transform_syntax_check.sh`, `test_cleanup_backups.sh`) unaffected.
- `go test ./internal/config/...`, `shellcheck`, and `PSScriptAnalyzer`
  run in CI.

Closes #268.
