### PR TITLE
fix: verify container GitHub auth via gh api user

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,13 +323,24 @@ limitations, switch to API keys in `.env`.
 > it with an empty string would otherwise make the SDK ignore the
 > `.credentials.json` from OAuth.
 
-**GitHub CLI (`gh`)** is automatically available inside containers. The host's
-`~/.config/gh/` is bind-mounted read-only, so `gh` commands use the host's
-GitHub session without separate authentication.
+**GitHub CLI (`gh`)** is automatically available inside containers. The
+preferred container auth path is the `GH_TOKEN` environment variable:
+`scripts/claude-docker gh-auth` extracts a token from the host `gh` CLI and
+injects it into `.env`, and the installer auto-detects one on first run.
+
+The host's `~/.config/gh/` is still bind-mounted read-only as a fallback for
+Linux hosts that keep their token in `hosts.yml`. On **Windows and macOS**,
+`gh` stores the token in the OS credential store (Credential Manager /
+Keychain), not in `hosts.yml` — the Linux container cannot read those stores,
+so `GH_TOKEN` is required there.
+
+Because the mounted host config can expose an unusable `default` account
+alongside a working `GH_TOKEN`, verify auth with `gh api user` (which checks
+the credential `gh` actually uses for API calls) rather than `gh auth status`:
 
 ```bash
 # Verify gh auth inside container
-scripts/claude-docker exec claude-a gh auth status
+scripts/claude-docker exec claude-a gh api user --jq .login
 
 # Use gh normally
 scripts/claude-docker exec claude-a gh pr list

--- a/scripts/claude-docker
+++ b/scripts/claude-docker
@@ -346,7 +346,11 @@ refresh_gh_token() {
 }
 
 # Verify GitHub auth inside a running container.
-# Prints status and returns gh auth exit code (0 = OK, non-zero = failure).
+# Uses `gh api user` rather than `gh auth status`: when GH_TOKEN coexists with
+# a mounted host gh config, `gh auth status` also evaluates the unusable
+# mounted `default` account and exits non-zero even though the token works.
+# `gh api user` checks the credential path gh actually uses for API calls.
+# Returns 0 if the API call succeeds, non-zero otherwise.
 verify_container_gh_auth() {
     local svc="${1:-claude-a}"
     local cid
@@ -355,7 +359,7 @@ verify_container_gh_auth() {
         return 1
     fi
 
-    if docker exec "$cid" gh auth status >/dev/null 2>&1; then
+    if docker exec "$cid" gh api user --jq .login >/dev/null 2>&1; then
         echo -e "  ${GREEN}*${NC} GitHub auth: OK ($svc)"
         return 0
     else

--- a/scripts/claude-docker.ps1
+++ b/scripts/claude-docker.ps1
@@ -303,13 +303,20 @@ function Test-ContainerGhAuth {
     .SYNOPSIS
     Verify GitHub auth inside a running container.
     Returns $true if gh auth is OK, $false otherwise.
+
+    .DESCRIPTION
+    Uses `gh api user` rather than `gh auth status`: when GH_TOKEN coexists
+    with a mounted host gh config, `gh auth status` also evaluates the
+    unusable mounted `default` account and exits non-zero even though the
+    token works. `gh api user` checks the credential path gh actually uses
+    for API calls.
     #>
     param([string]$Service = 'claude-a')
 
     $cid = Get-ContainerId -ProjectRoot $ProjectRoot -Service $Service
     if (-not $cid) { return $false }
 
-    $null = & docker exec $cid gh auth status 2>&1
+    $null = & docker exec $cid gh api user --jq .login 2>&1
     if ($LASTEXITCODE -eq 0) {
         Write-Host "  * GitHub auth: OK ($Service)" -ForegroundColor Green
         return $true

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -94,9 +94,12 @@ if command -v gh >/dev/null 2>&1; then
         echo "[entrypoint] GitHub auth: using GH_TOKEN environment variable"
     elif [ -f /home/node/.config/gh/hosts.yml ]; then
         gh auth setup-git 2>/dev/null || true
-        # Validate token (macOS Keychain / Windows Credential Manager tokens
-        # are NOT in hosts.yml — only the host config structure is present)
-        if ! gh auth status >/dev/null 2>&1; then
+        # Validate the credential gh actually uses for API calls. `gh api user`
+        # is checked instead of `gh auth status` because the latter also
+        # evaluates the unusable mounted `default` account and exits non-zero.
+        # macOS Keychain / Windows Credential Manager tokens are NOT in
+        # hosts.yml — only the host config structure is present.
+        if ! gh api user --jq .login >/dev/null 2>&1; then
             echo "[entrypoint] WARNING: GitHub token is invalid or missing."
             echo "  On macOS/Windows, gh stores tokens in OS credential stores"
             echo "  (Keychain / Credential Manager), not in hosts.yml."

--- a/tui/internal/account/manager_helpers.go
+++ b/tui/internal/account/manager_helpers.go
@@ -131,8 +131,14 @@ func (m *Manager) enrichAccounts(accounts []Account) map[string]apiResult {
 	return results
 }
 
-// enrichGHAuth runs `gh auth status` inside the account's running container
+// enrichGHAuth runs `gh api user` inside the account's running container
 // and sets GHAuthOK on success. No-op when the container is not running.
+//
+// `gh api user` is used instead of `gh auth status` because the latter
+// evaluates every configured account — including the unusable `default`
+// account the mounted host gh config exposes alongside a working GH_TOKEN —
+// and exits non-zero even though API calls succeed. The verdict is the
+// command exit code, not substring matching on the output.
 func (m *Manager) enrichGHAuth(a *Account, wg *sync.WaitGroup) {
 	if a.ContainerStatus != ContainerRunning || a.ContainerID == "" {
 		return
@@ -140,12 +146,17 @@ func (m *Manager) enrichGHAuth(a *Account, wg *sync.WaitGroup) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		cmd := exec.Command("docker", "exec", a.ContainerID, "gh", "auth", "status")
-		out, _ := cmd.CombinedOutput()
-		if strings.Contains(string(out), "Logged in") {
-			a.GHAuthOK = true
-		}
+		cmd := exec.Command("docker", "exec", a.ContainerID, "gh", "api", "user", "--jq", ".login")
+		err := cmd.Run()
+		a.GHAuthOK = ghAuthVerdict(err)
 	}()
+}
+
+// ghAuthVerdict maps the exit status of the in-container `gh api user`
+// command to a GitHub auth verdict: a nil error (exit code 0) means the
+// credential gh uses for API calls is valid.
+func ghAuthVerdict(runErr error) bool {
+	return runErr == nil
 }
 
 // enrichAPIUsage fetches usage from the limitline API for OAuth accounts

--- a/tui/internal/account/manager_helpers_test.go
+++ b/tui/internal/account/manager_helpers_test.go
@@ -3,6 +3,7 @@ package account
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -149,6 +150,32 @@ func TestEnrichGHAuth_NotRunning(t *testing.T) {
 				t.Errorf("GHAuthOK = true, want false for %s", c.name)
 			}
 		})
+	}
+}
+
+// TestGHAuthVerdict covers the auth verdict logic used by enrichGHAuth. The
+// container check switched from `gh auth status` to `gh api user` because
+// `gh auth status` exits non-zero when the mounted host gh config exposes an
+// unusable `default` account alongside a working GH_TOKEN. The verdict must
+// follow the command exit code: `gh api user` succeeding (exit 0) means the
+// credential is valid even in that mixed-config case where `gh auth status`
+// would fail.
+func TestGHAuthVerdict(t *testing.T) {
+	// A real exit-0 command stands in for `gh api user` succeeding.
+	if err := exec.Command("true").Run(); err != nil {
+		t.Fatalf("setup: `true` should exit 0: %v", err)
+	} else if !ghAuthVerdict(err) {
+		t.Error("ghAuthVerdict(nil) = false, want true (gh api user succeeded)")
+	}
+
+	// A real non-zero exit stands in for `gh auth status` style failure:
+	// the verdict must be false so a failed check is not reported as OK.
+	failErr := exec.Command("false").Run()
+	if failErr == nil {
+		t.Fatal("setup: `false` should exit non-zero")
+	}
+	if ghAuthVerdict(failErr) {
+		t.Error("ghAuthVerdict(exit-error) = true, want false (command exited non-zero)")
 	}
 }
 


### PR DESCRIPTION
## What

Replace the container-side GitHub auth verification across the bash CLI,
PowerShell CLI, container entrypoint, and TUI with an API-based check
(`gh api user --jq .login`), and update the README accordingly.

### Change Type
- [x] Bugfix (fixes an issue)
- [x] Documentation

### Affected Components
- `scripts/claude-docker` — `verify_container_gh_auth`
- `scripts/claude-docker.ps1` — `Test-ContainerGhAuth`
- `scripts/entrypoint.sh` — mounted `hosts.yml` validation
- `tui/internal/account/manager_helpers.go` — `enrichGHAuth`
- `README.md` — GitHub CLI auth section

## Why

### Problem Solved
When `GH_TOKEN` is injected from `.env` while the host `~/.config/gh/` is
also bind-mounted, the container sees two auth sources. On Windows/macOS the
host token lives in the OS credential store, not `hosts.yml`, so the
container sees the mounted `default` account metadata but cannot use it.
`gh auth status` evaluates the working `GH_TOKEN` and the unusable mounted
`default` account together and exits non-zero — reporting a false auth
failure even though `gh api user` and the git credential helper work.

The TUI made this worse by parsing the substring `Logged in` in
`gh auth status` output, so the TUI and CLI could disagree.

### Related Issues
- Closes #266

## How

### Implementation Details
1. Container auth verification now runs `gh api user --jq .login` and uses
   the command exit code as the verdict. This probes the credential path
   `gh` actually uses for API calls, ignoring the unusable mounted
   `default` account.
2. The bash, PowerShell, and entrypoint checks all switch to the same
   command, kept behaviorally equivalent (per issue #146 invariant).
3. The TUI `enrichGHAuth` drops the `Logged in` substring parse and derives
   `GHAuthOK` from the exit code via a new `ghAuthVerdict` helper.
4. `GH_CONFIG_DIR` mounting is unchanged — the Linux `hosts.yml` fallback is
   preserved; only the pass/fail signal changed.
5. README documents `GH_TOKEN` as the preferred container auth path and
   that Windows/macOS host credential stores cannot be read from the Linux
   container.

### Scope Notes
Host-side `gh auth status` calls (single-account host, not affected by the
mounted `default` confusion) and the display-only `gh auth status` output
in `gh-auth` are intentionally left unchanged, per the issue's instruction
to replace only the pass/fail signal.

### Testing Done
- [x] Added `TestGHAuthVerdict` in `manager_helpers_test.go` covering the
      case where a status-style check fails (non-zero exit) but the API
      check succeeds (exit 0).
- Local build/lint/test not run — no Go/shellcheck/pwsh toolchain in the
  work environment; CI is the verification gate.

### Test Plan
1. CI: shellcheck, hadolint, PSScriptAnalyzer, go-test, bash-tests,
   pwsh-tests must pass.
2. Manual (Windows host): `scripts/claude-docker.ps1 gh-auth` should no
   longer print an invalid `default` account warning as the verification
   result.
3. Manual: `docker exec <container> gh api user --jq .login` returns the
   expected login.

### Breaking Changes
None — only status checks and diagnostics changed; the token injection
mechanism is untouched.