### PR TITLE
refactor(scripts): generalize install/remove/cleanup over the runtime registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,11 @@
 
 # === Secrets and rotation ===
 # The following fields are secrets and should be rotated regularly:
-#   - CLAUDE_API_KEY_A / CLAUDE_API_KEY_B (Claude Console; mapped to
-#     ANTHROPIC_API_KEY at container runtime)
-#   - GH_TOKEN                            (GitHub CLI token)
+#   - <RUNTIME>_API_KEY_A / _B  (per-runtime Console API keys, mapped to the
+#     runtime's SDK key variable at container runtime — CLAUDE_API_KEY_* ->
+#     ANTHROPIC_API_KEY, CODEX_API_KEY_* -> OPENAI_API_KEY,
+#     GEMINI_API_KEY_* -> GEMINI_API_KEY)
+#   - GH_TOKEN                  (GitHub CLI token)
 # Recommended rotation cadence: every 90 days for production keys.
 #
 # install.sh creates .env.backup.<unix_ts> on every run, capturing the
@@ -21,14 +23,29 @@ PROJECT_DIR=/absolute/path/to/your/project
 # CLAUDE_CODE_VERSION=1.2.3
 
 # ==== Path B: Console API Keys (optional) ====
-# Required only if using API key authentication (not OAuth)
+# Required only if using API key authentication (not OAuth).
+# The variable prefix depends on the active runtime (see "Runtime selection"
+# below): CLAUDE_API_KEY_ for Claude, CODEX_API_KEY_ for Codex,
+# GEMINI_API_KEY_ for Gemini. Keys are per account (_A, _B, ...).
 # CLAUDE_API_KEY_A=sk-ant-...
 # CLAUDE_API_KEY_B=sk-ant-...
 
 # ==== Runtime selection (optional) ====
-# The default runtime is Claude. Set AGENT_RUNTIME to run a different CLI;
+# The default runtime is Claude — leaving AGENT_RUNTIME unset behaves exactly
+# as a Claude-only install. Set it to run a different registered CLI, then
 # regenerate compose files (scripts/generate-compose.sh) after changing it.
+# Registered runtimes: claude, codex, gemini.
 # AGENT_RUNTIME=gemini
+
+# ==== Codex CLI (optional; only when AGENT_RUNTIME=codex) ====
+# Codex CLI version pin — omit or leave empty for latest.
+# CODEX_CLI_VERSION=0.43.0
+#
+# For API-key based Codex sessions, set per-account CODEX_API_KEY_<LETTER>;
+# the compose generator maps it to OPENAI_API_KEY for accounts that have a
+# non-empty key.
+# CODEX_API_KEY_A=...
+# CODEX_API_KEY_B=...
 
 # ==== Gemini CLI (optional; only when AGENT_RUNTIME=gemini) ====
 # Gemini CLI version pin — omit or leave empty for latest.

--- a/README.md
+++ b/README.md
@@ -261,6 +261,43 @@ The TUI can list and attach to Gemini services; usage columns show `--`.
 Claude-specific usage aggregation and `scripts/claude-docker usage` remain
 Claude-only.
 
+### Adding a runtime
+
+Claude, Codex, and Gemini are all defined the same way: a registry entry plus
+a bootstrap module. No installer, lifecycle script, or compose generator code
+is runtime-specific — they all resolve per-runtime values from the registry.
+To add a new runtime:
+
+1. **Add a registry entry.** Append an object under `runtimes` in
+   `tui/internal/config/runtimes.json`, keyed by the runtime name. Populate
+   every field that the existing entries declare (the registry is the single
+   source of truth read by Go, bash, PowerShell, and the container
+   entrypoint). The fields the lifecycle scripts depend on are:
+
+   | Field | Used for |
+   |-------|----------|
+   | `binary` | CLI executable verified inside the container |
+   | `servicePrefix` | compose service names (`<prefix>-a`, `<prefix>-b`, ...) |
+   | `stateDir` | per-account host state directory (`~/<stateDir>/account-*`) |
+   | `containerHome` | its basename is the host config directory (`~/<basename>`) |
+   | `apiKeyVarPrefix` | `.env` API-key variable prefix (`<PREFIX><LETTER>`) |
+   | `sdkApiKeyVar` | SDK key variable the API key is mapped to at runtime |
+   | `buildArg` | Docker build argument for the version pin |
+   | `bootstrapModule` | bootstrap script sourced by the entrypoint |
+   | `credentialFiles` | credential filename hardened to `600` by the installer |
+
+2. **Add a bootstrap module.** Create `scripts/lib/bootstrap-<runtime>.sh`
+   matching the name in the registry's `bootstrapModule` field. It must
+   expose a single `runtime_bootstrap` entry point; the container entrypoint
+   sources it via the registry and runs it after the runtime-agnostic common
+   steps. Use `scripts/lib/bootstrap-codex.sh` as a template — shared logic
+   lives in `scripts/lib/bootstrap-common.sh`.
+
+Once both exist, `install`, `remove`, and `cleanup` (bash and PowerShell)
+pick up the new runtime automatically: the installer offers it in the
+runtime-selection prompt, and `remove`/`cleanup` iterate every registered
+runtime when removing state directories.
+
 ### Authentication
 
 Authenticate directly inside each container. Each container keeps its own

--- a/scripts/cleanup.ps1
+++ b/scripts/cleanup.ps1
@@ -97,15 +97,22 @@ try {
             Write-Error '  stdin is not interactive. Pass -Force to remove state non-interactively, or -SkipState to skip.'
             exit 1
         }
-        $shouldRemove = Read-Confirmation -Question 'Remove ~/.claude-state/*?'
+        $shouldRemove = Read-Confirmation -Question "Remove every runtime's state directory (~/.*-state)?"
     }
 
     if ($shouldRemove) {
-        $statePath = Join-Path $env:USERPROFILE '.claude-state'
-        if (Test-Path $statePath) {
-            Remove-Item $statePath -Recurse -Force
-            Write-Host '  State directories removed.'
+        # Remove every registered runtime's state directory, not just
+        # Claude's, so a codex/gemini install is fully cleaned up (see #273).
+        foreach ($runtime in Get-RuntimeList -ProjectRoot $ProjectRoot) {
+            $stateDir = Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $runtime -Field 'stateDir'
+            if (-not $stateDir) { continue }
+            $statePath = Join-Path $env:USERPROFILE $stateDir
+            if (Test-Path $statePath) {
+                Remove-Item $statePath -Recurse -Force
+                Write-Host "  Removed: ~/$stateDir"
+            }
         }
+        Write-Host '  State directories removed.'
     }
     else {
         Write-Host '  Skipped.'

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -17,6 +17,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="${PROJECT_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 cd "$PROJECT_ROOT"
 
+# runtime.sh resolves per-runtime state-directory names from the registry so
+# state cleanup covers every registered runtime, not just Claude (see #273).
+# shellcheck source=lib/runtime.sh
+. "$SCRIPT_DIR/lib/runtime.sh"
+
 REPO_DIR=""
 CONFIRM="ask"
 RUN_BACKUPS=0
@@ -101,7 +106,7 @@ fi
 echo "=== Removing state directories ==="
 if [ "$CONFIRM" = "ask" ]; then
     if [ -t 0 ]; then
-        read -p "Remove ~/.claude-state/*? (y/N) " confirm
+        read -p "Remove every runtime's state directory (~/.*-state)? (y/N) " confirm
         case "$confirm" in
             y|Y|yes|YES) CONFIRM="yes" ;;
             *)           CONFIRM="no"  ;;
@@ -114,7 +119,17 @@ if [ "$CONFIRM" = "ask" ]; then
 fi
 
 if [ "$CONFIRM" = "yes" ]; then
-    rm -rf "${HOME}/.claude-state"
+    # Remove every registered runtime's state directory, not just Claude's,
+    # so a codex/gemini install is fully cleaned up (see #273).
+    while IFS= read -r runtime; do
+        [ -z "$runtime" ] && continue
+        state_dir="$(runtime_field "$runtime" "stateDir")"
+        [ -z "$state_dir" ] && continue
+        if [ -d "${HOME}/${state_dir}" ]; then
+            rm -rf "${HOME:?}/${state_dir}"
+            echo "  Removed: ~/${state_dir}"
+        fi
+    done < <(runtime_list)
     echo "  State directories removed."
 else
     echo "  Skipped."

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -53,6 +53,9 @@ $Script:SourceDir = ''
 $Script:ClaudeVersion = ''
 $Script:ApiKeyA = ''
 $Script:ApiKeyB = ''
+# Selected agent runtime (claude, codex, gemini, ...). Defaults to claude so a
+# non-interactive or default install behaves exactly as before (see #273).
+$Script:Runtime = 'claude'
 
 # --- I/O Latency Benchmark ---------------------------------------------------
 
@@ -261,6 +264,23 @@ function Get-Configuration {
     Write-Host '=== Configuration ===' -ForegroundColor Cyan
     Write-Host ''
 
+    # Agent runtime. Options are read from the runtime registry; claude is
+    # listed first so accepting the default keeps today's behavior. A single
+    # registered runtime skips the prompt entirely.
+    $runtimes = @(Get-RuntimeList -ProjectRoot $ProjectRoot)
+    if ($runtimes -contains 'claude') {
+        $runtimes = @('claude') + ($runtimes | Where-Object { $_ -ne 'claude' })
+    }
+    if ($runtimes.Count -gt 1) {
+        $Script:Runtime = Read-Selection `
+            -Question 'Which agent runtime will you use?' `
+            -Options $runtimes
+    }
+    elseif ($runtimes.Count -eq 1) {
+        $Script:Runtime = $runtimes[0]
+    }
+    Write-LogInfo "Agent runtime: $($Script:Runtime)"
+
     # Auth Path
     $authChoice = Read-Selection `
         -Question 'Which authentication method will you use?' `
@@ -330,14 +350,16 @@ function Get-Configuration {
     }
     Write-LogInfo "Accounts: $($Script:NumAccounts)"
 
-    # API keys (Path B)
+    # API keys (Path B). The .env variable prefix is resolved from the runtime
+    # registry (CLAUDE_API_KEY_ / CODEX_API_KEY_ / GEMINI_API_KEY_ / ...).
     $Script:ApiKeys = @()
     if ($Script:AuthPath -eq 'B') {
+        $apiKeyPrefix = Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $Script:Runtime -Field 'apiKeyVarPrefix'
         Write-Host ''
-        Write-Host 'Enter Console API keys (from console.anthropic.com):' -ForegroundColor Cyan
+        Write-Host "Enter Console API keys (written as ${apiKeyPrefix}<LETTER>):" -ForegroundColor Cyan
         for ($i = 1; $i -le $Script:NumAccounts; $i++) {
             $letter = Get-AccountLetterUpper -Index $i  # A, B, ..., Z, AA, ZZ
-            $Script:ApiKeys += Read-Secret -Question "API key for Account $letter (sk-ant-...)"
+            $Script:ApiKeys += Read-Secret -Question "API key for Account $letter"
         }
 
         if (-not $Script:ApiKeys[0]) {
@@ -408,6 +430,15 @@ function New-EnvFile {
     $lines += '# ==== Windows: HOME for Docker Compose volume expansion ===='
     $lines += "HOME=$homePath"
     $lines += ''
+
+    # AGENT_RUNTIME is written only for non-default runtimes; omitting it for
+    # claude keeps a default install byte-compatible with prior runs.
+    if ($Script:Runtime -ne 'claude') {
+        $lines += '# ==== Agent Runtime ===='
+        $lines += "AGENT_RUNTIME=$($Script:Runtime)"
+        $lines += ''
+    }
+
     $lines += '# ==== Claude Config Source (optional) ===='
     $lines += '# Set to a path inside the container to source config directly from a repo.'
     $lines += '# Example: /project/claude-config/global'
@@ -421,10 +452,12 @@ function New-EnvFile {
     }
 
     if ($Script:AuthPath -eq 'B') {
+        # API-key variable prefix is resolved from the runtime registry.
+        $apiKeyPrefix = Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $Script:Runtime -Field 'apiKeyVarPrefix'
         $lines += '# ==== Path B: Console API Keys ===='
         for ($i = 1; $i -le $Script:NumAccounts; $i++) {
             $letter = Get-AccountLetterUpper -Index $i  # A, B, ..., Z, AA, ZZ
-            $lines += "CLAUDE_API_KEY_${letter}=$($Script:ApiKeys[$i - 1])"
+            $lines += "${apiKeyPrefix}${letter}=$($Script:ApiKeys[$i - 1])"
         }
         $lines += ''
     }
@@ -514,10 +547,18 @@ function New-EnvFile {
 function New-StateDirs {
     Write-LogStep 'Creating state directories'
 
-    $dirs = @((Join-Path $env:USERPROFILE '.claude'))
+    # Host config directory and per-account state directory are both resolved
+    # from the runtime registry (see #273). The host config dir is the
+    # basename of containerHome (e.g. /home/node/.claude -> .claude); the
+    # state-dir name is the registry's stateDir field verbatim.
+    $containerHome = Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $Script:Runtime -Field 'containerHome'
+    $configDir = ($containerHome -split '/')[-1]
+    $stateDir = Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $Script:Runtime -Field 'stateDir'
+
+    $dirs = @((Join-Path $env:USERPROFILE $configDir))
     for ($i = 1; $i -le $Script:NumAccounts; $i++) {
         $letter = Get-AccountLetter -Index $i
-        $dirs += (Join-Path $env:USERPROFILE ".claude-state\account-$letter")
+        $dirs += (Join-Path $env:USERPROFILE (Join-Path $stateDir "account-$letter"))
     }
 
     foreach ($dir in $dirs) {
@@ -759,7 +800,14 @@ function Install-Dependencies {
         return
     }
 
-    $services = @(Get-ServiceNames -ProjectRoot $ProjectRoot)
+    # Service names use the selected runtime's registry servicePrefix
+    # (claude-a, codex-a, gemini-a, ...) so npm install targets the right
+    # containers (see #273).
+    $servicePrefix = Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $Script:Runtime -Field 'servicePrefix'
+    $services = @()
+    for ($i = 1; $i -le $Script:NumAccounts; $i++) {
+        $services += "$servicePrefix-$(Get-AccountLetter -Index $i)"
+    }
 
     foreach ($svc in $services) {
         Write-LogInfo "Installing npm dependencies in $svc..."
@@ -779,7 +827,11 @@ function Install-Dependencies {
 function Invoke-Verification {
     Write-LogStep 'Verifying setup'
 
-    $primarySvc = 'claude-a'
+    # The primary service name and the runtime binary are resolved from the
+    # registry (claude-a/claude, codex-a/codex, gemini-a/gemini — see #273).
+    $servicePrefix = Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $Script:Runtime -Field 'servicePrefix'
+    $runtimeBinary = Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $Script:Runtime -Field 'binary'
+    $primarySvc = "$servicePrefix-a"
 
     # Check container is running
     $psOutput = Invoke-Compose -ProjectRoot $ProjectRoot ps --format '{{.Name}}' 2>$null
@@ -788,21 +840,21 @@ function Invoke-Verification {
     }
     else {
         Write-LogError "Container $primarySvc is not running"
-        Write-LogInfo 'Check logs: docker compose logs claude-a'
+        Write-LogInfo "Check logs: docker compose logs $primarySvc"
         return
     }
 
-    # Check Claude Code is available
-    $version = Invoke-Compose -ProjectRoot $ProjectRoot exec -T $primarySvc claude --version 2>$null
+    # Check the runtime CLI is available
+    $version = Invoke-Compose -ProjectRoot $ProjectRoot exec -T $primarySvc $runtimeBinary --version 2>$null
     if ($LASTEXITCODE -eq 0) {
-        Write-LogSuccess "Claude Code is available ($version)"
+        Write-LogSuccess "$runtimeBinary is available ($version)"
     }
     else {
-        Write-LogWarn 'Could not verify Claude Code (container may still be starting)'
+        Write-LogWarn "Could not verify $runtimeBinary (container may still be starting)"
     }
 
     # Check auth status (Path A: OAuth login required; Path B: API key validates)
-    $null = Invoke-Compose -ProjectRoot $ProjectRoot exec -T $primarySvc claude auth status 2>$null
+    $null = Invoke-Compose -ProjectRoot $ProjectRoot exec -T $primarySvc $runtimeBinary auth status 2>$null
     if ($LASTEXITCODE -eq 0) {
         Write-LogSuccess 'Authentication verified'
     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,6 +57,9 @@ AUTH_PATH=""
 TIER=""
 SOURCE_DIR=""
 CLAUDE_VERSION=""
+# Selected agent runtime (claude, codex, gemini, ...). Defaults to claude so a
+# non-interactive or default install behaves exactly as before (see #273).
+RUNTIME="claude"
 
 # --- Utility Functions --------------------------------------------------------
 
@@ -71,6 +74,8 @@ log_step()    { CURRENT_STEP=$((CURRENT_STEP + 1)); echo -e "\n${BOLD}[$CURRENT_
 . "$SCRIPT_DIR/lib/tui-release.sh"
 # shellcheck source=lib/parse_env.sh
 . "$SCRIPT_DIR/lib/parse_env.sh"
+# shellcheck source=lib/runtime.sh
+. "$SCRIPT_DIR/lib/runtime.sh"
 # shellcheck source=lib/index.sh
 . "$SCRIPT_DIR/lib/index.sh"
 # shellcheck source=lib/build-compose-cmd.sh
@@ -478,6 +483,27 @@ run_prerequisite_checks() {
 collect_configuration() {
     echo -e "\n${BOLD}${CYAN}=== Configuration ===${NC}\n"
 
+    # Agent runtime. Options are read from the runtime registry; claude is
+    # listed first so pressing 1 (or accepting the default) keeps today's
+    # behavior. A single registered runtime skips the prompt entirely.
+    local runtimes=()
+    local r
+    while IFS= read -r r; do
+        [[ -z "$r" ]] && continue
+        if [[ "$r" == "claude" ]]; then
+            runtimes=("$r" "${runtimes[@]}")
+        else
+            runtimes+=("$r")
+        fi
+    done < <(runtime_list)
+
+    if [[ ${#runtimes[@]} -gt 1 ]]; then
+        RUNTIME=$(prompt_select "Which agent runtime will you use?" "${runtimes[@]}")
+    elif [[ ${#runtimes[@]} -eq 1 ]]; then
+        RUNTIME="${runtimes[0]}"
+    fi
+    log_info "Agent runtime: $RUNTIME"
+
     # Auth Path
     local auth_choice
     auth_choice=$(prompt_select \
@@ -543,16 +569,19 @@ collect_configuration() {
     fi
     log_info "Accounts: $NUM_ACCOUNTS"
 
-    # API keys (Path B)
+    # API keys (Path B). The .env variable prefix is resolved from the runtime
+    # registry (CLAUDE_API_KEY_ / CODEX_API_KEY_ / GEMINI_API_KEY_ / ...).
     API_KEYS=()
     if [[ "$AUTH_PATH" == "B" ]]; then
-        echo -e "\n${CYAN}Enter Console API keys (from console.anthropic.com):${NC}"
+        local api_key_prefix
+        api_key_prefix=$(runtime_field "$RUNTIME" "apiKeyVarPrefix")
+        echo -e "\n${CYAN}Enter Console API keys (written as ${api_key_prefix}<LETTER>):${NC}"
         for i in $(seq 1 "$NUM_ACCOUNTS"); do
             local letter
             letter=$(index_to_letter "$i")
             local upper
             upper=$(printf '%s' "$letter" | tr '[:lower:]' '[:upper:]')
-            API_KEYS+=("$(prompt_secret "API key for Account $upper (sk-ant-...)")")
+            API_KEYS+=("$(prompt_secret "API key for Account $upper")")
         done
 
         # Validate at least the first key is non-empty
@@ -602,6 +631,15 @@ generate_env() {
         fi
         echo "IMAGE_TAG=${default_tag:-$(date '+%Y.%m.%d')}"
         echo ""
+
+        # AGENT_RUNTIME is written only for non-default runtimes; omitting it
+        # for claude keeps a default install byte-compatible with prior runs.
+        if [[ "$RUNTIME" != "claude" ]]; then
+            echo "# ==== Agent Runtime ===="
+            echo "AGENT_RUNTIME=$RUNTIME"
+            echo ""
+        fi
+
         echo "# ==== Claude Config Source (optional) ===="
         echo "# Set to a path inside the container to source config directly from a repo."
         echo "# Example: /project/claude-config/global"
@@ -615,13 +653,16 @@ generate_env() {
         fi
 
         if [[ "$AUTH_PATH" == "B" ]]; then
+            # API-key variable prefix is resolved from the runtime registry.
+            local api_key_prefix
+            api_key_prefix=$(runtime_field "$RUNTIME" "apiKeyVarPrefix")
             echo "# ==== Path B: Console API Keys ===="
             for i in $(seq 1 "$NUM_ACCOUNTS"); do
                 local letter
                 letter=$(index_to_letter "$i")
                 local upper
                 upper=$(printf '%s' "$letter" | tr '[:lower:]' '[:upper:]')
-                echo "CLAUDE_API_KEY_${upper}=${API_KEYS[$((i-1))]}"
+                echo "${api_key_prefix}${upper}=${API_KEYS[$((i-1))]}"
             done
             echo ""
         fi
@@ -706,11 +747,20 @@ generate_env() {
 create_state_dirs() {
     log_step "Creating state directories"
 
-    local dirs=("$HOME/.claude")
+    # Host config directory and per-account state directory are both resolved
+    # from the runtime registry (see #273). The host config dir is the
+    # basename of containerHome (e.g. /home/node/.claude -> .claude); the
+    # state-dir name is the registry's stateDir field verbatim.
+    local container_home state_dir config_dir
+    container_home=$(runtime_field "$RUNTIME" "containerHome")
+    config_dir="${container_home##*/}"
+    state_dir=$(runtime_field "$RUNTIME" "stateDir")
+
+    local dirs=("$HOME/$config_dir")
     for i in $(seq 1 "$NUM_ACCOUNTS"); do
         local letter
         letter=$(index_to_letter "$i")
-        dirs+=("$HOME/.claude-state/account-${letter}")
+        dirs+=("$HOME/$state_dir/account-${letter}")
     done
 
     for dir in "${dirs[@]}"; do
@@ -725,9 +775,12 @@ create_state_dirs() {
         fi
     done
 
-    # Harden any existing credential files (Path A OAuth stores .credentials.json)
+    # Harden any existing credential files (Path A OAuth stores them under the
+    # account state dir; the filename is the registry's credentialFiles field).
+    local cred_file
+    cred_file=$(runtime_field "$RUNTIME" "credentialFiles")
     local cred_files
-    cred_files=$(find "$HOME/.claude-state" -name "*.credentials.json" -o -name ".credentials.json" 2>/dev/null || true)
+    cred_files=$(find "$HOME/$state_dir" -name "*${cred_file}" -o -name "$cred_file" 2>/dev/null || true)
     if [[ -n "$cred_files" ]]; then
         while IFS= read -r cfile; do
             chmod 600 "$cfile"
@@ -963,12 +1016,16 @@ install_dependencies() {
 
     build_compose_cmd
 
+    # Service names use the runtime's registry servicePrefix (claude-a,
+    # codex-a, gemini-a, ...) so npm install targets the right containers.
+    local service_prefix
+    service_prefix=$(runtime_field "$RUNTIME" "servicePrefix")
     local services=()
     local n="${NUM_ACCOUNTS:-2}"
     for i in $(seq 1 "$n"); do
         local letter
         letter=$(index_to_letter "$i")
-        services+=("claude-${letter}")
+        services+=("${service_prefix}-${letter}")
     done
 
     for svc in "${services[@]}"; do
@@ -989,7 +1046,13 @@ run_verification() {
     cd "$PROJECT_ROOT"
 
     build_compose_cmd
-    local primary_svc="claude-a"
+
+    # The primary service name and the runtime binary are resolved from the
+    # registry (claude-a/claude, codex-a/codex, gemini-a/gemini — see #273).
+    local service_prefix runtime_binary primary_svc
+    service_prefix=$(runtime_field "$RUNTIME" "servicePrefix")
+    runtime_binary=$(runtime_field "$RUNTIME" "binary")
+    primary_svc="${service_prefix}-a"
 
     # Check container is running
     if "${COMPOSE_CMD[@]}" ps --format '{{.Name}}' 2>/dev/null | grep -q "$primary_svc"; then
@@ -1000,15 +1063,15 @@ run_verification() {
         return 1
     fi
 
-    # Check Claude Code is available
-    if "${COMPOSE_CMD[@]}" exec -T "$primary_svc" claude --version 2>/dev/null; then
-        log_success "Claude Code is available"
+    # Check the runtime CLI is available
+    if "${COMPOSE_CMD[@]}" exec -T "$primary_svc" "$runtime_binary" --version 2>/dev/null; then
+        log_success "$runtime_binary is available"
     else
-        log_warn "Could not verify Claude Code (container may still be starting)"
+        log_warn "Could not verify $runtime_binary (container may still be starting)"
     fi
 
     # Check auth status
-    if "${COMPOSE_CMD[@]}" exec -T "$primary_svc" claude auth status 2>/dev/null; then
+    if "${COMPOSE_CMD[@]}" exec -T "$primary_svc" "$runtime_binary" auth status 2>/dev/null; then
         log_success "Authentication verified"
     else
         log_warn "Authentication not verified (may need browser login or API key check)"

--- a/scripts/remove.ps1
+++ b/scripts/remove.ps1
@@ -157,27 +157,37 @@ function Remove-Worktrees {
 function Remove-StateDirectories {
     Write-LogStep 'Removing state directories'
 
-    $stateRoot = Join-Path $env:USERPROFILE '.claude-state'
+    # Offer every registered runtime's state directory, not just Claude's, so
+    # a codex/gemini install does not leave its state orphaned. State-dir
+    # names are resolved from the runtime registry (see #267, #273).
+    $found = $false
+    foreach ($runtime in Get-RuntimeList -ProjectRoot $ProjectRoot) {
+        $stateDir = Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $runtime -Field 'stateDir'
+        if (-not $stateDir) { continue }
+        $stateRoot = Join-Path $env:USERPROFILE $stateDir
 
-    if (-not (Test-Path $stateRoot)) {
-        Write-LogInfo "No state directories found at $stateRoot"
-        return
+        if (-not (Test-Path $stateRoot)) { continue }
+        $found = $true
+
+        # List what exists
+        Write-Host "  Contents of ${stateRoot}:" -ForegroundColor DarkGray
+        foreach ($item in Get-ChildItem $stateRoot -ErrorAction SilentlyContinue) {
+            $size = Get-FriendlySize -Bytes (Get-DirectorySize -Path $item.FullName)
+            Write-Host "    $($item.Name) ($size)" -ForegroundColor DarkGray
+        }
+
+        Write-Host ''
+        if (Read-Confirmation -Question "Remove all $runtime state directories (~/$stateDir)?") {
+            Remove-Item $stateRoot -Recurse -Force
+            Write-LogSuccess "$runtime state directories removed"
+        }
+        else {
+            Write-LogInfo "$runtime state directories kept"
+        }
     }
 
-    # List what exists
-    Write-Host "  Contents of ${stateRoot}:" -ForegroundColor DarkGray
-    foreach ($item in Get-ChildItem $stateRoot -ErrorAction SilentlyContinue) {
-        $size = Get-FriendlySize -Bytes (Get-DirectorySize -Path $item.FullName)
-        Write-Host "    $($item.Name) ($size)" -ForegroundColor DarkGray
-    }
-
-    Write-Host ''
-    if (Read-Confirmation -Question 'Remove all account state directories (~/.claude-state)?') {
-        Remove-Item $stateRoot -Recurse -Force
-        Write-LogSuccess 'State directories removed'
-    }
-    else {
-        Write-LogInfo 'State directories kept'
+    if (-not $found) {
+        Write-LogInfo 'No state directories found'
     }
 }
 

--- a/scripts/remove.sh
+++ b/scripts/remove.sh
@@ -11,6 +11,8 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # shellcheck source=lib/parse_env.sh
 . "$SCRIPT_DIR/lib/parse_env.sh"
+# shellcheck source=lib/runtime.sh
+. "$SCRIPT_DIR/lib/runtime.sh"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -182,28 +184,50 @@ remove_worktrees() {
 remove_state_directories() {
     log_step "Removing state directories"
 
-    local state_root="$HOME/.claude-state"
+    # Offer every registered runtime's state directory, not just Claude's,
+    # so a codex/gemini install does not leave its state orphaned. State-dir
+    # names are resolved from the runtime registry (see #267, #273).
+    #
+    # runtime_list output is collected into an array first: prompt_confirm
+    # reads from stdin, so iterating via `done < <(runtime_list)` would let
+    # the prompt consume the runtime stream instead of the user's answer.
+    local runtimes=()
+    local runtime
+    while IFS= read -r runtime; do
+        [[ -n "$runtime" ]] && runtimes+=("$runtime")
+    done < <(runtime_list)
 
-    if [[ ! -d "$state_root" ]]; then
-        log_info "No state directories found at $state_root"
-        return 0
-    fi
+    local found=0
+    local state_dir state_root
+    for runtime in "${runtimes[@]}"; do
+        state_dir="$(runtime_field "$runtime" "stateDir")"
+        [[ -z "$state_dir" ]] && continue
+        state_root="$HOME/$state_dir"
 
-    # List what exists
-    echo -e "${DIM}  Contents of $state_root/:${NC}"
-    ls -1 "$state_root" 2>/dev/null | while read -r item; do
-        local size
-        size=$(du -sh "$state_root/$item" 2>/dev/null | cut -f1)
-        echo -e "${DIM}    $item ($size)${NC}"
+        if [[ ! -d "$state_root" ]]; then
+            continue
+        fi
+        found=1
+
+        # List what exists
+        echo -e "${DIM}  Contents of $state_root/:${NC}"
+        ls -1 "$state_root" 2>/dev/null | while read -r item; do
+            local size
+            size=$(du -sh "$state_root/$item" 2>/dev/null | cut -f1)
+            echo -e "${DIM}    $item ($size)${NC}"
+        done
+
+        echo ""
+        if prompt_confirm "Remove all $runtime state directories (~/$state_dir)?"; then
+            rm -rf "$state_root"
+            log_success "$runtime state directories removed"
+        else
+            log_info "$runtime state directories kept"
+        fi
     done
 
-    # Account state directories
-    echo ""
-    if prompt_confirm "Remove all account state directories (~/.claude-state)?"; then
-        rm -rf "$state_root"
-        log_success "State directories removed"
-    else
-        log_info "State directories kept"
+    if [[ "$found" -eq 0 ]]; then
+        log_info "No state directories found"
     fi
 }
 


### PR DESCRIPTION
## Summary

Generalizes the installer and lifecycle scripts so they resolve state
directories, API-key prefixes, and service names from the runtime registry
(`tui/internal/config/runtimes.json`) instead of hardcoding `claude` /
`.claude-state` / `CLAUDE_API_KEY_`.

- **install.sh / install.ps1** — add an optional runtime-selection prompt
  (default `claude`). The state directory, host config directory, API-key
  variable prefix, npm-install service name, verification service name, and
  verified binary are all resolved from the selected runtime's registry
  entry. `AGENT_RUNTIME` is written to `.env` only for non-`claude` runtimes,
  so a non-interactive or default install stays byte-compatible with prior
  runs.
- **remove.sh / remove.ps1** — iterate the registered runtime list so every
  runtime's state directory (claude, codex, gemini) is offered for removal,
  not just `.claude-state`. `remove.sh` now also sources `runtime.sh`.
- **cleanup.sh / cleanup.ps1** — same registered-runtime iteration when
  removing state directories. `cleanup.sh` now sources `runtime.sh`.
- **.env.example** — document the per-runtime API-key variables
  (`CLAUDE_API_KEY_` / `CODEX_API_KEY_` / `GEMINI_API_KEY_`) and clarify
  that an unset `AGENT_RUNTIME` behaves as a Claude-only install.
- **README.md** — add an "Adding a runtime" guide (registry entry +
  bootstrap module).

## Why

`install` / `remove` / `cleanup` still hardcoded `.claude-state` and
`CLAUDE_API_KEY_` (#267). `remove` deleted only one runtime's state, leaving
others orphaned. Generalizing closes the last set of hardcoded branches and
documents the runtime-addition procedure for contributors.

State-directory names in the registry equal the prior hardcoded names, so
existing claude/codex installs require **no migration**. The installer's new
runtime prompt defaults to `claude`, so a default install behaves exactly as
today.

`remove.sh` collects the runtime list into an array before iterating: the
confirmation prompt reads from stdin, so a `done < <(runtime_list)` loop
would let the prompt consume the runtime stream instead of the user's answer.

## Test Plan

- `bash -n` syntax-checks pass for all three changed shell scripts.
- The runtime registry accessors resolve `claude` to exactly the prior
  hardcoded values (`~/.claude`, `~/.claude-state`, `CLAUDE_API_KEY_`,
  `claude-a`, `claude`, `.credentials.json`) — verified, confirming no
  migration is needed.
- `remove.sh`'s `remove_state_directories` exercised against fake state
  dirs with y/y/y, y/n/y, and n/n/n answers — each runtime's directory is
  removed or kept per its own answer, with no stdin-stream consumption.
- `cleanup.sh --no` and `--yes` exercised against fake state dirs — `--yes`
  removes every registered runtime's state directory.
- Existing `tests/test_cleanup_backups.sh` (13 assertions) and
  `tests/test_runtime_registry_equivalence.sh` (64 assertions) still pass.
- `shellcheck`, `PSScriptAnalyzer`, and Hadolint are exercised by CI.

Closes #273.
