### PR TITLE
fix(runtime): reconcile mountsAgentsSkills value with compose mount behavior

### DIFF
--- a/scripts/generate-compose.ps1
+++ b/scripts/generate-compose.ps1
@@ -89,6 +89,10 @@ $RtConfigDirEnv        = Get-RtField 'configDirEnv'
 # (gemini) whose CLI appends its own subdirectory.
 $RtConfigDirEnvValue   = Get-RtField 'configDirEnvValue'
 $RtConfigSourceEnv     = Get-RtField 'configSourceEnv'
+# Whether this runtime needs the separate agents/skills compose volume.
+# Only codex binds it; claude obtains skills via its host config mount and
+# gemini via its own config mount, so neither needs the extra volume.
+$RtMountsAgentsSkills  = Get-RtField 'mountsAgentsSkills'
 # Host-side config directory basename (e.g. .claude, .codex) — the host
 # mount whose container target is <hostConfigMount>. Derived from the
 # container config mount basename, which the registry keeps in sync.
@@ -169,11 +173,9 @@ function New-BaseCompose {
         [void]$sb.AppendLine('      - ${PROJECT_DIR}:${CONTAINER_PROJECT_DIR:-/project}')
         [void]$sb.AppendLine("      - `${HOME}/${RtStateDir}/account-${letter}:${RtContainerConfigMount}")
         [void]$sb.AppendLine("      - `${HOME}/${RtHostConfigBasename}:${RtHostConfigMount}:ro")
-        # The agents/skills mount is a codex-only volume: claude does not
-        # bind it. The registry has no per-runtime field that singles it
-        # out (mountsAgentsSkills is true for both), so this one line is
-        # gated on the runtime id to preserve byte-identical output.
-        if ($AgentRuntime -eq 'codex') {
+        # The agents/skills volume is bound only for runtimes whose
+        # registry entry sets mountsAgentsSkills (currently codex).
+        if ($RtMountsAgentsSkills -eq $true) {
             [void]$sb.AppendLine('      - ${AGENTS_SKILLS_DIR:-${HOME}/.agents/skills}:/home/node/.agents/skills:ro')
         }
         [void]$sb.AppendLine('      - ${GH_CONFIG_DIR:-${HOME}/.config/gh}:/home/node/.config/gh:ro')

--- a/scripts/generate-compose.sh
+++ b/scripts/generate-compose.sh
@@ -48,6 +48,10 @@ RT_CONFIG_DIR_ENV="$(runtime_field "$AGENT_RUNTIME" configDirEnv)"
 # (gemini) whose CLI appends its own subdirectory.
 RT_CONFIG_DIR_ENV_VALUE="$(runtime_field "$AGENT_RUNTIME" configDirEnvValue)"
 RT_CONFIG_SOURCE_ENV="$(runtime_field "$AGENT_RUNTIME" configSourceEnv)"
+# Whether this runtime needs the separate agents/skills compose volume.
+# Only codex binds it; claude obtains skills via its host config mount and
+# gemini via its own config mount, so neither needs the extra volume.
+RT_MOUNTS_AGENTS_SKILLS="$(runtime_field "$AGENT_RUNTIME" mountsAgentsSkills)"
 # Host-side config directory basename (e.g. .claude, .codex) — the host
 # mount whose container target is <hostConfigMount>. Derived from the
 # container config mount basename, which the registry keeps in sync.
@@ -130,11 +134,9 @@ generate_base() {
             echo "      - \${PROJECT_DIR}:\${CONTAINER_PROJECT_DIR:-/project}"
             echo "      - \${HOME}/${RT_STATE_DIR}/account-${letter}:${RT_CONTAINER_CONFIG_MOUNT}"
             echo "      - \${HOME}/${RT_HOST_CONFIG_BASENAME}:${RT_HOST_CONFIG_MOUNT}:ro"
-            # The agents/skills mount is a codex-only volume: claude does not
-            # bind it. The registry has no per-runtime field that singles it
-            # out (mountsAgentsSkills is true for both), so this one line is
-            # gated on the runtime id to preserve byte-identical output.
-            if [[ "$AGENT_RUNTIME" == "codex" ]]; then
+            # The agents/skills volume is bound only for runtimes whose
+            # registry entry sets mountsAgentsSkills (currently codex).
+            if [[ "$RT_MOUNTS_AGENTS_SKILLS" == "true" ]]; then
                 echo '      - ${AGENTS_SKILLS_DIR:-${HOME}/.agents/skills}:/home/node/.agents/skills:ro'
             fi
             echo "      - \${GH_CONFIG_DIR:-\${HOME}/.config/gh}:/home/node/.config/gh:ro"

--- a/tui/internal/config/runtimes.json
+++ b/tui/internal/config/runtimes.json
@@ -22,7 +22,7 @@
       "extraEnv": "",
       "extraRunArgs": "",
       "supportsUsage": true,
-      "mountsAgentsSkills": true,
+      "mountsAgentsSkills": false,
       "credentialFiles": ".credentials.json",
       "oauthCredentialFile": ".credentials.json"
     },
@@ -72,7 +72,7 @@
       "extraEnv": "",
       "extraRunArgs": "",
       "supportsUsage": false,
-      "mountsAgentsSkills": true,
+      "mountsAgentsSkills": false,
       "credentialFiles": "oauth_creds.json",
       "oauthCredentialFile": "oauth_creds.json"
     }


### PR DESCRIPTION
## Summary

Reconciles the `mountsAgentsSkills` registry field with the compose
generator's actual mount behavior, then makes the field authoritative.

- `tui/internal/config/runtimes.json` — set `mountsAgentsSkills` to
  `false` for `claude` and `gemini`, leave `true` for `codex`.
- `scripts/generate-compose.sh` / `.ps1` — gate the agents/skills volume
  on the `mountsAgentsSkills` field instead of a hardcoded `codex`
  string check; remove the now-stale explanatory comment.

Closes #282.

## Why

The `mountsAgentsSkills` field was `true` for all three runtimes, but
the generator bound the agents/skills volume only for `codex` through a
hardcoded `[[ "$AGENT_RUNTIME" == "codex" ]]` check. The data and the
behavior disagreed, so the field was unused and a new runtime's
`mountsAgentsSkills` value had no effect — defeating the table-driven
registry goal of #267 / #268.

## STEP A investigation conclusion

The agents/skills compose volume is genuinely **codex-only**. Evidence
from the bootstrap modules:

- `bootstrap-codex.sh` `mkdir -p /home/node/.agents/skills`, and the
  `codex` service binds the host `.agents/skills` volume there.
- `bootstrap-claude.sh` symlinks the host config mount's `skills/`
  directory into the account state dir (`for item in skills commands
  ccstatusline`). Claude obtains skills through its own `.claude-host`
  config mount and never needs the separate volume — `bootstrap-claude.sh`
  does not even create `.agents/skills`.
- `bootstrap-gemini.sh` `mkdir`s `.agents/skills` but no host volume is
  ever bound there; Gemini obtains config (`commands/`, `extensions/`)
  via its own `.gemini-host` config mount.

So the conservative, behavior-preserving outcome is `mountsAgentsSkills`
= `true` for `codex` only. The field now means precisely "needs the
separate agents/skills compose volume". No runtime behavior change is
introduced; the volume is not newly mounted for `claude`.

## Test Plan

- `jq . tui/internal/config/runtimes.json` parses; field values are
  `claude: false`, `codex: true`, `gemini: false`.
- Byte-identical guard: captured `generate-compose.sh` output for the
  `claude` / `codex` / `gemini` env fixtures (all three generated files:
  base, worktree, linux) before and after the change — all 9 files are
  **byte-identical**. `codex` still mounts the volume; `claude` and
  `gemini` still do not.
- `runtime_field` returns identical values via the `jq` path and the
  `awk` fallback for the changed field, so the bash gate
  `[[ "$RT_MOUNTS_AGENTS_SKILLS" == "true" ]]` is reader-agnostic.
- `tests/test_runtime_registry_equivalence.sh` passes locally (70 PASS,
  0 FAIL; pwsh leg runs in CI).
- `shellcheck` / `PSScriptAnalyzer` / the `compose-validate` matrix run
  in CI.

## Breaking Changes

None — compose output is byte-identical for all three runtimes.
