### PR TITLE
test(ci): smoke-test keyless gemini up/down for AC3 #1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,3 +146,60 @@ jobs:
       - name: Run ${{ matrix.test }}
         shell: pwsh
         run: pwsh -NoProfile -File "${{ matrix.test }}"
+
+  # Live keyless smoke test for Epic #267 AC3 #1: AGENT_RUNTIME=gemini +
+  # `claude-docker up` brings the gemini container to a running state. This
+  # goes one step beyond `compose-validate (gemini)` (static `docker compose
+  # config`) by actually building the image, starting the container, asserting
+  # it is running, and tearing it down. The gemini service command is
+  # ["sleep", "infinity"] and the boot path never references GEMINI_API_KEY, so
+  # this runs with no secret — a passing run is the automated discharge of
+  # AC3 #1. AC3 #2 (`claude-docker gemini` attach) and #3 (TUI account listing)
+  # remain key-gated, interactive, and are NOT covered here. Kept as a single,
+  # NUM_ACCOUNTS=1 dedicated job (not folded into the compose-validate matrix)
+  # so the heavy image build runs once for one runtime rather than per fixture.
+  gemini-up-smoke:
+    name: "Gemini up/down smoke (keyless, AC3 #1)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Stage gemini fixture (single account)
+        run: |
+          cp tests/env_fixtures/gemini.env .env
+          # Narrow to one account so the image build + boot runs once for
+          # gemini-a only. The caller env overrides the fixture's value.
+          echo "NUM_ACCOUNTS=1" >> .env
+      - name: Prepare host bind-mount directories
+        run: |
+          # The fixture sets HOME=/tmp/claude-test; create the per-account
+          # state dir, the read-only host config mount, the gh config mount,
+          # and the project dir so the keyless bind mounts resolve.
+          mkdir -p /tmp/claude-test/.gemini-state/account-a \
+                   /tmp/claude-test/.gemini-host \
+                   /tmp/claude-test/.config/gh \
+                   /tmp/claude-test/project
+      - name: Generate compose
+        run: NUM_ACCOUNTS=1 bash scripts/generate-compose.sh
+      - name: Build image and bring up gemini-a (keyless)
+        run: bash scripts/claude-docker up
+      - name: Assert gemini-a is running
+        run: |
+          set -euo pipefail
+          cid="$(bash scripts/claude-docker compose ps -q gemini-a)"
+          if [[ -z "$cid" ]]; then
+            echo "::error::gemini-a container was not created"
+            bash scripts/claude-docker ps || true
+            exit 1
+          fi
+          running="$(docker inspect -f '{{.State.Running}}' "$cid")"
+          restarting="$(docker inspect -f '{{.State.Restarting}}' "$cid")"
+          echo "gemini-a: Running=$running Restarting=$restarting"
+          if [[ "$running" != "true" || "$restarting" != "false" ]]; then
+            echo "::error::gemini-a is not in a stable running state"
+            docker inspect -f '{{json .State}}' "$cid"
+            bash scripts/claude-docker compose logs gemini-a || true
+            exit 1
+          fi
+      - name: Tear down
+        if: always()
+        run: bash scripts/claude-docker down -v --remove-orphans

--- a/scripts/lib/build-compose-cmd.sh
+++ b/scripts/lib/build-compose-cmd.sh
@@ -36,10 +36,15 @@ build_compose_cmd() {
     # Linux override: auto-detect platform via uname.
     if [[ "$(uname -s)" == "Linux" ]] && [[ -f "${PROJECT_ROOT}/docker-compose.linux.yml" ]]; then
         COMPOSE_CMD+=(-f "${PROJECT_ROOT}/docker-compose.linux.yml")
-        # Export UID/GID for the linux override file.
+        # Export UID/GID for the linux override file. Bash already maintains
+        # UID as a readonly special variable holding the current user's id, so
+        # assigning to it aborts under `set -e` ("UID: readonly variable").
+        # Reuse the existing values and only fall back to `id` when unset
+        # (e.g. a shell that does not provide them); the result is identical
+        # since UID/GID already equal `id -u`/`id -g`.
+        : "${UID:=$(id -u)}"
+        : "${GID:=$(id -g)}"
         export UID GID
-        UID=$(id -u)
-        GID=$(id -g)
     fi
 
     # Worktree override: drive selection from .env state, not caller-local vars.


### PR DESCRIPTION
## What

Adds a dedicated CI job, **`Gemini up/down smoke (keyless, AC3 #1)`**, that
automates the keyless half of Epic #267 **AC3** — the residual live
verification tracked by #289.

The job runs, with **no secret**:

1. Stage the `gemini` fixture (narrowed to `NUM_ACCOUNTS=1`).
2. `generate-compose` (`AGENT_RUNTIME=gemini`).
3. Build the `claude-code-base` image.
4. `claude-docker up` -> bring up `gemini-a`.
5. Assert `gemini-a` reaches a stable running state via `docker inspect`
   (`State.Running=true`, `State.Restarting=false`).
6. `claude-docker down -v --remove-orphans`.

A passing run **is** the automated live verification of AC3 #1.

## Why

CI's existing `Compose validate (gemini)` job already exercises the static
half of the chain (`generate-compose` -> `docker compose config`). The live
half (build -> `up` -> running) was the only part that still required a manual
Docker host, which is exactly what #289 tracks.

AC3 #1 is **keyless**: the generated gemini service command is
`["sleep", "infinity"]` and the boot path (entrypoint -> `bootstrap-gemini.sh`)
never references `GEMINI_API_KEY`. The owner proposed in #289 moving this slice
into CI as a permanent smoke test; this PR implements that.

## How — design tradeoff (CI footprint)

A full image build + `up` + `down` is heavier than the existing static checks,
so placement was chosen to keep the footprint minimal:

- **Dedicated job, not a matrix row.** Folding the build/`up`/`down` into the
  `compose-validate` matrix (7 fixtures) would multiply a heavy build across
  every fixture. A single gemini-only job builds the image **once**.
- **`NUM_ACCOUNTS=1`.** Only `gemini-a` is built and booted; the second
  account adds nothing to the AC3 #1 assertion.
- **Robust assertion.** `docker inspect` on `State.Running` / `State.Restarting`
  rather than a bare `sleep`, matching the criteria recorded in #289's live
  verification note.
- Uses `claude-docker up` / `down` (not raw `docker compose`) so the job
  exercises the real user entrypoint, including the Linux compose overlay.

## Where

- `.github/workflows/ci.yml` — one new job appended after `pwsh-tests`.
- `scripts/lib/build-compose-cmd.sh` — small fix described below, required for
  the new job to reach the build step.

The image build needs no `--build-arg` override: the `CLAUDE_INSTALLER_SHA256`
pin fixed on `develop` (#292 / #293) is current, so a clean `develop` build
passes (`/tmp/claude-install.sh: OK`).

### Accompanying fix: readonly `UID` under `set -e`

The first CI run surfaced a pre-existing latent bug, not a flaw in the new job.
`build_compose_cmd` did `UID=$(id -u)` on Linux to export `UID`/`GID` for the
`docker-compose.linux.yml` override. Bash keeps `UID` as a **readonly** special
variable, so that assignment aborts with `UID: readonly variable` under
`set -e` — exactly how GitHub Actions runs `bash -e {0}`. The existing
`compose-validate` jobs never hit it because they call `docker compose config`
directly, never the `claude-docker` wrapper; this is the first CI path to run
`claude-docker up`.

Fix: `: "${UID:=$(id -u)}"` / `: "${GID:=$(id -g)}"` — the fallback fires only
when the variable is unset, so the always-set `UID` is left untouched. The
exported values are identical to before, so behavior is unchanged for working
shells; it just no longer aborts under `set -e`. Verified the new logic
survives `set -e` locally.

## Verified locally (Docker 29.2.1)

Reproduced the keyless sequence on a Docker host (Windows Git Bash, Linux
engine), driving `docker compose` directly to bypass the wrapper's
native-Windows-shell guard:

| Step | Result |
|------|--------|
| image build (no `--build-arg`) | SHA pin OK, `claude-code-base:ci-test` built |
| `up` (keyless) | `gemini-a` created and started |
| `docker inspect` | `Running=true`, `Restarting=false`, `ExitCode=0`, `Status=running` |
| in-container runtime | `AGENT_RUNTIME=gemini`, `gemini --version` -> `0.47.0`, no `GEMINI_API_KEY` |
| teardown | `down -v --remove-orphans` clean, no leftover containers/volumes |

The CI run of this new job is the authoritative verification on the real
Linux Docker-host target.

## Scope

This PR automates **AC3 #1 only**. AC3 #2 (`claude-docker gemini` attach,
authenticated) and AC3 #3 (TUI lists/attaches accounts from `~/.gemini-state`)
both require a real `GEMINI_API_KEY` and an interactive terminal, so they
remain a manual key-gated run by an operator. **#289 stays open** pending that
manual verification — hence `Relates to #289`, not a closing keyword.

Relates to #289
