### PR TITLE
test(ci): add key-gated authenticated gemini check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,17 +158,29 @@ jobs:
   # ["sleep", "infinity"], and neither the boot path nor `gemini --version`
   # references GEMINI_API_KEY, so this runs with no secret.
   #
-  # What stays manual after this job is only an authenticated interactive
-  # session — a real key plus a TTY. *Which* service and argv the attach
+  # A final, key-gated phase then covers the authenticated half of AC3 #2 when
+  # a GEMINI_API_KEY secret exists (#301). It runs strictly *after* every
+  # keyless assertion above, and only then introduces the key — so the AC3 #1
+  # checks keep being made in an environment that has no credential at all,
+  # which is the whole point of them. Without the secret (forks, Dependabot,
+  # or before the owner configures one) that phase emits a notice and passes.
+  #
+  # Folded into this job rather than split into a second one so the heavy image
+  # build happens once; a separate job would need a buildx layer cache to avoid
+  # paying for it twice, which the `claude-docker up` build path does not
+  # currently wire up.
+  #
+  # What stays manual after this job is the TUI screen check — accounts listed
+  # and attached from the dashboard (#289). *Which* service and argv an attach
   # resolves to is pinned daemon-free by tests/test_agent_attach_argv.sh, and
-  # the TUI's equivalent of both is covered by the Go tests in
-  # tui/internal/docker and tui/internal/config (AC3 #3).
+  # the TUI's equivalent is covered by the Go tests in tui/internal/docker and
+  # tui/internal/config (AC3 #3).
   #
   # Kept as a single, NUM_ACCOUNTS=1 dedicated job (not folded into the
   # compose-validate matrix) so the heavy image build runs once for one runtime
   # rather than per fixture.
   gemini-up-smoke:
-    name: "Gemini up/down smoke (keyless, AC3 #1 + #2)"
+    name: "Gemini up/down smoke (AC3 #1 + #2)"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -225,6 +237,56 @@ jobs:
             echo "::error::gemini --version produced no output in gemini-a"
             exit 1
           fi
+      - name: "Authenticated round-trip when a key is available (AC3 #2)"
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          set -euo pipefail
+          # The `secrets` context is not available in a job-level `if:`, so the
+          # guard lives here: take the secret through env and no-op when empty.
+          # Fork and Dependabot PRs are never given secrets, so they take this
+          # path and pass rather than failing contributors who cannot supply a
+          # key. The same applies before the owner configures one at all.
+          if [[ -z "${GEMINI_API_KEY:-}" ]]; then
+            echo "::notice::GEMINI_API_KEY not configured; skipping the authenticated gemini check"
+            exit 0
+          fi
+
+          # Everything above ran with no credential in the environment -- that
+          # is what makes the AC3 #1 assertions meaningful. The key enters only
+          # now, through the per-account variable the compose generator reads
+          # (it injects GEMINI_API_KEY into the service only for accounts whose
+          # key is non-empty), so the container must be recreated to see it.
+          echo "GEMINI_API_KEY_A=${GEMINI_API_KEY}" >> .env
+          NUM_ACCOUNTS=1 bash scripts/generate-compose.sh
+          bash scripts/claude-docker up
+
+          # Gemini CLI switches to headless mode under -p (and in any non-TTY
+          # environment such as this runner). --output-format json makes the
+          # result parseable, so the assertion is on response shape rather than
+          # on model wording, which would be brittle.
+          rc=0
+          out="$(bash scripts/claude-docker compose exec -T gemini-a \
+                   gemini -p 'Reply with the single word OK.' \
+                   --output-format json)" || rc=$?
+          if [[ "$rc" -ne 0 ]]; then
+            # Documented headless exit codes: 1 general/API failure,
+            # 42 input validation, 53 turn limit.
+            echo "::error::authenticated gemini call exited with status $rc"
+            printf '%s\n' "$out"
+            exit 1
+          fi
+
+          # A successful headless run carries no .error and a non-empty
+          # .response string.
+          if ! printf '%s' "$out" \
+               | jq -e '.error == null and (.response | type) == "string" and (.response | length) > 0' \
+                 >/dev/null; then
+            echo "::error::gemini returned no usable response"
+            printf '%s\n' "$out"
+            exit 1
+          fi
+          echo "authenticated gemini round-trip OK: $(printf '%s' "$out" | jq -r '.response' | head -c 80)"
       - name: Tear down
         if: always()
         run: bash scripts/claude-docker down -v --remove-orphans


### PR DESCRIPTION
## What

Implements #301: a **key-gated** authenticated round-trip in the gemini smoke
job, covering the authenticated half of Epic #267 **AC3 #2** — the part of #289
that turned out to be automatable after all.

When a `GEMINI_API_KEY` secret exists, the job now runs, inside the container it
just started:

```
gemini -p 'Reply with the single word OK.' --output-format json
```

and asserts the response *shape*. When the secret is absent it emits a notice
and passes.

One file changed (`.github/workflows/ci.yml`): +67 / −5.

## Why

Before this, the gemini chain was verified up to but not including
authentication — `gemini --version` deliberately touches no credential. That
left a whole class of container-specific breakage unexercised: key injection
into the service environment, config-directory resolution
(`GEMINI_CLI_HOME` → `/home/node/.gemini`), and the state-volume mount. A
regression in any of those currently surfaces on a user's first real prompt.

Gemini CLI supports headless execution (`-p`, and automatically in any non-TTY
environment), so this needs no terminal — only a key.

## How

### Guard: step env, not a job-level `if:`

The `secrets` context is **not** available in `jobs.<id>.if` (only `github`,
`needs`, `vars`, `inputs` are). So the secret is taken through step `env` and
checked at runtime:

```yaml
env:
  GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
run: |
  if [[ -z "${GEMINI_API_KEY:-}" ]]; then
    echo "::notice::GEMINI_API_KEY not configured; skipping..."
    exit 0
  fi
```

Forks and Dependabot PRs are never given secrets, so they take this path and
pass rather than failing contributors who cannot supply a key. The same holds
before the owner configures a secret at all — **the check is inert until then,
by design**, so this PR is safe to merge whether or not a key is ever added.

### The keyless assertions stay keyless

This was the main design constraint from #301. The key is appended to `.env`
**only after** every keyless assertion has run, then compose is regenerated and
the container recreated so the service picks it up. The AC3 #1 checks therefore
keep being made in an environment with no credential — which is precisely what
makes them meaningful.

### Why one job rather than two

#301 offered two shapes. A separate job has cleaner semantics but pays for the
image build twice; avoiding that needs a buildx layer cache, which the
`claude-docker up` build path does not currently wire up. Folding it in keeps
one build, at the cost of the job carrying two meanings — so the job was
renamed (it is no longer "keyless" throughout) and its header comment now
states exactly which slice runs under which condition.

### Assertion

`jq -e '.error == null and (.response | type) == "string" and (.response | length) > 0'`

Shape, not wording — asserting on model output text would be brittle. Documented
headless exit codes (1 general/API failure, 42 input validation, 53 turn limit)
are surfaced in the error message.

## Verified locally

| Check | Result |
|-------|--------|
| Keyless path (secret unset, as on a fork PR) | exits 0, prints the notice, leaves no `.env` behind |
| jq assertion — well-formed response | accepted |
| jq assertion — `.error` present / empty `.response` / missing `.response` / non-string `.response` | all rejected |
| `bash -n` on every run block in the job | clean |
| YAML parse; step and job names survive `#` handling | confirmed |

The authenticated path itself cannot run here — no secret is configured on the
repository, and this machine has no Docker daemon. It stays dormant until a key
is added, which is the intended behavior.

## Where

- `.github/workflows/ci.yml` — one new step, plus the job rename and header
  comment update.
- Needs a repository secret named `GEMINI_API_KEY` to become active. Adding it
  is the owner's call: it implies a real API call (trivially small) per run of
  this job.

## Note on issue closing

This repository has no `auto-close-linked-issues` workflow, and GitHub's own
auto-close only fires on merges into the default branch (`main`), not `develop`.
`Closes #301` will therefore **not** close the issue automatically on merge — it
needs a manual close.

Closes #301
Relates to #289
Relates to #267
