### PR TITLE
feat(runtime): add Gemini CLI as a third runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,23 @@ PROJECT_DIR=/absolute/path/to/your/project
 # CLAUDE_API_KEY_A=sk-ant-...
 # CLAUDE_API_KEY_B=sk-ant-...
 
+# ==== Runtime selection (optional) ====
+# The default runtime is Claude. Set AGENT_RUNTIME to run a different CLI;
+# regenerate compose files (scripts/generate-compose.sh) after changing it.
+# AGENT_RUNTIME=gemini
+
+# ==== Gemini CLI (optional; only when AGENT_RUNTIME=gemini) ====
+# Gemini CLI version pin — omit or leave empty for latest.
+# GEMINI_CLI_VERSION=0.43.0
+#
+# Gemini OAuth ("Login with Google") credentials are stored in the host's
+# system keychain, which a Linux container cannot read. Inside the
+# container, set a per-account GEMINI_API_KEY_<LETTER>; the compose
+# generator maps it to GEMINI_API_KEY for accounts that have a non-empty
+# key. GEMINI_API_KEY is therefore the primary in-container auth path.
+# GEMINI_API_KEY_A=...
+# GEMINI_API_KEY_B=...
+
 # ==== Git Identity (auto-set by install.sh) ====
 # Used for git commits inside containers
 # GIT_USER_NAME=Your Name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fixture: [minimal, tier-b, n5, n30, with-special-chars]
+        fixture: [minimal, tier-b, n5, n30, with-special-chars, codex, gemini]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Stage fixture

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Version pinning via build arg (omit for latest)
 ARG CLAUDE_CODE_VERSION
 ARG CODEX_CLI_VERSION
+ARG GEMINI_CLI_VERSION
 
 WORKDIR /workspace
 
@@ -97,17 +98,26 @@ RUN curl -fsSL https://claude.ai/install.sh -o /tmp/claude-install.sh \
 # Add the native install location to PATH for all users
 ENV PATH="/home/node/.local/bin:${PATH}"
 
-# Install Codex CLI and statusline tools globally (npm packages)
+# Install Codex CLI, Gemini CLI, and statusline tools globally (npm packages)
 #
-# DL3016 waived: @openai/codex, ccstatusline, and claude-limitline are
-# latest-tracking helper packages; pinning them would block bug fixes without
-# a security benefit. CODEX_CLI_VERSION is available when reproducibility is
-# preferred for the Codex CLI.
+# Codex and Gemini share this npm layer: both runtimes install via npm
+# (installMethod "npm" in runtimes.json), so a single RUN keeps the image
+# layer count down. Each CLI keeps its own version-pin ARG.
+#
+# DL3016 waived: @openai/codex, @google/gemini-cli, ccstatusline, and
+# claude-limitline are latest-tracking helper packages; pinning them would
+# block bug fixes without a security benefit. CODEX_CLI_VERSION and
+# GEMINI_CLI_VERSION are available when reproducibility is preferred.
 # hadolint ignore=DL3016
 RUN if [[ -n "${CODEX_CLI_VERSION:-}" ]]; then \
         npm install -g "@openai/codex@${CODEX_CLI_VERSION}" ccstatusline claude-limitline; \
     else \
         npm install -g @openai/codex ccstatusline claude-limitline; \
+    fi \
+    && if [[ -n "${GEMINI_CLI_VERSION:-}" ]]; then \
+        npm install -g "@google/gemini-cli@${GEMINI_CLI_VERSION}"; \
+    else \
+        npm install -g @google/gemini-cli; \
     fi \
     && npm cache clean --force
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ scripts/claude-docker help       # Show all available commands
 | | `logs` | Follow container logs |
 | **Interactive** | `claude [service]` | Start Claude Code (default: claude-a) |
 | | `codex [service]` | Start OpenAI Codex CLI (default: codex-a) |
+| | `gemini [service]` | Start Google Gemini CLI (default: gemini-a) |
 | | `exec <service>` | Open shell in a container |
 | **Usage Tracking** | `usage [type] [flags]` | Token usage report |
 | **Dashboard** | `tui` (alias `dashboard`) | Launch multi-account TUI; auto-downloads a prebuilt binary if missing |
@@ -227,6 +228,38 @@ account state bind mount.
 
 The TUI can list and attach to Codex services. Claude-specific usage
 aggregation and `scripts/claude-docker usage` remain Claude-only.
+
+### Running Google Gemini CLI
+
+Gemini support is opt-in. Set `AGENT_RUNTIME=gemini` in `.env`, then
+regenerate compose files and recreate containers:
+
+```bash
+scripts/generate-compose.sh
+scripts/claude-docker up --remove-orphans
+scripts/claude-docker gemini
+```
+
+PowerShell users can run `.\scripts\generate-compose.ps1` and
+`.\scripts\claude-docker.ps1 gemini` instead.
+
+When `AGENT_RUNTIME=gemini` is active, generated services are named
+`gemini-a`, `gemini-b`, and so on. Each account stores mutable Gemini state
+in `~/.gemini-state/account-*/`, while host-managed Gemini config is mounted
+read-only from `~/.gemini/` and linked into the container's Gemini config
+directory. `settings.json`, `GEMINI.md`, `commands/`, and `extensions/` are
+linked; OAuth credentials, sessions, and logs stay in the writable account
+state directory.
+
+Gemini OAuth credentials ("Login with Google") are stored in the host
+system keychain, which a Linux container cannot read — the same limitation
+as the `gh` token caveat. The primary in-container auth path is therefore an
+API key: set per-account keys such as `GEMINI_API_KEY_A`, and the generator
+injects `GEMINI_API_KEY` only for accounts that have a non-empty key.
+
+The TUI can list and attach to Gemini services; usage columns show `--`.
+Claude-specific usage aggregation and `scripts/claude-docker usage` remain
+Claude-only.
 
 ### Authentication
 

--- a/scripts/lib/bootstrap-gemini.sh
+++ b/scripts/lib/bootstrap-gemini.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# bootstrap-gemini.sh — Gemini-runtime bootstrap module.
+#
+# Library file meant to be `source`d by scripts/entrypoint.sh. The shebang
+# doubles as a shellcheck shell directive (SC2148). Exposes a single entry
+# point, runtime_bootstrap, which the dispatcher calls after sourcing this
+# file via the registry's bootstrapModule field (issues #269, #272).
+#
+# Gemini is the validating third runtime (issue #272). Unlike bootstrap-
+# claude.sh, no jq transform is applied: Gemini's settings.json has no
+# sandbox flag or PowerShell-hook concept, so host config is plain-linked.
+# Unlike bootstrap-codex.sh there is no hooks/ tree to copy with CRLF
+# normalization.
+#
+# Depends on: scripts/lib/bootstrap-common.sh (sourced by entrypoint.sh).
+
+if [[ -n "${_CLAUDE_DOCKER_BOOTSTRAP_GEMINI_SH_SOURCED:-}" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+_CLAUDE_DOCKER_BOOTSTRAP_GEMINI_SH_SOURCED=1
+
+# --- Gemini config -------------------------------------------------------------
+# Gemini CLI resolves its config directory as <home>/.gemini, where <home> is
+# GEMINI_CLI_HOME when set, otherwise the OS home directory. The compose
+# generator emits GEMINI_CLI_HOME=<containerConfigMount> (the state-volume
+# mount), so the effective config directory is <GEMINI_CLI_HOME>/.gemini —
+# still inside the per-account state volume, so credentials and history
+# persist. oauth_creds.json, google_accounts.json, sessions, and logs are
+# left in that writable state directory; only non-secret host config
+# (settings.json, GEMINI.md, commands/, extensions/) is linked in.
+
+# runtime_bootstrap
+# Gemini-runtime entry point. Prepares the Gemini config directory:
+# plain-links non-secret host config (settings.json, GEMINI.md, commands/,
+# extensions/). GEMINI_ACCOUNT_DIR and GEMINI_SOURCE are resolved here from
+# the Gemini-specific environment variables.
+runtime_bootstrap() {
+    # Gemini computes its config dir as <home>/.gemini. GEMINI_CLI_HOME, when
+    # set by the generated compose file, overrides <home>; fall back to
+    # /home/node so the path matches the container's default OS home.
+    local GEMINI_HOME_ROOT="${GEMINI_CLI_HOME:-/home/node}"
+    local GEMINI_ACCOUNT_DIR="$GEMINI_HOME_ROOT/.gemini"
+    local GEMINI_SOURCE="${GEMINI_CONFIG_SOURCE:-/home/node/.gemini-host}"
+    mkdir -p "$GEMINI_ACCOUNT_DIR" /home/node/.agents/skills 2>/dev/null || true
+    chmod 700 "$GEMINI_ACCOUNT_DIR" 2>/dev/null || true
+
+    if [ -d "$GEMINI_SOURCE" ]; then
+        local FORCE_GEMINI_LINK="${GEMINI_CONFIG_SOURCE:+true}"
+
+        if [ -f "$GEMINI_SOURCE/settings.json" ]; then
+            bootstrap_link_item "$GEMINI_SOURCE/settings.json" "$GEMINI_ACCOUNT_DIR/settings.json" "$FORCE_GEMINI_LINK"
+        fi
+
+        if [ -f "$GEMINI_SOURCE/GEMINI.md" ]; then
+            bootstrap_link_item "$GEMINI_SOURCE/GEMINI.md" "$GEMINI_ACCOUNT_DIR/GEMINI.md" "$FORCE_GEMINI_LINK"
+        fi
+
+        if [ -d "$GEMINI_SOURCE/commands" ]; then
+            bootstrap_link_item "$GEMINI_SOURCE/commands" "$GEMINI_ACCOUNT_DIR/commands" "$FORCE_GEMINI_LINK"
+        fi
+
+        if [ -d "$GEMINI_SOURCE/extensions" ]; then
+            bootstrap_link_item "$GEMINI_SOURCE/extensions" "$GEMINI_ACCOUNT_DIR/extensions" "$FORCE_GEMINI_LINK"
+        fi
+    fi
+}

--- a/tests/env_fixtures/README.md
+++ b/tests/env_fixtures/README.md
@@ -11,6 +11,8 @@ is copied to the repo root as `.env`, then `scripts/generate-compose.sh` and
 | `n5.env` | `NUM_ACCOUNTS=5` scaling path (claude-a..claude-e) |
 | `n30.env` | `NUM_ACCOUNTS=30` Excel-style letter enumeration (#178) |
 | `with-special-chars.env` | Values containing `#`, `=`, quotes, whitespace — exercises the #170 parser |
+| `codex.env` | `AGENT_RUNTIME=codex` runtime selection (codex-a/codex-b services) |
+| `gemini.env` | `AGENT_RUNTIME=gemini` runtime selection (gemini-a/gemini-b services, #272) |
 
 ## Running locally
 

--- a/tests/env_fixtures/codex.env
+++ b/tests/env_fixtures/codex.env
@@ -1,0 +1,10 @@
+# Fixture: codex — AGENT_RUNTIME=codex runtime selection.
+# Used by .github/workflows/ci.yml compose-validate matrix: exercises the
+# Codex registry entry end-to-end through generate-compose.sh and
+# docker compose config (codex-a / codex-b services, .codex-state mounts).
+NUM_ACCOUNTS=2
+HOME=/tmp/claude-test
+PROJECT_DIR=/tmp/claude-test/project
+CONTAINER_PROJECT_DIR=/project
+IMAGE_TAG=ci-test
+AGENT_RUNTIME=codex

--- a/tests/env_fixtures/gemini.env
+++ b/tests/env_fixtures/gemini.env
@@ -1,0 +1,10 @@
+# Fixture: gemini — AGENT_RUNTIME=gemini runtime selection (issue #272).
+# Used by .github/workflows/ci.yml compose-validate matrix: exercises the
+# Gemini registry entry end-to-end through generate-compose.sh and
+# docker compose config (gemini-a / gemini-b services, .gemini-state mounts).
+NUM_ACCOUNTS=2
+HOME=/tmp/claude-test
+PROJECT_DIR=/tmp/claude-test/project
+CONTAINER_PROJECT_DIR=/project
+IMAGE_TAG=ci-test
+AGENT_RUNTIME=gemini

--- a/tui/internal/config/runtimes.json
+++ b/tui/internal/config/runtimes.json
@@ -46,6 +46,29 @@
       "mountsAgentsSkills": true,
       "credentialFiles": "auth.json",
       "oauthCredentialFile": "auth.json"
+    },
+    "gemini": {
+      "binary": "gemini",
+      "servicePrefix": "gemini",
+      "stateDir": ".gemini-state",
+      "containerHome": "/home/node/.gemini",
+      "hostConfigMount": "/home/node/.gemini-host",
+      "containerConfigMount": "/home/node/.gemini",
+      "configDirEnv": "GEMINI_CLI_HOME",
+      "configSourceEnv": "GEMINI_CONFIG_SOURCE",
+      "apiKeyVarPrefix": "GEMINI_API_KEY_",
+      "sdkApiKeyVar": "GEMINI_API_KEY",
+      "buildArg": "GEMINI_CLI_VERSION",
+      "installMethod": "npm",
+      "skipPermissionsFlag": "--yolo",
+      "configFormat": "json",
+      "bootstrapModule": "bootstrap-gemini.sh",
+      "extraEnv": "",
+      "extraRunArgs": "",
+      "supportsUsage": false,
+      "mountsAgentsSkills": true,
+      "credentialFiles": "oauth_creds.json",
+      "oauthCredentialFile": "oauth_creds.json"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds Google's Gemini CLI as the third agent runtime — the validating case
for the runtime-registry generalization (Epic #267). After this change
`AGENT_RUNTIME=gemini` drives compose generation, CLI dispatch, and the TUI
runtime field with no scattered branch logic. The only additions are a
registry entry and a bootstrap module, exactly as the registry design
promised.

Changes:

- **`tui/internal/config/runtimes.json`** — new `gemini` entry mirroring
  the 21-field schema (parity verified against `codex`).
- **`scripts/lib/bootstrap-gemini.sh`** (new, mode 644) — per-runtime
  bootstrap module. Plain-links non-secret host config (`settings.json`,
  `GEMINI.md`, `commands/`, `extensions/`); no `jq` transform, since
  Gemini's settings have no sandbox flag or PowerShell-hook concept.
- **`Dockerfile`** — `GEMINI_CLI_VERSION` ARG and `npm install -g
  @google/gemini-cli`, sharing the existing codex npm layer (both runtimes
  install via npm).
- **`tests/env_fixtures/gemini.env`, `codex.env`** (new) — fixtures for the
  `compose-validate` matrix.
- **`.github/workflows/ci.yml`** — `codex` and `gemini` added to the
  `compose-validate` matrix.
- **`.env.example`, `README.md`** — document the gemini runtime.

## Why

A registry validated by only a single second runtime (codex) risks being
"claude plus one exception". A genuine third runtime exercises the registry
and surfaces any remaining hardcoded assumptions (#267).

## Gemini CLI flag verification

The Gemini flag and credential filename were CLI-verified, not
web-research-based. `@google/gemini-cli@0.43.0` was installed via npm and
inspected:

- `skipPermissionsFlag` = **`--yolo`** — confirmed in `gemini --help`
  (`-y, --yolo  Automatically accept all actions`). The issue's 2026-05
  web-research estimate was correct.
- `credentialFiles` / `oauthCredentialFile` = **`oauth_creds.json`** —
  confirmed in the installed package (`OAUTH_FILE = "oauth_creds.json"`),
  written under the Gemini config directory.
- Gemini resolves its config directory as `<home>/.gemini`, where `<home>`
  is `GEMINI_CLI_HOME` when set, else the OS home directory. The registry
  uses `GEMINI_CLI_HOME` as `configDirEnv`; the compose generator emits
  `GEMINI_CLI_HOME=/home/node/.gemini`, so the effective config path is
  `/home/node/.gemini/.gemini` — still inside the per-account
  `.gemini-state` volume, so credentials and history persist. The bootstrap
  module links host config to the same `<GEMINI_CLI_HOME>/.gemini` path.

## Test Plan

CI-verified by this PR:

- `compose-validate (gemini)` and `compose-validate (codex)` — new matrix
  fixtures; CI runs `generate-compose.sh` then `docker compose config`.
- `Hadolint` — Dockerfile change (warnings fail CI).
- `Go tests (TUI)` — the registry is `go:embed`-ed; the new entry must
  compile and pass.
- `Bash Tests` — `test_runtime_registry_equivalence.sh` now covers the
  `gemini` entry (bash jq / bash awk / pwsh readers byte-identical;
  verified locally: 64/64 PASS).
- `Shellcheck` — `bootstrap-gemini.sh`.

Verified locally:

- `jq` parses `runtimes.json`; `gemini` entry has all 21 schema fields.
- `generate-compose.sh` with `AGENT_RUNTIME=gemini` produces
  gemini-flavored YAML (`gemini-a`/`gemini-b` services, `.gemini-state`
  mounts, `GEMINI_CLI_VERSION` build arg).
- `bash -n scripts/lib/bootstrap-gemini.sh` passes.
- Existing bash tests pass (no regression).

**Not verifiable in this environment or in CI** — these require a built
Docker image with the Gemini CLI and a running container, and are NOT
covered by the `compose-validate` job:

- `scripts/claude-docker up` then `scripts/claude-docker gemini` attaching
  to a live `gemini-a` container.
- The TUI listing and attaching to `gemini-*` services with `--` usage
  columns.

These are implemented per the registry/bootstrap pattern but should be
exercised in a Docker environment before the Epic is closed.

Refs #267
Closes #272
