### PR TITLE
fix(cli): generalize cmd_agent launch banner label per runtime

### DIFF
--- a/scripts/claude-docker
+++ b/scripts/claude-docker
@@ -243,10 +243,11 @@ cmd_agent() {
     # differ (claude under AGENT_RUNTIME=codex), and the historical
     # cmd_claude always launched the claude binary regardless — so resolve
     # from the subcommand to keep that behavior.
-    local binary skip_flag extra_run_args
+    local binary skip_flag extra_run_args label
     binary="$(runtime_field "$subcommand" binary)"
     skip_flag="$(runtime_field "$subcommand" skipPermissionsFlag)"
     extra_run_args="$(runtime_field "$subcommand" extraRunArgs)"
+    label="$(runtime_field "$subcommand" displayName)"
 
     # Skip-permissions flags accepted: the runtime's own flag plus the
     # universal --dangerously-skip-permissions alias (a no-op duplicate for
@@ -264,13 +265,8 @@ cmd_agent() {
     service="${service:-$(runtime_field "$subcommand" servicePrefix)-a}"
     ensure_compose_cmd
 
-    # Pretty launch banner: Claude Code vs Codex CLI matched the prior wording.
-    local label
-    if [[ "$subcommand" == "codex" ]]; then
-        label="Codex CLI"
-    else
-        label="Claude Code"
-    fi
+    # Pretty launch banner: the label is the runtime's registry displayName,
+    # so every registered runtime prints a correct name (not just claude/codex).
     echo -e "${CYAN}Starting ${label} in ${BOLD}$service${NC}${CYAN}...${NC}"
 
     # Build argv: binary, then registry extraRunArgs (word-split; the codex

--- a/scripts/claude-docker.ps1
+++ b/scripts/claude-docker.ps1
@@ -153,6 +153,7 @@ function Invoke-Agent {
     $skipFlag     = Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $Subcommand -Field 'skipPermissionsFlag'
     $extraRunArgs = Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $Subcommand -Field 'extraRunArgs'
     $servicePrefix = Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $Subcommand -Field 'servicePrefix'
+    $label        = Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $Subcommand -Field 'displayName'
 
     # Skip-permissions flags accepted: the runtime's own flag plus the
     # universal --dangerously-skip-permissions alias (a no-op duplicate for
@@ -169,8 +170,8 @@ function Invoke-Agent {
     # Default service is keyed off the subcommand (claude-a / codex-a).
     if (-not $service) { $service = "$servicePrefix-a" }
 
-    # Pretty launch banner: Claude Code vs Codex CLI matched the prior wording.
-    $label = if ($Subcommand -eq 'codex') { 'Codex CLI' } else { 'Claude Code' }
+    # Pretty launch banner: the label is the runtime's registry displayName,
+    # so every registered runtime prints a correct name (not just claude/codex).
     Write-Host "Starting $label in " -ForegroundColor Cyan -NoNewline
     Write-Host $service -ForegroundColor White -NoNewline
     Write-Host '...' -ForegroundColor Cyan

--- a/tests/test_runtime_registry_equivalence.sh
+++ b/tests/test_runtime_registry_equivalence.sh
@@ -37,11 +37,11 @@ fi
 
 # The set of fields every runtime entry carries (see #268 / #267).
 FIELDS=(
-    binary servicePrefix stateDir containerHome hostConfigMount
-    containerConfigMount configDirEnv configDirEnvValue configSourceEnv
-    apiKeyVarPrefix sdkApiKeyVar buildArg installMethod skipPermissionsFlag
-    configFormat bootstrapModule extraEnv extraRunArgs supportsUsage
-    mountsAgentsSkills credentialFiles oauthCredentialFile
+    binary displayName servicePrefix stateDir containerHome
+    hostConfigMount containerConfigMount configDirEnv configDirEnvValue
+    configSourceEnv apiKeyVarPrefix sdkApiKeyVar buildArg installMethod
+    skipPermissionsFlag configFormat bootstrapModule extraEnv extraRunArgs
+    supportsUsage mountsAgentsSkills credentialFiles oauthCredentialFile
 )
 
 PASS=0

--- a/tui/internal/config/runtime.go
+++ b/tui/internal/config/runtime.go
@@ -19,6 +19,7 @@ var runtimesJSON []byte
 // awk fallback and PowerShell readers stay simple.
 type RuntimeSpec struct {
 	Binary               string `json:"binary"`
+	DisplayName          string `json:"displayName"`
 	ServicePrefix        string `json:"servicePrefix"`
 	StateDir             string `json:"stateDir"`
 	ContainerHome        string `json:"containerHome"`

--- a/tui/internal/config/runtimes.json
+++ b/tui/internal/config/runtimes.json
@@ -3,6 +3,7 @@
   "runtimes": {
     "claude": {
       "binary": "claude",
+      "displayName": "Claude Code",
       "servicePrefix": "claude",
       "stateDir": ".claude-state",
       "containerHome": "/home/node/.claude",
@@ -27,6 +28,7 @@
     },
     "codex": {
       "binary": "codex",
+      "displayName": "Codex CLI",
       "servicePrefix": "codex",
       "stateDir": ".codex-state",
       "containerHome": "/home/node/.codex",
@@ -51,6 +53,7 @@
     },
     "gemini": {
       "binary": "gemini",
+      "displayName": "Gemini CLI",
       "servicePrefix": "gemini",
       "stateDir": ".gemini-state",
       "containerHome": "/home/node/.gemini",


### PR DESCRIPTION
## Summary

`cmd_agent` (`scripts/claude-docker`) and `Invoke-Agent` (`scripts/claude-docker.ps1`)
hardcoded the launch-banner label to a two-way branch — `"Codex CLI"` for the
`codex` subcommand, `"Claude Code"` for everything else. Runtime dispatch was
already fully registry-driven (#270), so `claude-docker gemini` correctly
launched the Gemini CLI but printed the misleading banner
`Starting Claude Code in gemini-a...`.

This PR derives the banner label from the runtime registry:

- Adds a `displayName` field to `tui/internal/config/runtimes.json`
  (`claude` → `Claude Code`, `codex` → `Codex CLI`, `gemini` → `Gemini CLI`).
- Reads it via the generic `runtime_field` / `Get-RuntimeField` accessors,
  keyed off the subcommand exactly like `binary` / `skipPermissionsFlag` /
  `extraRunArgs`. The two-way `codex`/else conditional is removed in both
  scripts.
- Mirroring #280, the new field is also added to the Go `RuntimeSpec` struct
  (`runtime.go`) for reader completeness and to the `FIELDS` list in
  `tests/test_runtime_registry_equivalence.sh`. The bash/pwsh accessors resolve
  fields generically and need no change.

## Why

#270 made runtime dispatch fully registry-driven, but the cosmetic banner
label was never generalized. The output was misleading for `gemini` and would
be wrong for any future runtime — only `claude` and `codex` printed a correct
label. No functional impact (the correct binary launches regardless), hence
`priority/low`.

`codex` keeps its existing wording `Codex CLI` (not `OpenAI Codex CLI`)
because the issue's Acceptance Criteria requires the `claude` and `codex`
banner labels to be unchanged.

## Test Plan

- `jq . tui/internal/config/runtimes.json` parses cleanly.
- `bash -n scripts/claude-docker` passes.
- `runtime_field <runtime> displayName` resolves to `Claude Code` / `Codex CLI`
  / `Gemini CLI` for `claude` / `codex` / `gemini` respectively (verified via
  `scripts/lib/runtime.sh`).
- The `displayName` field is present in the Go `RuntimeSpec` struct and the
  registry-equivalence test `FIELDS` list, so `Go tests (TUI)` and the
  registry-equivalence bash test exercise it.
- CI `Shellcheck` and `PSScriptAnalyzer` verify the two scripts.

The live runtime banner output (`claude-docker gemini` inside the container)
is **logic-verified** — the code path resolves the label from the registry
`displayName` — **not container-verified**, as the change ships no Docker
image change and the verification environment has no Docker.

## Acceptance Criteria

- [x] `claude-docker gemini` prints a Gemini-appropriate launch banner
      (`Starting Gemini CLI in gemini-a...`).
- [x] `claude` and `codex` banner labels are unchanged.
- [x] bash and PowerShell produce the same label for each runtime (both read
      the same `displayName` registry field via their generic accessors).
- [x] `shellcheck` and `PSScriptAnalyzer` clean (verified by CI).

Closes #281
