### PR TITLE
refactor(tui): promote runtime to a first-class Account field

### DIFF
--- a/tui/internal/account/account.go
+++ b/tui/internal/account/account.go
@@ -64,20 +64,25 @@ func (t TokenSummary) Total() int64 {
 	return t.InputTokens + t.OutputTokens + t.CacheTokens
 }
 
-// Account represents a single Claude Code account with its runtime state.
+// Account represents a single agent account with its runtime state.
 type Account struct {
 	Letter          string
 	ServiceName     string
+	Runtime         string // agent runtime name (e.g. "claude", "codex"); set from env.AgentRuntime()
 	StateDirPath    string
 	AuthType        AuthType
 	ContainerStatus ContainerStatus
 	ContainerID     string
 	GHAuthOK        bool
-	FiveHourUsage   *UsageBucket
-	SevenDayUsage   *UsageBucket
-	Tokens          *TokenSummary // JSONL-derived fallback when limitline is unavailable
-	APIRateLimited  bool          // true when usage API returned 429 recently
-	LastAPIStatus   string        // debug: last API status ("200", "429", "err: ...", "skipped (cooldown)", "cached")
+
+	// Claude-only fields. These stay zero/nil for runtimes that do not
+	// expose a Claude-style OAuth usage endpoint; the dashboard then
+	// renders "--" for usage. See #271.
+	FiveHourUsage  *UsageBucket
+	SevenDayUsage  *UsageBucket
+	Tokens         *TokenSummary // JSONL-derived fallback when limitline is unavailable
+	APIRateLimited bool          // true when usage API returned 429 recently
+	LastAPIStatus  string        // debug: last API status ("200", "429", "err: ...", "skipped (cooldown)", "cached")
 }
 
 // HasUsageData returns true if any usage data is available (limitline or JSONL).

--- a/tui/internal/account/manager.go
+++ b/tui/internal/account/manager.go
@@ -47,21 +47,33 @@ func (m *Manager) ListAccounts() ([]Account, error) {
 	return accounts, nil
 }
 
+// detectAuthType resolves an account's authentication method from the
+// runtime registry, with no per-runtime branching. Runtimes that expose a
+// Claude-style OAuth usage endpoint (SupportsUsage) treat an OAuth
+// credential as AuthOAuth and rank it above an API key; other runtimes
+// treat the credential as opaque login state (AuthLogin) and rank an API
+// key first. A nil env degrades to a Claude-shaped lookup.
 func detectAuthType(sd config.StateDir, env *config.Env, letter string) AuthType {
-	if env != nil && env.AgentRuntime() == config.RuntimeCodex {
-		if env.APIKey(letter) != "" {
-			return AuthAPIKey
+	spec, _ := config.LookupRuntime(config.RuntimeClaude)
+	apiKey := ""
+	if env != nil {
+		spec = env.RuntimeSpec()
+		apiKey = env.APIKey(letter)
+	}
+	if spec.SupportsUsage {
+		if sd.HasAnyCredential(spec) {
+			return AuthOAuth
 		}
-		if sd.HasCodexAuth() {
-			return AuthLogin
+		if apiKey != "" {
+			return AuthAPIKey
 		}
 		return AuthNone
 	}
-	if sd.HasCredentials() {
-		return AuthOAuth
-	}
-	if env.APIKey(letter) != "" {
+	if apiKey != "" {
 		return AuthAPIKey
+	}
+	if sd.HasAnyCredential(spec) {
+		return AuthLogin
 	}
 	return AuthNone
 }

--- a/tui/internal/account/manager_helpers.go
+++ b/tui/internal/account/manager_helpers.go
@@ -51,6 +51,7 @@ func (m *Manager) fetchContainerStatus() map[string]docker.ContainerInfo {
 // and container status applied.
 func (m *Manager) buildAccounts(n int, stateDirs map[string]config.StateDir, containerMap map[string]docker.ContainerInfo) []Account {
 	accounts := make([]Account, n)
+	runtime := m.env.AgentRuntime()
 	servicePrefix := m.env.ServicePrefix()
 	claudeUsage := m.env.SupportsClaudeUsage()
 	for i := 1; i <= n; i++ {
@@ -60,6 +61,7 @@ func (m *Manager) buildAccounts(n int, stateDirs map[string]config.StateDir, con
 		acct := Account{
 			Letter:      letter,
 			ServiceName: svcName,
+			Runtime:     runtime,
 		}
 
 		if sd, ok := stateDirs[letter]; ok {

--- a/tui/internal/auth/claude_usage_api.go
+++ b/tui/internal/auth/claude_usage_api.go
@@ -1,6 +1,12 @@
 // Package auth provides OAuth token reading and Anthropic usage API access.
 package auth
 
+// This file is Claude-only. The usage API it wraps
+// (api.anthropic.com/api/oauth/usage) is specific to Anthropic's OAuth
+// flow; Codex, Gemini, and other runtimes have no equivalent endpoint.
+// Callers gate it via Env.SupportsClaudeUsage so non-Claude runtimes
+// degrade gracefully (the dashboard renders "--" for usage). See #271.
+
 import (
 	"encoding/json"
 	"fmt"

--- a/tui/internal/config/env.go
+++ b/tui/internal/config/env.go
@@ -149,22 +149,30 @@ func (e *Env) NumAccounts() int {
 }
 
 // AgentRuntime returns the selected agent runtime. Claude is the default.
+// Only runtimes present in the embedded registry are honored; any other
+// value (including an empty one) falls back to Claude.
 func (e *Env) AgentRuntime() string {
 	if e == nil {
 		return RuntimeClaude
 	}
 	v := strings.ToLower(strings.TrimSpace(e.Get("AGENT_RUNTIME")))
-	switch v {
-	case RuntimeCodex:
-		return RuntimeCodex
-	default:
-		return RuntimeClaude
+	if _, ok := LookupRuntime(v); ok {
+		return v
 	}
+	return RuntimeClaude
+}
+
+// RuntimeSpec returns the registry entry for the selected agent runtime.
+// AgentRuntime guarantees the name is registered, so the lookup always
+// succeeds.
+func (e *Env) RuntimeSpec() RuntimeSpec {
+	spec, _ := LookupRuntime(e.AgentRuntime())
+	return spec
 }
 
 // ServicePrefix returns the docker compose service prefix for the runtime.
 func (e *Env) ServicePrefix() string {
-	return e.AgentRuntime()
+	return e.RuntimeSpec().ServicePrefix
 }
 
 // StateDirName returns the host-side state directory name for the runtime.
@@ -174,32 +182,28 @@ func (e *Env) StateDirName() string {
 
 // RuntimeBinary returns the executable used inside the container.
 func (e *Env) RuntimeBinary() string {
-	return e.AgentRuntime()
+	return e.RuntimeSpec().Binary
 }
 
 // SkipPermissionsFlag returns the runtime-specific unsafe permission bypass flag.
 func (e *Env) SkipPermissionsFlag() string {
-	if e.AgentRuntime() == RuntimeCodex {
-		return "--dangerously-bypass-approvals-and-sandbox"
-	}
-	return "--dangerously-skip-permissions"
+	return e.RuntimeSpec().SkipPermissionsFlag
 }
 
 // RuntimeCommandArgs returns the command used to attach to the selected agent.
 func (e *Env) RuntimeCommandArgs(skipPermissions bool) []string {
-	args := []string{e.RuntimeBinary()}
-	if e.AgentRuntime() == RuntimeCodex {
-		args = append(args, "-c", `cli_auth_credentials_store="file"`)
-	}
+	spec := e.RuntimeSpec()
+	args := []string{spec.Binary}
+	args = append(args, strings.Fields(spec.ExtraRunArgs)...)
 	if skipPermissions {
-		args = append(args, e.SkipPermissionsFlag())
+		args = append(args, spec.SkipPermissionsFlag)
 	}
 	return args
 }
 
 // SupportsClaudeUsage reports whether Claude-specific usage integrations apply.
 func (e *Env) SupportsClaudeUsage() bool {
-	return e.AgentRuntime() == RuntimeClaude
+	return e.RuntimeSpec().SupportsUsage
 }
 
 // APIKey returns the per-account provider API key if set.
@@ -207,11 +211,7 @@ func (e *Env) APIKey(letter string) string {
 	if e == nil {
 		return ""
 	}
-	prefix := "CLAUDE_API_KEY_"
-	if e.AgentRuntime() == RuntimeCodex {
-		prefix = "CODEX_API_KEY_"
-	}
-	return e.Get(prefix + strings.ToUpper(letter))
+	return e.Get(e.RuntimeSpec().APIKeyVarPrefix + strings.ToUpper(letter))
 }
 
 // HasWorktrees returns true if PROJECT_DIR_A is set (worktree mode).

--- a/tui/internal/config/state.go
+++ b/tui/internal/config/state.go
@@ -60,6 +60,25 @@ func (s StateDir) HasCodexAuth() bool {
 	return err == nil
 }
 
+// OAuthCredentialPath returns the path to the runtime's OAuth credential
+// file (e.g. .credentials.json for Claude, auth.json for Codex) inside
+// this state dir, sourced from the runtime registry.
+func (s StateDir) OAuthCredentialPath(spec RuntimeSpec) string {
+	return filepath.Join(s.Path, spec.OAuthCredentialFile)
+}
+
+// HasAnyCredential reports whether any of the runtime's credential files
+// exist in this state dir. The registry's credentialFiles entry is a
+// space-separated list, so each candidate is checked in turn.
+func (s StateDir) HasAnyCredential(spec RuntimeSpec) bool {
+	for _, name := range strings.Fields(spec.CredentialFiles) {
+		if _, err := os.Stat(filepath.Join(s.Path, name)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
 // HasLimitlineCache returns true if limitline-usage-cache.json exists.
 func (s StateDir) HasLimitlineCache() bool {
 	_, err := os.Stat(s.LimitlineCachePath())


### PR DESCRIPTION
## Summary

Promotes `Runtime` to a first-class field on the TUI `Account` struct and
migrates the config layer from `ServiceName`-prefix-inferred runtime
branching to runtime registry lookups (the registry added in #268-#270).

- `account.go` — add `Account.Runtime`; group the five Claude-only fields
  (`FiveHourUsage`, `SevenDayUsage`, `Tokens`, `APIRateLimited`,
  `LastAPIStatus`) under a documented comment block.
- `env.go` — rewrite `AgentRuntime`, `ServicePrefix`, `RuntimeBinary`,
  `SkipPermissionsFlag`, `RuntimeCommandArgs`, `SupportsClaudeUsage`, and
  `APIKey` as registry lookups; add a `RuntimeSpec()` accessor.
  `AgentRuntime` now honors only registered runtimes and falls back to
  Claude for any unknown value.
- `state.go` — add `HasAnyCredential(spec)` and `OAuthCredentialPath(spec)`,
  both registry-driven. The existing `CodexAuthPath` / `HasCodexAuth` /
  `CredentialsPath` / `HasCredentials` methods are kept (a test asserts
  them directly).
- `manager.go` — rewrite `detectAuthType` as one registry-driven flow with
  no per-runtime `if-else` chain.
- `manager_helpers.go` — set `Account.Runtime` from `env.AgentRuntime()` in
  `buildAccounts`.
- rename `auth/usage_api.go` to `auth/claude_usage_api.go` (via `git mv`,
  history preserved) and add a file-level Claude-only doc comment.

## Why

The TUI previously inferred the runtime from the `ServiceName` prefix and
had no runtime field, while the usage/API code is 100% Claude-hardcoded
(`api.anthropic.com`). Promoting `Runtime` to a field and isolating usage
gives a clean, honest model: non-Claude runtimes are first-class, and
usage gracefully shows `--`.

Usage/API is deliberately NOT abstracted into a `Provider` interface —
Codex and Gemini have no Claude-style OAuth usage endpoint, so
`SupportsClaudeUsage` stays a registry-sourced `bool`. No RUNTIME column
is added: `AGENT_RUNTIME` is global per session and already shown in the
header.

## Test Plan

This is a behavior-preserving refactor. The `Go tests (TUI)` CI job is the
regression gate.

- All function signatures are unchanged, so callers in `docker/client.go`
  and `ui/dashboard/` are unaffected.
- `detectAuthType` preserves prior precedence: Claude ranks an OAuth
  credential above an API key; Codex ranks an API key first and treats
  `auth.json` as `AuthLogin`.
- These existing tests must pass unchanged: `TestCodexRuntimeAPIKeyAndCommandArgs`,
  `TestStateDir_PathHelpers`, `TestBuildAccounts_CodexRuntime`,
  `TestAgentRuntime_DefaultAndCodex`, `TestAPIKey_CaseInsensitiveLetter`.

Closes #271
Part of #267
