### PR TITLE
fix(docker): bump stale CLAUDE_INSTALLER_SHA256 pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ RUN set -eux; \
 # if the upstream installer is unexpectedly modified. Refresh by
 # computing the hash of the latest installer and bumping the ARG
 # default below; CI will fail loudly when this drift occurs.
-ARG CLAUDE_INSTALLER_SHA256=b315b46925a9bfb9422f2503dd5aa649f680832f4c076b22d87c39d578c3d830
+ARG CLAUDE_INSTALLER_SHA256=005ec1a937f32dfbb74f9e810287bcb12cba2d5cae4c9277aa8c6364adbf1787
 
 RUN curl -fsSL https://claude.ai/install.sh -o /tmp/claude-install.sh \
     && echo "${CLAUDE_INSTALLER_SHA256}  /tmp/claude-install.sh" | sha256sum -c - \


### PR DESCRIPTION
## What

Bump the Dockerfile `CLAUDE_INSTALLER_SHA256` pin from `b315b469...` to the current
`https://claude.ai/install.sh` hash `005ec1a937f32dfbb74f9e810287bcb12cba2d5cae4c9277aa8c6364adbf1787`
(4912 bytes). One-line change.

Closes #292.

## Why

The stale pin made a from-scratch `docker compose build` fail at the Claude native-installer
step (`sha256sum -c` mismatch), blocking the clean build of the shared image for **all three
runtimes** (claude, codex, gemini), including the documented `install.sh` -> build onboarding
flow. The Dockerfile already documents this refresh procedure. Found during the #289 gemini
end-to-end verification.

## Where

- `Dockerfile` — the `ARG CLAUDE_INSTALLER_SHA256` default consumed by the
  `RUN curl ... claude.ai/install.sh ... | sha256sum -c -` step.

## How / Testing

- Confirmed the current `claude.ai/install.sh` (4912 bytes) hashes to `005ec1a9...`.
- `docker build --no-cache` now passes the installer step (previously aborted at step 5)
  and the build completes.
- No CI job builds the image (`compose-validate` runs only `docker compose config`,
  `hadolint` lints statically), so this is verified locally; lint and compose-config gates
  are unaffected by a value-only ARG change.

## Breaking changes

None.

## Follow-up (out of scope)

A CI job that actually builds the image would catch future installer-pin drift automatically
(see the note in #292 / #289).
