### PR TITLE
fix(tui): resolve state-dir name from runtime registry

### DIFF
--- a/tui/internal/account/manager_helpers_test.go
+++ b/tui/internal/account/manager_helpers_test.go
@@ -112,6 +112,33 @@ func TestDiscoverStateDirs_CodexRuntime(t *testing.T) {
 	}
 }
 
+func TestDiscoverStateDirs_GeminiRuntime(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	stateBase := filepath.Join(tmp, ".gemini-state")
+	if err := os.MkdirAll(filepath.Join(stateBase, "account-a"), 0755); err != nil {
+		t.Fatalf("mkdir gemini state: %v", err)
+	}
+
+	env := config.NewEmptyEnv(filepath.Join(tmp, ".env"))
+	env.Set("AGENT_RUNTIME", "gemini")
+	env.Set("NUM_ACCOUNTS", "1")
+	m := newTestManager(t, env)
+
+	stateDirs, n := m.discoverStateDirs()
+	if n != 1 {
+		t.Errorf("n = %d, want 1", n)
+	}
+	sd, ok := stateDirs["a"]
+	if !ok {
+		t.Fatal("missing gemini state dir for account a")
+	}
+	if got, want := sd.Path, filepath.Join(stateBase, "account-a"); got != want {
+		t.Errorf("gemini state path = %q, want %q", got, want)
+	}
+}
+
 // TestFetchContainerStatus confirms the helper returns an empty map when
 // the docker client cannot enumerate containers (no compose project, no
 // daemon). The orchestrator must continue to function in this degraded

--- a/tui/internal/config/state.go
+++ b/tui/internal/config/state.go
@@ -90,10 +90,12 @@ func DiscoverStateDirs() ([]StateDir, error) {
 	return DiscoverStateDirsForRuntime(RuntimeClaude)
 }
 
-// StateDirNameForRuntime returns the host-side state directory name.
+// StateDirNameForRuntime returns the host-side state directory name for the
+// given runtime, resolved from the runtime registry. Falls back to
+// ".claude-state" when the runtime is unknown.
 func StateDirNameForRuntime(runtime string) string {
-	if runtime == RuntimeCodex {
-		return ".codex-state"
+	if spec, ok := LookupRuntime(runtime); ok {
+		return spec.StateDir
 	}
 	return ".claude-state"
 }


### PR DESCRIPTION
## What

Replace the hardcoded `if runtime == RuntimeCodex` branch in `StateDirNameForRuntime` with a registry lookup via `LookupRuntime`. Falls back to `.claude-state` when the runtime is unknown, preserving the existing behaviour for unregistered runtimes.

Adds `TestDiscoverStateDirs_GeminiRuntime` to cover the previously broken path.

## Why

`StateDirNameForRuntime` hardcoded only the codex special-case. Any runtime not explicitly listed (e.g. gemini) silently fell through to `.claude-state`, causing `DiscoverStateDirsForRuntime` to scan the wrong directory on the host.

`runtimes.json` already carries `"stateDir": ".gemini-state"` for the gemini entry. This fix makes the function a single source of truth: the registry.

Closes #287
Part of #267 (Epic: single-source-of-truth runtime registry). This addresses Epic AC1 (all runtime-specific values read from `runtimes.json`) and AC2 (no hardcoded per-runtime branches outside the registry) for the state-dir path.

## How

- `tui/internal/config/state.go`: rewrite `StateDirNameForRuntime` to call `LookupRuntime(runtime)` and return `spec.StateDir`; keep `.claude-state` as the fallback for unknown runtimes.
- `tui/internal/account/manager_helpers_test.go`: add `TestDiscoverStateDirs_GeminiRuntime` mirroring the existing `TestDiscoverStateDirs_CodexRuntime` structure — sets up `~/.gemini-state/account-a`, runs `discoverStateDirs` with `AGENT_RUNTIME=gemini`, and asserts the path is resolved correctly.

No new imports are required; `LookupRuntime` is in the same `config` package.

## Test Plan

- CI `go-test` job runs the full test suite including the new `TestDiscoverStateDirs_GeminiRuntime`.
- The new test exercises the previously untested gemini state-dir resolution path.
- No local Go toolchain available; CI is the verification gate.
