### PR TITLE
test: cover keyless gemini attach for AC3 #2/#3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
           - tests/test_parse_env.sh
           - tests/test_parse_env_equivalence.sh
           - tests/test_runtime_registry_equivalence.sh
+          - tests/test_agent_attach_argv.sh
           - tests/test_transform_syntax_check.sh
           - tests/test_cleanup_backups.sh
           - scripts/test-entrypoint-settings.sh
@@ -147,19 +148,27 @@ jobs:
         shell: pwsh
         run: pwsh -NoProfile -File "${{ matrix.test }}"
 
-  # Live keyless smoke test for Epic #267 AC3 #1: AGENT_RUNTIME=gemini +
-  # `claude-docker up` brings the gemini container to a running state. This
-  # goes one step beyond `compose-validate (gemini)` (static `docker compose
-  # config`) by actually building the image, starting the container, asserting
-  # it is running, and tearing it down. The gemini service command is
-  # ["sleep", "infinity"] and the boot path never references GEMINI_API_KEY, so
-  # this runs with no secret — a passing run is the automated discharge of
-  # AC3 #1. AC3 #2 (`claude-docker gemini` attach) and #3 (TUI account listing)
-  # remain key-gated, interactive, and are NOT covered here. Kept as a single,
-  # NUM_ACCOUNTS=1 dedicated job (not folded into the compose-validate matrix)
-  # so the heavy image build runs once for one runtime rather than per fixture.
+  # Live keyless smoke test for Epic #267 AC3 #1 and the keyless half of AC3 #2:
+  # AGENT_RUNTIME=gemini + `claude-docker up` brings the gemini container to a
+  # running state, and the service/binary pair that `claude-docker gemini`
+  # resolves to actually runs inside it. This goes one step beyond
+  # `compose-validate (gemini)` (static `docker compose config`) by building the
+  # image, starting the container, asserting it is running, exercising the
+  # attach target, and tearing it down. The gemini service command is
+  # ["sleep", "infinity"], and neither the boot path nor `gemini --version`
+  # references GEMINI_API_KEY, so this runs with no secret.
+  #
+  # What stays manual after this job is only an authenticated interactive
+  # session — a real key plus a TTY. *Which* service and argv the attach
+  # resolves to is pinned daemon-free by tests/test_agent_attach_argv.sh, and
+  # the TUI's equivalent of both is covered by the Go tests in
+  # tui/internal/docker and tui/internal/config (AC3 #3).
+  #
+  # Kept as a single, NUM_ACCOUNTS=1 dedicated job (not folded into the
+  # compose-validate matrix) so the heavy image build runs once for one runtime
+  # rather than per fixture.
   gemini-up-smoke:
-    name: "Gemini up/down smoke (keyless, AC3 #1)"
+    name: "Gemini up/down smoke (keyless, AC3 #1 + #2)"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -198,6 +207,22 @@ jobs:
             echo "::error::gemini-a is not in a stable running state"
             docker inspect -f '{{json .State}}' "$cid"
             bash scripts/claude-docker compose logs gemini-a || true
+            exit 1
+          fi
+      - name: "Attach target runs inside the container (AC3 #2, keyless)"
+        run: |
+          set -euo pipefail
+          # `claude-docker gemini` resolves to `docker compose exec gemini-a
+          # gemini` — pinned without a daemon by tests/test_agent_attach_argv.sh.
+          # Here that same service/binary pair is executed for real: -T because
+          # the runner has no TTY, and `--version` because it is the one gemini
+          # invocation that needs no credential. A wrong service name, a binary
+          # missing from the image, or a PATH the runtime is not on all fail here
+          # rather than in a user's first attach.
+          version="$(bash scripts/claude-docker compose exec -T gemini-a gemini --version)"
+          echo "gemini --version -> $version"
+          if [[ -z "${version//[[:space:]]/}" ]]; then
+            echo "::error::gemini --version produced no output in gemini-a"
             exit 1
           fi
       - name: Tear down

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ RUN set -eux; \
 # if the upstream installer is unexpectedly modified. Refresh by
 # computing the hash of the latest installer and bumping the ARG
 # default below; CI will fail loudly when this drift occurs.
-ARG CLAUDE_INSTALLER_SHA256=005ec1a937f32dfbb74f9e810287bcb12cba2d5cae4c9277aa8c6364adbf1787
+ARG CLAUDE_INSTALLER_SHA256=cde4f1702d3b1695f92b73d26888364e17bca476e17f0fd676484c951d36c125
 
 RUN curl -fsSL https://claude.ai/install.sh -o /tmp/claude-install.sh \
     && echo "${CLAUDE_INSTALLER_SHA256}  /tmp/claude-install.sh" | sha256sum -c - \

--- a/tests/test_agent_attach_argv.sh
+++ b/tests/test_agent_attach_argv.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# test_agent_attach_argv.sh -- Verify the argv `claude-docker <runtime>` hands
+# to `docker compose exec` is resolved entirely from the runtime registry.
+#
+# This is the keyless, daemon-free half of Epic #267 AC3 #2 ("`claude-docker
+# gemini` attaches"), tracked by #289. The live half -- that the resolved
+# service/binary actually execute inside a running container -- is covered by
+# the `Gemini up/down smoke` CI job; what cannot be observed there is *which*
+# service and argv the wrapper picked, because an interactive attach needs a
+# TTY and a real credential. This test observes exactly that, with no Docker
+# daemon and no API key.
+#
+# Method: put a stub `docker` earlier on PATH that records its argv and exits
+# 0, then run the real `scripts/claude-docker` end to end. Nothing is faked
+# inside the wrapper -- registry lookup, subcommand dispatch, service
+# defaulting and flag translation all run for real; only the final process
+# execution is intercepted.
+#
+# Only the tokens *after* `exec` are asserted. The preceding `-f` overlay list
+# varies by host (docker-compose.linux.yml on Linux) and by .env
+# (docker-compose.worktree.yml when PROJECT_DIR_A is set), and is the concern
+# of build_compose_cmd, not of attach resolution. This mirrors how the Go
+# side asserts the same boundary (tui/internal/docker/docker_test.go).
+#
+# AGENT_RUNTIME is passed in the environment, which agent_runtime() honors
+# ahead of .env (scripts/lib/runtime.sh), so the repository's own .env is
+# read but never written and the test leaves no trace.
+#
+# Run:  bash tests/test_agent_attach_argv.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLI="$PROJECT_ROOT/scripts/claude-docker"
+
+PASS=0
+FAIL=0
+
+TMP_DIR="$(mktemp -d)"
+cleanup_tmp() {
+    rm -rf "$TMP_DIR"
+}
+trap cleanup_tmp EXIT
+
+STUB_DIR="$TMP_DIR/bin"
+CAPTURE="$TMP_DIR/argv.txt"
+mkdir -p "$STUB_DIR"
+
+# Stub docker: record argv one token per line, succeed silently. One token per
+# line keeps tokens containing spaces intact, which a flat string would lose.
+cat > "$STUB_DIR/docker" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$DOCKER_STUB_CAPTURE"
+exit 0
+STUB
+chmod +x "$STUB_DIR/docker"
+
+# attach_argv RUNTIME SUBCOMMAND [args...]
+# Run the real CLI with the docker stub in front, then echo the captured
+# tokens that follow `exec` (service name first), one per line.
+attach_argv() {
+    local runtime="$1"
+    shift
+
+    : > "$CAPTURE"
+    AGENT_RUNTIME="$runtime" \
+    DOCKER_STUB_CAPTURE="$CAPTURE" \
+    PATH="$STUB_DIR:$PATH" \
+        bash "$CLI" "$@" >/dev/null 2>&1
+
+    local token seen_exec=0
+    while IFS= read -r token; do
+        if [[ "$seen_exec" -eq 1 ]]; then
+            printf '%s\n' "$token"
+        elif [[ "$token" == "exec" ]]; then
+            seen_exec=1
+        fi
+    done < "$CAPTURE"
+}
+
+# assert_attach LABEL EXPECTED_NEWLINE_SEPARATED RUNTIME SUBCOMMAND [args...]
+assert_attach() {
+    local label="$1" expected="$2"
+    shift 2
+
+    local actual
+    actual="$(attach_argv "$@")"
+
+    if [[ "$expected" == "$actual" ]]; then
+        printf '  PASS  %s\n' "$label"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL  %s\n        expected: %s\n        actual:   %s\n' \
+            "$label" \
+            "$(printf '%s' "$expected" | tr '\n' ' ')" \
+            "$(printf '%s' "$actual" | tr '\n' ' ')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+if [[ ! -x "$CLI" ]] && [[ ! -r "$CLI" ]]; then
+    echo "FAIL: CLI not found at $CLI" >&2
+    exit 1
+fi
+
+echo "== Gemini attach resolution (AC3 #2, keyless) =="
+
+# Default service is the registry servicePrefix + '-a'; the binary is the
+# registry `binary`. Neither is hardcoded in cmd_agent.
+assert_attach "gemini -> exec gemini-a gemini" \
+    "$(printf 'gemini-a\ngemini')" \
+    gemini gemini
+
+# --yolo is gemini's registry skipPermissionsFlag; it must survive to argv
+# rather than being swallowed as a service name.
+assert_attach "gemini --yolo -> appends registry skip flag" \
+    "$(printf 'gemini-a\ngemini\n--yolo')" \
+    gemini gemini --yolo
+
+# The universal alias must be translated into the runtime's own flag, not
+# passed through verbatim (gemini CLI has no --dangerously-skip-permissions).
+assert_attach "gemini --dangerously-skip-permissions -> translated to --yolo" \
+    "$(printf 'gemini-a\ngemini\n--yolo')" \
+    gemini gemini --dangerously-skip-permissions
+
+# An explicit service overrides the default while keeping the same binary.
+assert_attach "gemini gemini-b -> exec gemini-b gemini" \
+    "$(printf 'gemini-b\ngemini')" \
+    gemini gemini gemini-b
+
+# Service and flag together, in either order relative to each other.
+assert_attach "gemini gemini-b --yolo -> both honored" \
+    "$(printf 'gemini-b\ngemini\n--yolo')" \
+    gemini gemini gemini-b --yolo
+
+echo "== Regression baseline: claude and codex are unchanged =="
+
+# The registry generalization must not have altered the two pre-existing
+# runtimes; these assertions pin the behavior cmd_claude/cmd_codex had before
+# they collapsed into cmd_agent (#270).
+assert_attach "claude -> exec claude-a claude" \
+    "$(printf 'claude-a\nclaude')" \
+    claude claude
+
+assert_attach "claude --dangerously-skip-permissions -> claude's own flag" \
+    "$(printf 'claude-a\nclaude\n--dangerously-skip-permissions')" \
+    claude claude --dangerously-skip-permissions
+
+# codex carries a non-empty registry extraRunArgs, so its argv is not a plain
+# [binary] -- it proves the argv builder splices extra args between the binary
+# and the skip flag.
+assert_attach "codex -> binary plus registry extraRunArgs" \
+    "$(printf 'codex-a\ncodex\n-c\ncli_auth_credentials_store="file"')" \
+    codex codex
+
+assert_attach "codex --dangerously-bypass-approvals-and-sandbox -> extras then flag" \
+    "$(printf 'codex-a\ncodex\n-c\ncli_auth_credentials_store="file"\n--dangerously-bypass-approvals-and-sandbox')" \
+    codex codex --dangerously-bypass-approvals-and-sandbox
+
+echo
+echo "== Summary: PASS=$PASS FAIL=$FAIL =="
+if (( FAIL > 0 )); then
+    exit 1
+fi

--- a/tui/internal/config/env_test.go
+++ b/tui/internal/config/env_test.go
@@ -271,3 +271,56 @@ func TestCodexRuntimeAPIKeyAndCommandArgs(t *testing.T) {
 		}
 	}
 }
+
+// TestGeminiRuntimeAPIKeyAndCommandArgs is the gemini counterpart of the codex
+// case above: every value the TUI needs to list and attach a gemini account
+// must come from the registry, not from a claude-shaped default. It covers the
+// non-interactive half of Epic #267 AC3 #3 (#289) — the command the dashboard
+// hands to `docker compose exec`, which no live smoke test can observe because
+// an attach needs a TTY and a credential.
+func TestGeminiRuntimeAPIKeyAndCommandArgs(t *testing.T) {
+	// The claude key is present but must be ignored: key selection follows
+	// the registry apiKeyVarPrefix, not the historical CLAUDE_ default.
+	path := writeTempEnv(t, "AGENT_RUNTIME=gemini\nGEMINI_API_KEY_A=gm-key\nCLAUDE_API_KEY_A=sk-ant\n")
+	e, err := LoadEnv(path)
+	if err != nil {
+		t.Fatalf("LoadEnv: %v", err)
+	}
+	if got := e.APIKey("a"); got != "gm-key" {
+		t.Errorf("APIKey(a) = %q, want gemini key", got)
+	}
+	// The state dir the dashboard scans for accounts — the #287 / #288 fix.
+	if got := e.StateDirName(); got != ".gemini-state" {
+		t.Errorf("StateDirName() = %q, want .gemini-state", got)
+	}
+	// Gemini has no Claude-style OAuth usage endpoint; usage must stay off so
+	// the dashboard degrades instead of querying api.anthropic.com.
+	if e.SupportsClaudeUsage() {
+		t.Error("SupportsClaudeUsage() = true, want false for gemini")
+	}
+
+	// Gemini's registry entry has an empty extraRunArgs, so the attach argv is
+	// the bare binary plus, on request, its own skip-permissions flag (--yolo).
+	// A claude-shaped fallback would emit --dangerously-skip-permissions here,
+	// which the gemini CLI does not accept.
+	cases := []struct {
+		skipPermissions bool
+		want            []string
+	}{
+		{false, []string{"gemini"}},
+		{true, []string{"gemini", "--yolo"}},
+	}
+	for _, c := range cases {
+		gotArgs := e.RuntimeCommandArgs(c.skipPermissions)
+		if len(gotArgs) != len(c.want) {
+			t.Fatalf("RuntimeCommandArgs(%v) len = %d, want %d (%v)",
+				c.skipPermissions, len(gotArgs), len(c.want), gotArgs)
+		}
+		for i := range c.want {
+			if gotArgs[i] != c.want[i] {
+				t.Errorf("RuntimeCommandArgs(%v)[%d] = %q, want %q",
+					c.skipPermissions, i, gotArgs[i], c.want[i])
+			}
+		}
+	}
+}

--- a/tui/internal/docker/docker_test.go
+++ b/tui/internal/docker/docker_test.go
@@ -230,3 +230,79 @@ func TestUpRecreateArgs(t *testing.T) {
 		}
 	}
 }
+
+// execTail returns the argv tokens after "exec" — the service name followed by
+// the command. The compose plumbing before "exec" varies with the host (linux
+// overlay) and .env (worktree overlay), so attach assertions must not depend on
+// its length.
+func execTail(t *testing.T, args []string) []string {
+	t.Helper()
+	for i, a := range args {
+		if a == "exec" {
+			return args[i+1:]
+		}
+	}
+	t.Fatalf("args missing %q: %v", "exec", args)
+	return nil
+}
+
+// TestServiceNames_GeminiRuntime covers the "lists" half of Epic #267 AC3 #3
+// (#289): the dashboard derives account service names from the registry
+// servicePrefix, so a gemini session enumerates gemini-a/gemini-b rather than
+// falling back to claude-*.
+func TestServiceNames_GeminiRuntime(t *testing.T) {
+	env := config.NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+	env.Set("AGENT_RUNTIME", "gemini")
+	env.Set("NUM_ACCOUNTS", "2")
+	c := NewClient("/tmp/proj", env)
+
+	got := c.ServiceNames()
+	want := []string{"gemini-a", "gemini-b"}
+	if len(got) != len(want) {
+		t.Fatalf("ServiceNames len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("ServiceNames[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestExecArgs_GeminiAttach covers the "attaches" half of AC3 #3 by composing
+// the two calls the dashboard makes together (ui/dashboard/update.go):
+// ExecArgs(account service, env.RuntimeCommandArgs(skipPermissions)...). The
+// resulting argv must match what `claude-docker gemini` produces on the shell
+// side — the CLI equivalence is pinned by tests/test_agent_attach_argv.sh.
+func TestExecArgs_GeminiAttach(t *testing.T) {
+	env := config.NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+	env.Set("AGENT_RUNTIME", "gemini")
+	env.Set("NUM_ACCOUNTS", "1")
+	c := NewClient("/tmp/proj", env)
+
+	cases := []struct {
+		name            string
+		skipPermissions bool
+		want            []string
+	}{
+		{"plain attach", false, []string{"gemini-a", "gemini"}},
+		{"skip permissions", true, []string{"gemini-a", "gemini", "--yolo"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bin, args := c.ExecArgs("gemini-a", env.RuntimeCommandArgs(tc.skipPermissions)...)
+			if bin != "docker" {
+				t.Errorf("bin = %q, want %q", bin, "docker")
+			}
+			got := execTail(t, args)
+			if len(got) != len(tc.want) {
+				t.Fatalf("exec tail = %v, want %v", got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("exec tail[%d] = %q, want %q (full args=%v)", i, got[i], tc.want[i], args)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Automates the parts of Epic #267 **AC3 #2** (`claude-docker gemini` attaches) and
**AC3 #3** (TUI lists/attaches gemini accounts) that need neither a
`GEMINI_API_KEY` nor an interactive terminal — the residual manual verification
tracked by #289.

Three additions, no production-code changes:

| Layer | Added | Covers |
|-------|-------|--------|
| bash | `tests/test_agent_attach_argv.sh` | which service + argv `claude-docker gemini` resolves to |
| CI | one step in the existing gemini smoke job | that the resolved service/binary pair actually runs |
| Go | 3 tests in `tui/internal/{config,docker}` | the TUI's equivalent of both, for AC3 #3 |

## Why

PR #296 split AC3 into three checkable slices and automated #1 (`up` → running
→ `down`) as a keyless CI smoke test, leaving #2 and #3 as "key-gated,
interactive". That framing is right for the *end* of each chain — an
authenticated Gemini session genuinely needs a real key and a TTY — but it
bundles together two very different things:

1. **Which** container and argv an attach resolves to, and whether that target
   is executable. Neither needs a credential.
2. Whether an authenticated session then opens. This does.

Everything in group 1 is exactly where a runtime-registry regression would
surface: a stale `servicePrefix`, a `skipPermissionsFlag` that never reaches
argv, a binary missing from the image. Leaving it to a manual run means the
first person to notice is a user whose attach fails. This PR moves group 1 into
CI and leaves group 2 — one line of the original acceptance criteria — as the
only manual step.

## How

### `tests/test_agent_attach_argv.sh` (daemon-free, key-free)

Puts a stub `docker` earlier on `PATH` that records its argv and exits 0, then
runs the **real** `scripts/claude-docker`. Nothing inside the wrapper is faked:
registry lookup, subcommand dispatch, service defaulting and flag translation
all execute; only the final process launch is intercepted.

Nine assertions, gemini-first with claude/codex as regression baselines:

- `gemini` → `exec gemini-a gemini` (default service from `servicePrefix`)
- `gemini --yolo` → registry `skipPermissionsFlag` reaches argv
- `gemini --dangerously-skip-permissions` → **translated** to `--yolo`, not
  passed through (the gemini CLI does not accept the claude flag)
- `gemini gemini-b [--yolo]` → explicit service honored
- `claude` / `codex` → unchanged from their pre-`cmd_agent` behavior; codex's
  non-empty `extraRunArgs` proves argv assembly is not a plain `[binary]`

Only tokens **after** `exec` are asserted — the preceding `-f` overlay list
varies by host and `.env`, and belongs to `build_compose_cmd`. This mirrors how
the Go side draws the same boundary in `TestExecArgs`.

`AGENT_RUNTIME` is passed in the environment, which `agent_runtime()` honors
ahead of `.env`, so the test reads but never writes repository state.

**Mutation-checked**: flipping `skipPermissionsFlag` to a wrong value in
`runtimes.json` fails exactly the three flag assertions and no others.

### CI: `gemini --version` inside the running container

The smoke job already builds the image and brings up `gemini-a`. One step now
runs the same service/binary pair the CLI resolves to:

```
docker compose exec -T gemini-a gemini --version
```

`-T` because the runner has no TTY; `--version` because it is the one gemini
invocation needing no credential (PR #296 confirmed `0.47.0` on a Docker host).
A wrong service name, a binary missing from the image, or a PATH the runtime is
not on now fail in CI rather than in a user's first attach.

The job is renamed to `AC3 #1 + #2` and its header comment rewritten to state
precisely what is still manual.

### Go tests (AC3 #3)

`TestDiscoverStateDirs_GeminiRuntime` already covers *discovery* from
`~/.gemini-state` (added with #288). Added the two halves it does not reach:

- `TestServiceNames_GeminiRuntime` — the "lists" half: accounts enumerate as
  `gemini-a`/`gemini-b`, not a claude-shaped fallback.
- `TestExecArgs_GeminiAttach` — the "attaches" half, composing the two calls
  `ui/dashboard/update.go` makes together:
  `ExecArgs(service, env.RuntimeCommandArgs(skip)...)`.
- `TestGeminiRuntimeAPIKeyAndCommandArgs` — the gemini mirror of the existing
  codex case: `GEMINI_API_KEY_A` wins over a present `CLAUDE_API_KEY_A`,
  `StateDirName()` is `.gemini-state`, argv is `[gemini]` / `[gemini --yolo]`,
  and `SupportsClaudeUsage()` stays false so the dashboard degrades instead of
  querying `api.anthropic.com`.

The shell and Go sides assert the same expected argv, so drift between the CLI
and the TUI attach paths fails one of them.

## Accompanying fix: stale installer pin

The first CI run failed before reaching any of the above — the image build
aborted with `/tmp/claude-install.sh: FAILED`. `claude.ai/install.sh` changed
upstream again, so `CLAUDE_INSTALLER_SHA256` no longer matched: the same drift
#293 fixed, and it was breaking **every** image build on `develop`, not just
this branch.

Recomputed the hash of the currently served installer and bumped the ARG
default to `cde4f170…`. Shipped here rather than separately because the new
attach check cannot run until the image builds — the same reasoning #296 used
for its `build-compose-cmd.sh` fix.

Before trusting the new hash the served installer was reviewed: 217 lines, and
the only hosts it contacts are `claude.ai`, `downloads.claude.ai`,
`code.claude.com` and `anthropic.com`.

## Where

- `tests/test_agent_attach_argv.sh` (new) + one row in the `bash-tests` matrix
- `.github/workflows/ci.yml` — one step, plus the job rename/comment
- `tui/internal/config/env_test.go`, `tui/internal/docker/docker_test.go`
- `Dockerfile` — one ARG default (the pin bump above)

Apart from the pin, this PR is tests and CI only; no behavior changes.

## Verified

Locally (the authoring machine had neither a Docker daemon nor a Go toolchain,
so those two layers were deliberately left to the runner):

| Check | Result |
|-------|--------|
| `bash tests/test_agent_attach_argv.sh` | PASS=9 FAIL=0 |
| Mutation (`skipPermissionsFlag` → `--broken`) | 3 targeted failures, clean restore |
| `shellcheck --severity=warning` on the new test | clean |
| `ci.yml` parses; step/job names survive YAML `#` handling | confirmed |

In CI — all 22 checks green:

| Check | Evidence |
|-------|----------|
| installer pin | `/tmp/claude-install.sh: OK` |
| AC3 #1 | `gemini-a: Running=true Restarting=false` |
| AC3 #2, live | `gemini --version -> 0.53.1` |
| AC3 #2, resolution | `Bash Tests (tests/test_agent_attach_argv.sh)` pass |
| AC3 #3 | `Go tests (TUI)` pass |

## Scope

**#289 stays open.** After this PR the only unverified part of AC3 is an
authenticated interactive session — a real `GEMINI_API_KEY` plus a terminal —
which no CI runner can supply. Everything mechanically checkable about attach
resolution and execution is now covered, so what remains for an operator is a
single confirmation rather than a four-step procedure.

Relates to #289
Relates to #267
