### PR TITLE
fix(scripts): guard three bash entry points on native Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,7 @@ jobs:
           - tests/test_agent_attach_argv.sh
           - tests/test_transform_syntax_check.sh
           - tests/test_cleanup_backups.sh
+          - tests/test_windows_platform_guard.sh
           - scripts/test-entrypoint-settings.sh
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/README.md
+++ b/README.md
@@ -42,9 +42,12 @@ installer and CLI wrapper that match your host platform:
 | Windows (native) | `scripts/install.ps1` | `scripts/claude-docker.ps1` or `.cmd` | Docker Desktop (WSL2 backend) | Run from PowerShell 5.1+ or PowerShell 7 |
 | Windows (WSL2) | `scripts/install.sh` (**inside** WSL2) | `scripts/claude-docker` | Docker Desktop (WSL2 integration) | Keep project files inside the WSL2 filesystem for performance |
 
-**Do not cross platforms.** Running `install.sh` from a native Windows shell
-(Git Bash / MSYS / Cygwin) or `install.ps1` from PowerShell 7 on Linux/macOS
-will fail fast with a clear error pointing at the correct script.
+**Do not cross platforms.** Running a script from the wrong shell fails fast
+with an error naming the counterpart to use instead. On the bash side that
+covers `install.sh`, `claude-docker`, `generate-compose.sh`, `cleanup.sh`, and
+`remove.sh` when invoked from a native Windows shell (Git Bash / MSYS /
+Cygwin); on the PowerShell side, `install.ps1` and `claude-docker.ps1` when
+invoked from PowerShell 7 on Linux or macOS.
 
 ## Quick Start
 

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -13,6 +13,20 @@
 # PROJECT_ROOT_OVERRIDE to redirect the script root for tests.
 set -euo pipefail
 
+# Platform guard: same rationale as install.sh - refuse to run on native
+# Windows shells (Git Bash, MSYS, Cygwin). The state directories removed below
+# are addressed by MSYS-flavored paths that do not match what the PowerShell
+# installer created, so a run that appeared to succeed would leave the real
+# state in place. Placed ahead of the runtime-registry read for the same reason
+# as generate-compose.sh: on Windows that read misreports every registered
+# runtime as unknown (#306).
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+        echo "Error: cleanup.sh is not supported on native Windows shells." >&2
+        echo "Use: powershell -ExecutionPolicy Bypass -File scripts\\cleanup.ps1" >&2
+        exit 1 ;;
+esac
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="${PROJECT_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 cd "$PROJECT_ROOT"

--- a/scripts/generate-compose.sh
+++ b/scripts/generate-compose.sh
@@ -11,6 +11,20 @@
 #   NUM_ACCOUNTS=4 scripts/generate-compose.sh  # Override via env
 set -euo pipefail
 
+# Platform guard: same rationale as install.sh - refuse to run on native
+# Windows shells (Git Bash, MSYS, Cygwin), where this script fails twice over.
+# The paths it bakes into the compose files are MSYS-flavored, and Windows `jq`
+# writes stdout in text mode, so the runtime-registry reads come back with a
+# trailing CR and a correctly-registered runtime is rejected as unknown. The
+# guard sits ahead of the first registry read specifically so that misleading
+# "AGENT_RUNTIME is not a known runtime" error is never reached (#306).
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+        echo "Error: generate-compose.sh is not supported on native Windows shells." >&2
+        echo "Use: powershell -ExecutionPolicy Bypass -File scripts\\generate-compose.ps1" >&2
+        exit 1 ;;
+esac
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 

--- a/scripts/lib/runtime.sh
+++ b/scripts/lib/runtime.sh
@@ -11,6 +11,14 @@
 # it; this file finds it relative to PROJECT_ROOT. Reads use `jq` when it is
 # available (guaranteed inside the container image) and an `awk` state-machine
 # fallback otherwise (the host is not guaranteed to have `jq`).
+#
+# Registry reads are deliberately NOT made CR-tolerant (#306). A trailing CR
+# would make agent_runtime reject a correctly-registered runtime, but both ways
+# one could arrive are closed: Windows `jq` emits CRLF only in a native Windows
+# shell, and every bash entry point that reads this registry now refuses to run
+# on one; the registry file itself cannot carry CR because .gitattributes pins
+# *.json to eol=lf. A `tr -d '\r'` here would therefore defend against nothing
+# reachable, while masking the signal that a caller is on an unsupported path.
 
 if [[ -n "${_CLAUDE_DOCKER_RUNTIME_SH_SOURCED:-}" ]]; then
     return 0 2>/dev/null || exit 0

--- a/scripts/remove.sh
+++ b/scripts/remove.sh
@@ -4,6 +4,19 @@
 # worktrees, state directories, .env, and optionally host tools.
 set -euo pipefail
 
+# Platform guard: refuse to run on native Windows shells (Git Bash, MSYS,
+# Cygwin). This script reverses what install.sh set up, and install.sh already
+# refuses on those platforms - so there is no bash-created installation to
+# reverse there, only a PowerShell one that remove.ps1 owns. Running anyway
+# would walk MSYS-flavored paths and report success having removed nothing
+# (#306).
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+        echo "Error: remove.sh is not supported on native Windows shells." >&2
+        echo "Use: powershell -ExecutionPolicy Bypass -File scripts\\remove.ps1" >&2
+        exit 1 ;;
+esac
+
 # --- Constants & Colors -------------------------------------------------------
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/tests/test_windows_platform_guard.sh
+++ b/tests/test_windows_platform_guard.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# test_windows_platform_guard.sh — Verifies the native-Windows platform guard
+# on every bash entry point that has a PowerShell counterpart.
+#
+# The guard cannot be observed by simply running on Windows: CI runners are
+# Linux, so `uname -s` never reports a Git Bash kernel. Instead `uname` is
+# shadowed on PATH by a stub that reports one. A `jq` stub sits beside it and
+# appends to a marker file whenever it is called, which is what turns "the
+# refusal happens before any runtime-registry read" (#306 acceptance criterion
+# 2) into something observable: the guard has to fire first, so the marker must
+# stay empty.
+#
+# Run:  bash tests/test_windows_platform_guard.sh
+# Exits non-zero on any failure; prints a summary at the end.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+pass() {
+    printf '  PASS  %s\n' "$1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    printf '  FAIL  %s\n        %s\n' "$1" "$2"
+    FAIL=$((FAIL + 1))
+}
+
+# Entry points that must carry the guard, paired with the PowerShell script
+# their message has to name. An explicit list rather than a glob over
+# scripts/*.sh, so that adding a bash entry point forces a deliberate decision
+# to include or exclude it — the drift this list prevents is exactly how #306
+# happened, #146 having guarded only the first two.
+#
+# Deliberately absent:
+#   scripts/entrypoint.sh                runs only inside the container
+#   scripts/test-entrypoint-settings.sh  no .ps1 counterpart to redirect to
+#   scripts/setup-worktrees.sh           counterpart exists, guard not added yet
+#   scripts/test-concurrent-git.sh       counterpart exists, guard not added yet
+GUARDED=(
+    "scripts/install.sh|install.ps1"
+    "scripts/claude-docker|claude-docker.ps1"
+    "scripts/generate-compose.sh|generate-compose.ps1"
+    "scripts/cleanup.sh|cleanup.ps1"
+    "scripts/remove.sh|remove.ps1"
+)
+
+STUB_ROOT="$(mktemp -d)"
+trap 'rm -rf "$STUB_ROOT"' EXIT
+
+STUB_DIR="$STUB_ROOT/bin"
+JQ_MARKER="$STUB_ROOT/jq-was-called"
+mkdir -p "$STUB_DIR"
+
+# Resolve the real uname now, while PATH is still clean, so the stub can
+# delegate anything that is not `-s` without recursing into itself.
+REAL_UNAME="$(command -v uname)"
+
+cat > "$STUB_DIR/uname" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "-s" ]; then
+    printf 'MINGW64_NT-10.0-26200\n'
+    exit 0
+fi
+exec "$REAL_UNAME" "\$@"
+EOF
+
+# Records the call and fails, so a guard that let execution through would both
+# leave evidence and not silently succeed against the real registry.
+cat > "$STUB_DIR/jq" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$JQ_MARKER"
+exit 1
+EOF
+
+chmod +x "$STUB_DIR/uname" "$STUB_DIR/jq"
+
+check_guard() {
+    local rel="$1" counterpart="$2"
+    local script="$PROJECT_ROOT/$rel"
+    local output rc=0
+
+    if [ ! -f "$script" ]; then
+        fail "$rel exists" "no such file"
+        return
+    fi
+
+    : > "$JQ_MARKER"
+
+    # stdin is closed so that a missing guard cannot stall on an interactive
+    # prompt; stderr is folded in because the guard writes its message there.
+    output="$(PATH="$STUB_DIR:$PATH" bash "$script" </dev/null 2>&1)" || rc=$?
+
+    if [ "$rc" -eq 1 ]; then
+        pass "$rel refuses with exit 1"
+    else
+        fail "$rel refuses with exit 1" "actual exit status: $rc"
+    fi
+
+    case "$output" in
+        *"is not supported on native Windows shells"*)
+            pass "$rel says why it refused" ;;
+        *)
+            fail "$rel says why it refused" "output was: ${output:-<empty>}" ;;
+    esac
+
+    case "$output" in
+        *"$counterpart"*)
+            pass "$rel points at $counterpart" ;;
+        *)
+            fail "$rel points at $counterpart" "output did not name it: ${output:-<empty>}" ;;
+    esac
+
+    if [ -s "$JQ_MARKER" ]; then
+        fail "$rel refuses before any registry read" \
+            "jq was invoked: $(tr '\n' ';' < "$JQ_MARKER")"
+    else
+        pass "$rel refuses before any registry read"
+    fi
+}
+
+echo "=== Native-Windows platform guard ==="
+for entry in "${GUARDED[@]}"; do
+    check_guard "${entry%%|*}" "${entry##*|}"
+done
+
+# The guard must be conditional, not unconditional: on a supported platform the
+# same scripts have to get past it. generate-compose.sh proves that cheaply,
+# being non-interactive and needing no daemon.
+#
+# Skipped when this test is itself running on a native Windows shell, where the
+# guard is supposed to fire and asserting the opposite would be wrong. CI runs
+# on Linux, so the assertion is always made where it is meaningful.
+echo
+echo "=== Supported platform is unaffected ==="
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+        printf '  SKIP  running on a native Windows shell, where the guard is correct to fire\n'
+        printf '\nPassed: %d  Failed: %d\n' "$PASS" "$FAIL"
+        [ "$FAIL" -eq 0 ]
+        exit
+        ;;
+esac
+
+# generate-compose.sh writes compose files into whatever it resolves as the
+# project root, so it runs against a throwaway copy holding only the files it
+# reads. Without that, merely running this test would rewrite the committed
+# compose files from the caller's .env.
+SANDBOX="$STUB_ROOT/project"
+mkdir -p "$SANDBOX/scripts/lib" "$SANDBOX/tui/internal/config"
+cp "$PROJECT_ROOT/scripts/generate-compose.sh" "$SANDBOX/scripts/"
+cp "$PROJECT_ROOT"/scripts/lib/*.sh "$SANDBOX/scripts/lib/"
+cp "$PROJECT_ROOT/tui/internal/config/runtimes.json" "$SANDBOX/tui/internal/config/"
+if [ -f "$PROJECT_ROOT/VERSION" ]; then
+    cp "$PROJECT_ROOT/VERSION" "$SANDBOX/"
+fi
+
+: > "$JQ_MARKER"
+gen_rc=0
+gen_out="$(bash "$SANDBOX/scripts/generate-compose.sh" </dev/null 2>&1)" || gen_rc=$?
+if [ "$gen_rc" -eq 0 ]; then
+    pass "generate-compose.sh still runs on this platform"
+else
+    fail "generate-compose.sh still runs on this platform" \
+        "exit $gen_rc: ${gen_out:-<empty>}"
+fi
+
+case "$gen_out" in
+    *"not supported on native Windows shells"*)
+        fail "guard stays silent on a supported platform" "it fired anyway" ;;
+    *)
+        pass "guard stays silent on a supported platform" ;;
+esac
+
+echo
+printf 'Passed: %d  Failed: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/test_windows_platform_guard.sh
+++ b/tests/test_windows_platform_guard.sh
@@ -40,8 +40,8 @@ fail() {
 # Deliberately absent:
 #   scripts/entrypoint.sh                runs only inside the container
 #   scripts/test-entrypoint-settings.sh  no .ps1 counterpart to redirect to
-#   scripts/setup-worktrees.sh           counterpart exists, guard not added yet
-#   scripts/test-concurrent-git.sh       counterpart exists, guard not added yet
+#   scripts/setup-worktrees.sh           counterpart exists, guard pending (#310)
+#   scripts/test-concurrent-git.sh       counterpart exists, guard pending (#310)
 GUARDED=(
     "scripts/install.sh|install.ps1"
     "scripts/claude-docker|claude-docker.ps1"


### PR DESCRIPTION
Closes #306

## Summary

`generate-compose.sh`, `cleanup.sh`, and `remove.sh` now carry the same native-Windows platform guard as `install.sh` and `claude-docker`, so they refuse on Git Bash / MSYS / Cygwin and name the PowerShell script to use instead.

`generate-compose.sh` was the one that failed misleadingly. Windows `jq` writes stdout in text mode, so the runtime-registry read returned `claude\r` and `agent_runtime` rejected a correctly-registered runtime with `Error: AGENT_RUNTIME is not a known runtime (got: claude)` -- an error naming the user's `.env` when nothing about it was wrong. Each guard sits ahead of the first registry read, so that path is no longer reachable.

On the open question of whether `runtime_list` / `runtime_field` should strip `\r`: **no**, recorded in the `scripts/lib/runtime.sh` header. Both routes a CR could take are now closed -- the Windows `jq` text-mode path exists only in a native Windows shell, which every bash reader of the registry now refuses to run on, and the registry file itself cannot carry CR because `.gitattributes` pins `*.json` to `eol=lf`. A `tr -d '\r'` would defend against nothing reachable while masking the signal that a caller is on an unsupported path.

## Test Plan

`tests/test_windows_platform_guard.sh` (new, wired into the `bash-tests` matrix) asserts, for all five guarded bash entry points: exit status 1, a message explaining the refusal, a message naming the correct `.ps1` counterpart, and that no runtime-registry read happened.

The guard cannot be observed on a Linux runner, so `uname` is shadowed on PATH by a stub reporting a Git Bash kernel name, and a `jq` stub beside it records whether the registry was read. That last stub is what makes "the refusal happens before any registry read" an executable assertion rather than a claim about line ordering.

Verified both directions on Linux containers:

| Check | Result |
|-------|--------|
| Guard test, unmodified tree | 22/22 pass |
| Mutation: guard deleted from `generate-compose.sh` | 3 assertions red, including the registry-read one |
| Mutation: guard kept, message names the wrong counterpart | exactly 1 assertion red |
| `shellcheck -e SC1091 -S warning` on all edited scripts | clean |
| Existing bash tests (6) | pass |
| `compose-freshness` gate from #305 | no drift |

The `exit 1` assertion alone passes even with the guard deleted, because the `jq` stub makes the script fail anyway -- which is why the other three assertions exist.

The covered scripts are an explicit list rather than a glob over `scripts/*.sh`, so adding an entry point forces a decision to include or exclude it. That drift is how this defect arose: #146 guarded two scripts and the next three were never revisited.

## Follow-up

#310 -- the same gap remains on `setup-worktrees.sh` and `test-concurrent-git.sh` (bash), and symmetrically on `generate-compose.ps1`, `cleanup.ps1`, `remove.ps1`, and `setup-worktrees.ps1`, which have no non-Windows PowerShell guard. #146 guarded the installer and CLI wrapper on both sides; the lifecycle scripts were missed on both.

The `README.md` "Do not cross platforms" paragraph is updated here rather than deferred, because this change is what made it incomplete: it named only the two installers while the guard now covers five bash scripts.
