### PR TITLE
fix(ci): detect drift between committed compose files and the generators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,22 @@ jobs:
       - name: Run Go unit tests
         working-directory: ./tui
         run: go test ./...
+      # Formatting is checked here rather than in a separate job because the Go
+      # toolchain is already provisioned. The job name stays "Go tests (TUI)"
+      # so any branch-protection rule referencing it keeps matching; the step
+      # name is what identifies a formatting failure.
+      - name: Check gofmt
+        working-directory: ./tui
+        # `gofmt -l` lists offending files but still exits 0, so the emptiness
+        # of its output is the assertion. Asserting on its exit status instead
+        # would leave the gate permanently green (issue #305).
+        run: |
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "::error::gofmt violations found. Fix with: gofmt -w <file>"
+            printf '%s\n' "$unformatted"
+            exit 1
+          fi
 
   compose-validate:
     name: Compose validate (${{ matrix.fixture }})
@@ -113,6 +129,37 @@ jobs:
         run: bash scripts/generate-compose.sh
       - name: Validate compose
         run: docker compose config > /dev/null
+
+  # `compose-validate` above only ever inspects compose files it has just
+  # generated from a fixture, so it cannot observe drift in the copies that are
+  # actually committed. This job closes that gap: it regenerates in place and
+  # asserts the working tree is unchanged.
+  #
+  # The committed compose files represent the generator's built-in defaults
+  # with no `.env` present:
+  #   NUM_ACCOUNTS=2      (scripts/generate-compose.sh default)
+  #   AGENT_RUNTIME=claude (scripts/lib/runtime.sh default)
+  #   IMAGE_TAG           read from the repo-root VERSION file
+  # A VERSION bump therefore requires regenerating the compose files in the
+  # same change, because the committed files embed the tag as a default.
+  compose-freshness:
+    name: Compose files are current
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Regenerate from generator defaults
+        # `.env` is gitignored and absent on a fresh checkout; removing it
+        # anyway pins the job to the documented defaults rather than to
+        # whatever a future change might leave in the working tree.
+        run: |
+          rm -f .env
+          bash scripts/generate-compose.sh
+      - name: Assert no drift
+        run: |
+          if ! git diff --exit-code -- docker-compose.yml docker-compose.linux.yml docker-compose.worktree.yml; then
+            echo "::error::Committed compose files differ from generator output. Regenerate with: rm -f .env && bash scripts/generate-compose.sh"
+            exit 1
+          fi
 
   bash-tests:
     name: Bash Tests (${{ matrix.test }})

--- a/README.md
+++ b/README.md
@@ -599,6 +599,24 @@ All state is preserved across container restarts via Docker volume mounts:
 All compose files are **generated** by `scripts/generate-compose.sh` (or `.ps1`)
 based on `NUM_ACCOUNTS` in `.env`. Do not edit them manually.
 
+They are nonetheless **tracked in Git** as the committed source of truth, so
+what is committed has to match generator output. The committed copies represent
+the generator defaults with no `.env` present:
+
+| Setting | Value | Source |
+|---------|-------|--------|
+| `NUM_ACCOUNTS` | `2` | `scripts/generate-compose.sh` default |
+| `AGENT_RUNTIME` | `claude` | `scripts/lib/runtime.sh` default |
+| `IMAGE_TAG` | contents of `VERSION` | repo-root `VERSION` file |
+
+The `Compose files are current` CI job regenerates under exactly those defaults
+and fails on any difference. Regenerating with your own `.env` during local work
+is expected, but do not commit the result — restore the committed copies first:
+
+```bash
+git checkout -- docker-compose.yml docker-compose.linux.yml docker-compose.worktree.yml
+```
+
 | File | Purpose | When active |
 |------|---------|-------------|
 | `docker-compose.yml` | Base config (Tier A), incl. `user: ${UID:-1000}:${GID:-1000}` and `HOME=/home/node` | Always |
@@ -748,7 +766,10 @@ at `/home/node/.local/bin/claude`, so `/doctor` no longer warns about
    (e.g. `2026.04.17`). Both `scripts/generate-compose.sh`/`.ps1` and
    `scripts/install.sh`/`.ps1` read this file, so regenerating compose
    or running `install` picks up the new default automatically. Do not
-   hand-edit the generated `docker-compose.yml` — its header forbids it
+   hand-edit the generated `docker-compose.yml` — its header forbids it.
+   The committed compose files embed the tag as their default, so the bump
+   must carry a regeneration (`rm -f .env && scripts/generate-compose.sh`)
+   in the same change or the `Compose files are current` job fails
 5. Rebuild everything from scratch: `docker compose build --no-cache`
 6. Check the build log for the `[build] GitHub CLI keyring fingerprint:` line
    and confirm it matches prior builds (unexpected changes may indicate an

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - TERM=xterm-256color
       - TZ=${TZ:-UTC}
       - HOME=/home/node
+      - AGENT_RUNTIME=claude
       - CLAUDE_CONFIG_DIR=/home/node/.claude
       - CLAUDE_CONFIG_SOURCE=${CLAUDE_CONFIG_SOURCE:-}
       - CLAUDE_NORMALIZE_CRLF=${CLAUDE_NORMALIZE_CRLF:-}
@@ -66,6 +67,7 @@ services:
       - TERM=xterm-256color
       - TZ=${TZ:-UTC}
       - HOME=/home/node
+      - AGENT_RUNTIME=claude
       - CLAUDE_CONFIG_DIR=/home/node/.claude
       - CLAUDE_CONFIG_SOURCE=${CLAUDE_CONFIG_SOURCE:-}
       - CLAUDE_NORMALIZE_CRLF=${CLAUDE_NORMALIZE_CRLF:-}

--- a/tui/internal/ui/dashboard/render.go
+++ b/tui/internal/ui/dashboard/render.go
@@ -31,7 +31,7 @@ func renderAccountTable(accounts []account.Account, cursor int, width int) strin
 		Render(header) + "\n")
 
 	b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("#374151")).
-		Render("  " + strings.Repeat("─", min(76, width-4))) + "\n")
+		Render("  "+strings.Repeat("─", min(76, width-4))) + "\n")
 
 	// Styles
 	styleGreen := lipgloss.NewStyle().Foreground(lipgloss.Color("#22C55E"))


### PR DESCRIPTION
Closes #305

## Changes

- New `compose-freshness` CI job. It regenerates the compose files in place and asserts the working tree is unchanged, with the defaults the committed copies represent documented next to it.
- `docker-compose.yml` regenerated. The drift is exactly the two `AGENT_RUNTIME=claude` lines, one per service.
- `gofmt` assertion added to the existing `go-test` job, and `tui/internal/ui/dashboard/render.go` formatted.
- `README.md` records the tracked-vs-generated policy, the defaults the committed copies represent, how to restore them after local regeneration, and the new obligation a `VERSION` bump carries.

## Rationale

`compose-validate` only ever inspects compose files it has just generated from a fixture, so it cannot observe drift in the copies that are actually committed. That is why the `AGENT_RUNTIME` drift survived, and why this class of drift recurred after #243 aligned it once. The gate is what was missing, not the alignment.

The committed copies did not need a fixture decision. Regenerating with no `.env` reproduces them byte-for-byte apart from the known drift, so the configuration they represent was already determined rather than a choice to make: `NUM_ACCOUNTS=2` and `AGENT_RUNTIME=claude` from the generator defaults, `IMAGE_TAG` from the repo-root `VERSION` file.

`gofmt` is folded into `go-test` rather than a job of its own because that job already provisions the Go toolchain. Its name is left unchanged so any branch-protection rule referencing it keeps matching; the step name identifies a formatting failure.

## Verification

Everything below ran in Linux containers, so the generator executes the same way it will on `ubuntu-latest`.

**Gates green on a CI-equivalent checkout** — cloning `HEAD` into a clean tree and running each job's exact steps:

```
=== JOB compose-freshness / step: Assert no drift ===
STEP RESULT: PASS

=== JOB go-test / step: Check gofmt ===
STEP RESULT: PASS
```

**Gates red on the defect each targets.** A gate that only passes proves nothing, so both were run against a mutant on a throwaway copy:

| Mutation | Result |
|----------|--------|
| Strip the two `AGENT_RUNTIME=claude` lines from the committed compose | `compose-freshness` fails, reproducing exactly the drift #305 describes |
| Restore the pre-`gofmt` spacing in `render.go` | `go-test` fails and names `internal/ui/dashboard/render.go` |

The second mutation matters more than it looks: `gofmt -l` lists offending files but still **exits 0**, so a check asserting on its exit status would be green forever. The step asserts on its output being empty instead.

**Other checks**

- `actionlint` on `.github/workflows/` passes with no output. This also shellchecks the `run:` blocks.
- `go build ./...`, `go vet ./...`, and `go test ./... -count=1` pass across every package.
- The PowerShell generator was run against the same tree to confirm it does not break the new gate. Its output has no content difference from the committed copies; it emits CRLF on Windows, which `.gitattributes` (`docker-compose*.yml text eol=lf`) normalizes on commit.

## Scope

**In scope** — the three acceptance criteria, plus the `gofmt` gate the issue flagged under "Related gap" as sharing the same root cause.

**Out of scope** — cross-generator parity testing, filed as #308 (see Follow-up Work).

## Risks

- **A `VERSION` bump now fails CI unless it carries a regeneration.** The committed files embed the tag as a default, so this is correct behavior rather than a side effect, but it is new friction. The "Bumping the Base Image" procedure in `README.md` was updated to say so.
- **A contributor who commits a locally regenerated file gets a failure.** This is the intended gate firing, and it is the reason the README now documents the defaults and the one-line restore. The job's error message also prints the exact regeneration command.
- **The `go-test` job now has two reasons to fail.** Step names disambiguate. Renaming the job would have been clearer but would silently break any branch-protection rule that requires the current check name.

## Follow-up Work

- #308 — nothing keeps `generate-compose.sh` and `generate-compose.ps1` byte-identical. #243 required it and aligned them once; the new freshness gate compares committed-versus-bash only, so a PowerShell-side divergence would leave CI green. Verified as not a live defect today, but unguarded.

The gap audit also found that #243's acceptance criterion "policy choice is documented in `README.md`" was never satisfied. That omission is fixed here rather than filed, because this PR is what makes it load-bearing: without the policy written down, the new gate fails contributors with no documented explanation. #243 itself is left closed.
