### PR TITLE
refactor(compose): drive compose generator and CLI from runtime registry

### DIFF
--- a/scripts/claude-docker
+++ b/scripts/claude-docker
@@ -216,47 +216,76 @@ cmd_exec() {
     fi
 }
 
-cmd_claude() {
-    local skip_perms=false
-    local service=""
-    for arg in "$@"; do
-        case "$arg" in
-            --dangerously-skip-permissions) skip_perms=true ;;
-            *) [[ -z "$service" ]] && service="$arg" ;;
-        esac
-    done
-    service="${service:-claude-a}"
-    ensure_compose_cmd
-    echo -e "${CYAN}Starting Claude Code in ${BOLD}$service${NC}${CYAN}...${NC}"
-    if [[ "$skip_perms" == true ]]; then
-        "${COMPOSE_CMD[@]}" exec "$service" claude --dangerously-skip-permissions
-    else
-        "${COMPOSE_CMD[@]}" exec "$service" claude
-    fi
-}
+# cmd_agent SUBCOMMAND [args...]
+# Unified runtime-launch subcommand, replacing the former cmd_claude /
+# cmd_codex pair. SUBCOMMAND is the runtime name the user typed (claude or
+# codex). Every runtime-specific value — binary, skip-permissions flag,
+# extra run args — is read from the registry, so adding a runtime needs no
+# new subcommand here.
+cmd_agent() {
+    local subcommand="$1"
+    shift
 
-cmd_codex() {
-    if [[ "$(agent_runtime)" != "codex" ]]; then
+    local runtime
+    runtime="$(agent_runtime)" || exit 1
+
+    # Wrong-runtime guard, preserved verbatim from the former cmd_codex
+    # (claude-docker:239-241): a codex subcommand only works when
+    # AGENT_RUNTIME selects codex. Kept codex-specific so claude's prior
+    # behavior under any AGENT_RUNTIME is unchanged.
+    if [[ "$subcommand" == "codex" && "$runtime" != "codex" ]]; then
         log_error "codex command requires AGENT_RUNTIME=codex. Set it in .env, regenerate compose files, then run again."
         exit 1
     fi
 
+    # Runtime values for the *subcommand* the user typed. With the guard
+    # above, subcommand and runtime agree for codex; for claude they may
+    # differ (claude under AGENT_RUNTIME=codex), and the historical
+    # cmd_claude always launched the claude binary regardless — so resolve
+    # from the subcommand to keep that behavior.
+    local binary skip_flag extra_run_args
+    binary="$(runtime_field "$subcommand" binary)"
+    skip_flag="$(runtime_field "$subcommand" skipPermissionsFlag)"
+    extra_run_args="$(runtime_field "$subcommand" extraRunArgs)"
+
+    # Skip-permissions flags accepted: the runtime's own flag plus the
+    # universal --dangerously-skip-permissions alias (a no-op duplicate for
+    # claude, the historical alias codex also honored).
     local skip_perms=false
     local service=""
     for arg in "$@"; do
         case "$arg" in
-            --dangerously-bypass-approvals-and-sandbox|--dangerously-skip-permissions) skip_perms=true ;;
+            "$skip_flag"|--dangerously-skip-permissions) skip_perms=true ;;
             *) [[ -z "$service" ]] && service="$arg" ;;
         esac
     done
-    service="${service:-codex-a}"
+    # Default service is keyed off the subcommand (claude-a / codex-a),
+    # matching the former cmd_claude / cmd_codex defaults.
+    service="${service:-$(runtime_field "$subcommand" servicePrefix)-a}"
     ensure_compose_cmd
-    echo -e "${CYAN}Starting Codex CLI in ${BOLD}$service${NC}${CYAN}...${NC}"
-    local codex_args=(codex -c 'cli_auth_credentials_store="file"')
-    if [[ "$skip_perms" == true ]]; then
-        codex_args+=("--dangerously-bypass-approvals-and-sandbox")
+
+    # Pretty launch banner: Claude Code vs Codex CLI matched the prior wording.
+    local label
+    if [[ "$subcommand" == "codex" ]]; then
+        label="Codex CLI"
+    else
+        label="Claude Code"
     fi
-    "${COMPOSE_CMD[@]}" exec "$service" "${codex_args[@]}"
+    echo -e "${CYAN}Starting ${label} in ${BOLD}$service${NC}${CYAN}...${NC}"
+
+    # Build argv: binary, then registry extraRunArgs (word-split; the codex
+    # entry expands to  -c cli_auth_credentials_store="file" ), then the
+    # skip-permissions flag when requested.
+    local agent_args=("$binary")
+    if [[ -n "$extra_run_args" ]]; then
+        local extra_tokens=()
+        read -ra extra_tokens <<< "$extra_run_args"
+        agent_args+=("${extra_tokens[@]}")
+    fi
+    if [[ "$skip_perms" == true ]]; then
+        agent_args+=("$skip_flag")
+    fi
+    "${COMPOSE_CMD[@]}" exec "$service" "${agent_args[@]}"
 }
 
 # Resolve a compose service name to its running Docker container ID.
@@ -550,7 +579,11 @@ cmd_compose() {
 }
 
 cmd_usage() {
-    if [[ "$(agent_runtime)" != "claude" ]]; then
+    # Usage aggregation availability is a per-runtime registry capability
+    # (supportsUsage), not a hardcoded claude-only check.
+    local runtime
+    runtime="$(agent_runtime)" || exit 1
+    if [[ "$(runtime_field "$runtime" supportsUsage)" != "true" ]]; then
         log_error "usage is currently Claude-only; Codex usage aggregation is not supported."
         exit 1
     fi
@@ -743,9 +776,27 @@ HELP
 
 # --- Main ---------------------------------------------------------------------
 
+# is_runtime_subcommand NAME
+# True when NAME is a registered runtime (claude, codex, ...). The runtime
+# subcommands are dispatched to cmd_agent rather than enumerated in the
+# case statement, so a new registry entry needs no change here.
+is_runtime_subcommand() {
+    local name="$1" known
+    while IFS= read -r known; do
+        [[ "$known" == "$name" ]] && return 0
+    done < <(runtime_list)
+    return 1
+}
+
 main() {
     local command="${1:-help}"
     shift 2>/dev/null || true
+
+    # Runtime subcommands (claude, codex, ...) route to the unified cmd_agent.
+    if is_runtime_subcommand "$command"; then
+        cmd_agent "$command" "$@"
+        return
+    fi
 
     case "$command" in
         up)        cmd_up "$@" ;;
@@ -754,8 +805,6 @@ main() {
         logs)      cmd_logs "$@" ;;
         ps)        cmd_ps "$@" ;;
         exec)      cmd_exec "$@" ;;
-        claude)    cmd_claude "$@" ;;
-        codex)     cmd_codex "$@" ;;
         gh-auth)   cmd_gh_auth "$@" ;;
         usage)     cmd_usage "$@" ;;
         build)     cmd_build "$@" ;;

--- a/scripts/claude-docker.ps1
+++ b/scripts/claude-docker.ps1
@@ -125,51 +125,67 @@ function Invoke-Exec {
     Invoke-Compose -ProjectRoot $ProjectRoot exec $service @rest
 }
 
-function Invoke-Claude {
-    $skipPerms = $false
-    $service = ''
-    foreach ($arg in $Arguments) {
-        if ($arg -eq '--dangerously-skip-permissions') {
-            $skipPerms = $true
-        } elseif (-not $service) {
-            $service = $arg
-        }
-    }
-    if (-not $service) { $service = 'claude-a' }
-    Write-Host "Starting Claude Code in " -ForegroundColor Cyan -NoNewline
-    Write-Host $service -ForegroundColor White -NoNewline
-    Write-Host '...' -ForegroundColor Cyan
-    if ($skipPerms) {
-        Invoke-Compose -ProjectRoot $ProjectRoot exec $service claude --dangerously-skip-permissions
-    } else {
-        Invoke-Compose -ProjectRoot $ProjectRoot exec $service claude
-    }
-}
+function Invoke-Agent {
+    <#
+    .SYNOPSIS
+    Unified runtime-launch subcommand, replacing the former Invoke-Claude /
+    Invoke-Codex pair. $Subcommand is the runtime name the user typed
+    (claude or codex). Binary, skip-permissions flag, and extra run args are
+    all read from the registry.
+    #>
+    param([Parameter(Mandatory)][string]$Subcommand)
 
-function Invoke-Codex {
-    if ((Get-AgentRuntime -ProjectRoot $ProjectRoot) -ne 'codex') {
+    $runtime = Get-AgentRuntime -ProjectRoot $ProjectRoot
+
+    # Wrong-runtime guard, preserved verbatim from the former Invoke-Codex:
+    # a codex subcommand only works when AGENT_RUNTIME selects codex. Kept
+    # codex-specific so claude's prior behavior under any AGENT_RUNTIME is
+    # unchanged.
+    if ($Subcommand -eq 'codex' -and $runtime -ne 'codex') {
         Write-LogError 'codex command requires AGENT_RUNTIME=codex. Set it in .env, regenerate compose files, then run again.'
         exit 1
     }
 
+    # Runtime values for the subcommand the user typed. The former
+    # Invoke-Claude always launched the claude binary regardless of
+    # AGENT_RUNTIME, so resolve from the subcommand to keep that behavior.
+    $binary       = Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $Subcommand -Field 'binary'
+    $skipFlag     = Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $Subcommand -Field 'skipPermissionsFlag'
+    $extraRunArgs = Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $Subcommand -Field 'extraRunArgs'
+    $servicePrefix = Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $Subcommand -Field 'servicePrefix'
+
+    # Skip-permissions flags accepted: the runtime's own flag plus the
+    # universal --dangerously-skip-permissions alias (a no-op duplicate for
+    # claude, the historical alias codex also honored).
     $skipPerms = $false
     $service = ''
     foreach ($arg in $Arguments) {
-        if ($arg -in @('--dangerously-bypass-approvals-and-sandbox', '--dangerously-skip-permissions')) {
+        if ($arg -eq $skipFlag -or $arg -eq '--dangerously-skip-permissions') {
             $skipPerms = $true
         } elseif (-not $service) {
             $service = $arg
         }
     }
-    if (-not $service) { $service = 'codex-a' }
-    Write-Host "Starting Codex CLI in " -ForegroundColor Cyan -NoNewline
+    # Default service is keyed off the subcommand (claude-a / codex-a).
+    if (-not $service) { $service = "$servicePrefix-a" }
+
+    # Pretty launch banner: Claude Code vs Codex CLI matched the prior wording.
+    $label = if ($Subcommand -eq 'codex') { 'Codex CLI' } else { 'Claude Code' }
+    Write-Host "Starting $label in " -ForegroundColor Cyan -NoNewline
     Write-Host $service -ForegroundColor White -NoNewline
     Write-Host '...' -ForegroundColor Cyan
-    $codexArgs = @('codex', '-c', 'cli_auth_credentials_store="file"')
-    if ($skipPerms) {
-        $codexArgs += '--dangerously-bypass-approvals-and-sandbox'
+
+    # Build argv: binary, then registry extraRunArgs (split on whitespace;
+    # the codex entry expands to  -c cli_auth_credentials_store="file" ),
+    # then the skip-permissions flag when requested.
+    $agentArgs = @($binary)
+    if (-not [string]::IsNullOrWhiteSpace($extraRunArgs)) {
+        $agentArgs += ($extraRunArgs -split '\s+')
     }
-    Invoke-Compose -ProjectRoot $ProjectRoot exec $service @codexArgs
+    if ($skipPerms) {
+        $agentArgs += $skipFlag
+    }
+    Invoke-Compose -ProjectRoot $ProjectRoot exec $service @agentArgs
 }
 
 function Invoke-GhAuth {
@@ -435,7 +451,10 @@ function Invoke-ComposePass {
 }
 
 function Invoke-Usage {
-    if ((Get-AgentRuntime -ProjectRoot $ProjectRoot) -ne 'claude') {
+    # Usage aggregation availability is a per-runtime registry capability
+    # (supportsUsage), not a hardcoded claude-only check.
+    $runtime = Get-AgentRuntime -ProjectRoot $ProjectRoot
+    if ((Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $runtime -Field 'supportsUsage') -ne $true) {
         Write-LogError 'usage is currently Claude-only; Codex usage aggregation is not supported.'
         exit 1
     }
@@ -614,6 +633,14 @@ function Invoke-BuildTui {
     }
 }
 
+# Runtime subcommands (claude, codex, ...) route to the unified Invoke-Agent
+# rather than being enumerated below, so a new registry entry needs no change
+# here. Matched before the static switch.
+if ($Command -in (Get-RuntimeList -ProjectRoot $ProjectRoot)) {
+    Invoke-Agent -Subcommand $Command
+    return
+}
+
 switch ($Command) {
     'up'         { Invoke-Up }
     'down'       { Invoke-Down }
@@ -621,8 +648,6 @@ switch ($Command) {
     'logs'       { Invoke-Logs }
     'ps'         { Invoke-Ps }
     'exec'       { Invoke-Exec }
-    'claude'     { Invoke-Claude }
-    'codex'      { Invoke-Codex }
     'tui'        { Invoke-Tui }
     'dashboard'  { Invoke-Tui }
     'gh-auth'    { Invoke-GhAuth }

--- a/scripts/generate-compose.ps1
+++ b/scripts/generate-compose.ps1
@@ -69,6 +69,26 @@ $AgentRuntime = Get-AgentRuntime -ProjectRoot $ProjectRoot
 $ServicePrefix = Get-ServicePrefix -ProjectRoot $ProjectRoot
 $PrimaryService = Get-PrimaryService -ProjectRoot $ProjectRoot
 
+# Runtime registry bundle. Every per-runtime value the generator emits is
+# resolved once here from runtimes.json, so the loops below are pure variable
+# substitution with no `if ($AgentRuntime -eq 'codex')` branching. The bash
+# generator (generate-compose.sh) builds the same bundle.
+function Get-RtField([string]$Field) {
+    return Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $AgentRuntime -Field $Field
+}
+$RtBuildArg            = Get-RtField 'buildArg'
+$RtStateDir            = Get-RtField 'stateDir'
+$RtHostConfigMount     = Get-RtField 'hostConfigMount'
+$RtContainerConfigMount = Get-RtField 'containerConfigMount'
+$RtApiKeyPrefix        = Get-RtField 'apiKeyVarPrefix'
+$RtSdkApiKeyVar        = Get-RtField 'sdkApiKeyVar'
+$RtConfigDirEnv        = Get-RtField 'configDirEnv'
+$RtConfigSourceEnv     = Get-RtField 'configSourceEnv'
+# Host-side config directory basename (e.g. .claude, .codex) — the host
+# mount whose container target is <hostConfigMount>. Derived from the
+# container config mount basename, which the registry keeps in sync.
+$RtHostConfigBasename  = '.' + ($RtContainerConfigMount -split '\.')[-1]
+
 # Container resource envelope (override via .env or host env). Defaults
 # reproduce the historical hardcoded values so existing installs see no
 # behavior change after regenerating.
@@ -119,11 +139,7 @@ function New-BaseCompose {
             [void]$sb.AppendLine('    build:')
             [void]$sb.AppendLine('      context: .')
             [void]$sb.AppendLine('      args:')
-            if ($AgentRuntime -eq 'codex') {
-                [void]$sb.AppendLine('        CODEX_CLI_VERSION: ${CODEX_CLI_VERSION:-}')
-            } else {
-                [void]$sb.AppendLine('        CLAUDE_CODE_VERSION: ${CLAUDE_CODE_VERSION:-}')
-            }
+            [void]$sb.AppendLine("        ${RtBuildArg}: `${${RtBuildArg}:-}")
         }
 
         [void]$sb.AppendLine("    image: claude-code-base:`${IMAGE_TAG:-$ImageTag}")
@@ -138,11 +154,7 @@ function New-BaseCompose {
         # the committed file see why the user line falls back to 1000:1000.
         # The bash generator emits the same four lines verbatim.
         [void]$sb.AppendLine("    # Match the host user's UID/GID so bind-mounted paths")
-        if ($AgentRuntime -eq 'codex') {
-            [void]$sb.AppendLine('    # (${HOME}/.codex-state/account-*) stay writable from')
-        } else {
-            [void]$sb.AppendLine('    # (${HOME}/.claude-state/account-*) stay writable from')
-        }
+        [void]$sb.AppendLine("    # (`${HOME}/${RtStateDir}/account-*) stay writable from")
         [void]$sb.AppendLine('    # inside the container. Falls back to 1000:1000 (the')
         [void]$sb.AppendLine('    # upstream node:20-slim default) when UID/GID are unset.')
         [void]$sb.AppendLine('    user: "${UID:-1000}:${GID:-1000}"')
@@ -150,13 +162,14 @@ function New-BaseCompose {
         [void]$sb.AppendLine('    tty: true')
         [void]$sb.AppendLine('    volumes:')
         [void]$sb.AppendLine('      - ${PROJECT_DIR}:${CONTAINER_PROJECT_DIR:-/project}')
+        [void]$sb.AppendLine("      - `${HOME}/${RtStateDir}/account-${letter}:${RtContainerConfigMount}")
+        [void]$sb.AppendLine("      - `${HOME}/${RtHostConfigBasename}:${RtHostConfigMount}:ro")
+        # The agents/skills mount is a codex-only volume: claude does not
+        # bind it. The registry has no per-runtime field that singles it
+        # out (mountsAgentsSkills is true for both), so this one line is
+        # gated on the runtime id to preserve byte-identical output.
         if ($AgentRuntime -eq 'codex') {
-            [void]$sb.AppendLine("      - `${HOME}/.codex-state/account-${letter}:/home/node/.codex")
-            [void]$sb.AppendLine('      - ${HOME}/.codex:/home/node/.codex-host:ro')
             [void]$sb.AppendLine('      - ${AGENTS_SKILLS_DIR:-${HOME}/.agents/skills}:/home/node/.agents/skills:ro')
-        } else {
-            [void]$sb.AppendLine("      - `${HOME}/.claude-state/account-${letter}:/home/node/.claude")
-            [void]$sb.AppendLine('      - ${HOME}/.claude:/home/node/.claude-host:ro')
         }
         [void]$sb.AppendLine('      - ${GH_CONFIG_DIR:-${HOME}/.config/gh}:/home/node/.config/gh:ro')
         [void]$sb.AppendLine("      - node_modules_${letter}:`${CONTAINER_PROJECT_DIR:-/project}/node_modules")
@@ -167,30 +180,30 @@ function New-BaseCompose {
         # the passwd entry for that UID is missing, so $HOME defaults to
         # /. Pinning HOME keeps runtime state, ~/.config, etc. resolvable.
         [void]$sb.AppendLine('      - HOME=/home/node')
-        if ($AgentRuntime -eq 'codex') {
-            [void]$sb.AppendLine('      - AGENT_RUNTIME=codex')
-            [void]$sb.AppendLine('      - CODEX_HOME=/home/node/.codex')
-            [void]$sb.AppendLine('      - CODEX_CONFIG_SOURCE=${CODEX_CONFIG_SOURCE:-}')
-        } else {
-            [void]$sb.AppendLine('      - CLAUDE_CONFIG_DIR=/home/node/.claude')
-            [void]$sb.AppendLine('      - CLAUDE_CONFIG_SOURCE=${CLAUDE_CONFIG_SOURCE:-}')
+        # AGENT_RUNTIME is now always emitted (previously codex-only).
+        # The entrypoint defaults to claude when unset, so emitting it
+        # for claude too is functionally inert and keeps the env block
+        # uniform across runtimes.
+        [void]$sb.AppendLine("      - AGENT_RUNTIME=${AgentRuntime}")
+        [void]$sb.AppendLine("      - ${RtConfigDirEnv}=${RtContainerConfigMount}")
+        [void]$sb.AppendLine("      - ${RtConfigSourceEnv}=`${${RtConfigSourceEnv}:-}")
+        # CLAUDE_NORMALIZE_CRLF is a claude-only env var (read directly by
+        # the entrypoint, no codex equivalent). The registry has no field
+        # for it, so this one line stays gated on the runtime id.
+        if ($AgentRuntime -eq 'claude') {
             [void]$sb.AppendLine('      - CLAUDE_NORMALIZE_CRLF=${CLAUDE_NORMALIZE_CRLF:-}')
         }
         [void]$sb.AppendLine('      - NODE_OPTIONS=--max-old-space-size=4096')
         # Only emit provider API keys when a per-account key is set at
         # generate time. Emitting an empty key makes SDKs prefer the blank env
         # var over persisted credentials in the mounted state dir.
-        $keyVarName = if ($AgentRuntime -eq 'codex') { "CODEX_API_KEY_${upper}" } else { "CLAUDE_API_KEY_${upper}" }
+        $keyVarName = "${RtApiKeyPrefix}${upper}"
         $keyValue = [Environment]::GetEnvironmentVariable($keyVarName)
         if ([string]::IsNullOrEmpty($keyValue) -and $envData.ContainsKey($keyVarName)) {
             $keyValue = $envData[$keyVarName]
         }
         if (-not [string]::IsNullOrEmpty($keyValue)) {
-            if ($AgentRuntime -eq 'codex') {
-                [void]$sb.AppendLine("      - OPENAI_API_KEY=`${CODEX_API_KEY_${upper}}")
-            } else {
-                [void]$sb.AppendLine("      - ANTHROPIC_API_KEY=`${CLAUDE_API_KEY_${upper}}")
-            }
+            [void]$sb.AppendLine("      - ${RtSdkApiKeyVar}=`${${keyVarName}}")
         }
         [void]$sb.AppendLine('      - GH_TOKEN=${GH_TOKEN:-}')
         [void]$sb.AppendLine('      - GIT_USER_NAME=${GIT_USER_NAME:-}')

--- a/scripts/generate-compose.sh
+++ b/scripts/generate-compose.sh
@@ -31,6 +31,23 @@ AGENT_RUNTIME="$(agent_runtime)"
 SERVICE_PREFIX="$(agent_service_prefix)"
 PRIMARY_SERVICE="${SERVICE_PREFIX}-a"
 
+# Runtime registry bundle. Every per-runtime value the generator emits is
+# resolved once here from runtimes.json, so the loops below are pure variable
+# substitution with no `if [[ == codex ]]` branching. Adding a runtime to the
+# registry is then sufficient to make the generator emit correct compose.
+RT_BUILD_ARG="$(runtime_field "$AGENT_RUNTIME" buildArg)"
+RT_STATE_DIR="$(runtime_field "$AGENT_RUNTIME" stateDir)"
+RT_HOST_CONFIG_MOUNT="$(runtime_field "$AGENT_RUNTIME" hostConfigMount)"
+RT_CONTAINER_CONFIG_MOUNT="$(runtime_field "$AGENT_RUNTIME" containerConfigMount)"
+RT_API_KEY_PREFIX="$(runtime_field "$AGENT_RUNTIME" apiKeyVarPrefix)"
+RT_SDK_API_KEY_VAR="$(runtime_field "$AGENT_RUNTIME" sdkApiKeyVar)"
+RT_CONFIG_DIR_ENV="$(runtime_field "$AGENT_RUNTIME" configDirEnv)"
+RT_CONFIG_SOURCE_ENV="$(runtime_field "$AGENT_RUNTIME" configSourceEnv)"
+# Host-side config directory basename (e.g. .claude, .codex) — the host
+# mount whose container target is <hostConfigMount>. Derived from the
+# container config mount basename, which the registry keeps in sync.
+RT_HOST_CONFIG_BASENAME=".${RT_CONTAINER_CONFIG_MOUNT##*.}"
+
 # IMAGE_TAG defaults come from the repo-root VERSION file — single source of
 # truth shared with install.sh and the "Bumping the Base Image" README
 # procedure. Falls back to "latest" if VERSION is missing (e.g. the user is
@@ -84,11 +101,7 @@ generate_base() {
                 echo "    build:"
                 echo "      context: ."
                 echo "      args:"
-                if [[ "$AGENT_RUNTIME" == "codex" ]]; then
-                    echo "        CODEX_CLI_VERSION: \${CODEX_CLI_VERSION:-}"
-                else
-                    echo "        CLAUDE_CODE_VERSION: \${CLAUDE_CODE_VERSION:-}"
-                fi
+                echo "        ${RT_BUILD_ARG}: \${${RT_BUILD_ARG}:-}"
             fi
 
             echo "    image: claude-code-base:\${IMAGE_TAG:-${IMAGE_TAG}}"
@@ -102,11 +115,7 @@ generate_base() {
 
             echo "    working_dir: \${CONTAINER_PROJECT_DIR:-/project}"
             echo "    # Match the host user's UID/GID so bind-mounted paths"
-            if [[ "$AGENT_RUNTIME" == "codex" ]]; then
-                echo "    # (\${HOME}/.codex-state/account-*) stay writable from"
-            else
-                echo "    # (\${HOME}/.claude-state/account-*) stay writable from"
-            fi
+            echo "    # (\${HOME}/${RT_STATE_DIR}/account-*) stay writable from"
             echo "    # inside the container. Falls back to 1000:1000 (the"
             echo "    # upstream node:20-slim default) when UID/GID are unset."
             echo "    user: \"\${UID:-1000}:\${GID:-1000}\""
@@ -114,13 +123,14 @@ generate_base() {
             echo "    tty: true"
             echo "    volumes:"
             echo "      - \${PROJECT_DIR}:\${CONTAINER_PROJECT_DIR:-/project}"
+            echo "      - \${HOME}/${RT_STATE_DIR}/account-${letter}:${RT_CONTAINER_CONFIG_MOUNT}"
+            echo "      - \${HOME}/${RT_HOST_CONFIG_BASENAME}:${RT_HOST_CONFIG_MOUNT}:ro"
+            # The agents/skills mount is a codex-only volume: claude does not
+            # bind it. The registry has no per-runtime field that singles it
+            # out (mountsAgentsSkills is true for both), so this one line is
+            # gated on the runtime id to preserve byte-identical output.
             if [[ "$AGENT_RUNTIME" == "codex" ]]; then
-                echo "      - \${HOME}/.codex-state/account-${letter}:/home/node/.codex"
-                echo "      - \${HOME}/.codex:/home/node/.codex-host:ro"
                 echo '      - ${AGENTS_SKILLS_DIR:-${HOME}/.agents/skills}:/home/node/.agents/skills:ro'
-            else
-                echo "      - \${HOME}/.claude-state/account-${letter}:/home/node/.claude"
-                echo "      - \${HOME}/.claude:/home/node/.claude-host:ro"
             fi
             echo "      - \${GH_CONFIG_DIR:-\${HOME}/.config/gh}:/home/node/.config/gh:ro"
             echo "      - node_modules_${letter}:\${CONTAINER_PROJECT_DIR:-/project}/node_modules"
@@ -132,31 +142,26 @@ generate_base() {
             # to /. Pinning HOME keeps runtime state, ~/.config, etc.
             # resolvable.
             echo "      - HOME=/home/node"
-            if [[ "$AGENT_RUNTIME" == "codex" ]]; then
-                echo "      - AGENT_RUNTIME=codex"
-                echo "      - CODEX_HOME=/home/node/.codex"
-                echo "      - CODEX_CONFIG_SOURCE=\${CODEX_CONFIG_SOURCE:-}"
-            else
-                echo "      - CLAUDE_CONFIG_DIR=/home/node/.claude"
-                echo "      - CLAUDE_CONFIG_SOURCE=\${CLAUDE_CONFIG_SOURCE:-}"
+            # AGENT_RUNTIME is now always emitted (previously codex-only).
+            # The entrypoint defaults to claude when unset, so emitting it
+            # for claude too is functionally inert and keeps the env block
+            # uniform across runtimes.
+            echo "      - AGENT_RUNTIME=${AGENT_RUNTIME}"
+            echo "      - ${RT_CONFIG_DIR_ENV}=${RT_CONTAINER_CONFIG_MOUNT}"
+            echo "      - ${RT_CONFIG_SOURCE_ENV}=\${${RT_CONFIG_SOURCE_ENV}:-}"
+            # CLAUDE_NORMALIZE_CRLF is a claude-only env var (read directly by
+            # the entrypoint, no codex equivalent). The registry has no field
+            # for it, so this one line stays gated on the runtime id.
+            if [[ "$AGENT_RUNTIME" == "claude" ]]; then
                 echo "      - CLAUDE_NORMALIZE_CRLF=\${CLAUDE_NORMALIZE_CRLF:-}"
             fi
             echo "      - NODE_OPTIONS=--max-old-space-size=4096"
             # Only emit provider API keys when a per-account key is set at
             # generate time. Emitting an empty key makes SDKs prefer the
             # blank env var over persisted credentials.
-            local key_var
-            if [[ "$AGENT_RUNTIME" == "codex" ]]; then
-                key_var="CODEX_API_KEY_${upper}"
-            else
-                key_var="CLAUDE_API_KEY_${upper}"
-            fi
+            local key_var="${RT_API_KEY_PREFIX}${upper}"
             if [[ -n "${!key_var:-}" ]]; then
-                if [[ "$AGENT_RUNTIME" == "codex" ]]; then
-                    echo "      - OPENAI_API_KEY=\${CODEX_API_KEY_${upper}}"
-                else
-                    echo "      - ANTHROPIC_API_KEY=\${CLAUDE_API_KEY_${upper}}"
-                fi
+                echo "      - ${RT_SDK_API_KEY_VAR}=\${${key_var}}"
             fi
             echo "      - GH_TOKEN=\${GH_TOKEN:-}"
             echo "      - GIT_USER_NAME=\${GIT_USER_NAME:-}"


### PR DESCRIPTION
Closes #270. Part of #267.

## Summary

Makes the docker-compose generator and the CLI wrappers table-driven from
the runtime registry (`tui/internal/config/runtimes.json`), removing the
hardcoded `if [[ == codex ]]` / `if ($AgentRuntime -eq 'codex')` branches.

**`generate-compose.sh` / `.ps1`** — a registry bundle is resolved once at
entry (`buildArg`, `stateDir`, `hostConfigMount`, `containerConfigMount`,
`apiKeyVarPrefix`, `sdkApiKeyVar`, `configDirEnv`, `configSourceEnv`). The
build-args, volumes, environment, and API-key-injection blocks become pure
variable substitution.

**`claude-docker` / `.ps1`** — `cmd_claude` + `cmd_codex` (and the
PowerShell `Invoke-Claude` + `Invoke-Codex`) collapse into one
`cmd_agent` / `Invoke-Agent`, reading `binary`, `skipPermissionsFlag`,
`extraRunArgs`, and `servicePrefix` from the registry. Main dispatch
recognizes runtime subcommands via `runtime_list` / `Get-RuntimeList`.
`cmd_usage` gates on the `supportsUsage` field instead of a hardcoded
claude check. The codex wrong-runtime subcommand guard is preserved.

## Why

The compose generator was the densest concentration of hardcoded runtime
branches (#267). Table-driving it is what makes "new runtime = registry
entry" true for compose output, and it removes the `cmd_claude` /
`cmd_codex` duplication.

## Intentional behavior change

This change is behavior-preserving for claude and codex **except one
intentional diff**: the generator previously omitted the `AGENT_RUNTIME`
env line for claude and now always emits it. This is functionally safe —
the entrypoint defaults to claude when `AGENT_RUNTIME` is unset — and keeps
the environment block uniform across runtimes.

Two lines remain gated on the runtime id because the registry has no field
that distinguishes them, and changing them would break byte-identical
output:

- the codex-only `agents/skills` volume mount (`mountsAgentsSkills` is
  `true` for both runtimes, so it cannot select this line);
- the claude-only `CLAUDE_NORMALIZE_CRLF` env var (no codex equivalent).

Both are kept minimal and documented inline.

## Test Plan

- [x] `bash scripts/generate-compose.sh` against the claude fixtures
  (`minimal`, `n5`, `tier-b`, plus an API-key variant): generated
  `docker-compose*.yml` are byte-identical to pre-change output **except**
  the added `AGENT_RUNTIME=claude` line.
- [x] Same for codex (`AGENT_RUNTIME=codex`, minimal / n5 / API-key
  variants): output is fully byte-identical — `AGENT_RUNTIME` was already
  emitted for codex before this change.
- [x] `claude-docker` dispatch + argv comparison against the pre-change
  script for claude and codex: default service, explicit service,
  skip-permissions flag, the `--dangerously-skip-permissions` alias for
  codex, and the codex wrong-runtime guard all produce identical
  `docker compose exec` argv.
- [x] `bash -n` syntax check on both bash scripts.
- CI `Compose validate` (5 fixtures), `Shellcheck`, `PSScriptAnalyzer`,
  `Bash Tests`, and `PowerShell Tests` are the regression gate;
  `docker compose config` and `pwsh` are not available locally.
