### PR TITLE
fix(scripts): honor NUM_ACCOUNTS and IMAGE_TAG from the environment in generate-compose.ps1

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,11 +600,13 @@ All state is preserved across container restarts via Docker volume mounts:
 ## Compose Overrides
 
 All compose files are **generated** by `scripts/generate-compose.sh` (or `.ps1`)
-based on `NUM_ACCOUNTS` in `.env`. Do not edit them manually.
+based on `NUM_ACCOUNTS`, which both generators read from the environment first
+and then from `.env`. Do not edit them manually.
 
 They are nonetheless **tracked in Git** as the committed source of truth, so
 what is committed has to match generator output. The committed copies represent
-the generator defaults with no `.env` present:
+the generator defaults with no `.env` present and none of these set in the
+environment:
 
 | Setting | Value | Source |
 |---------|-------|--------|

--- a/scripts/generate-compose.ps1
+++ b/scripts/generate-compose.ps1
@@ -33,9 +33,26 @@ if (Test-Path $envFile) {
     $envData = Read-EnvFile -Path $envFile
 }
 
+# Resolve a configuration value the way the bash generator does: a value already
+# present in the caller's environment wins over the .env entry, which wins over
+# the built-in default. parse_env.sh states that rule for load_env_file, and
+# generate-compose.sh inherits it for every value it reads.
+function Resolve-EnvOrDefault([string]$Key, [string]$Default) {
+    $val = [Environment]::GetEnvironmentVariable($Key)
+    if (-not [string]::IsNullOrEmpty($val)) { return $val }
+    if ($envData.ContainsKey($Key) -and -not [string]::IsNullOrEmpty($envData[$Key])) {
+        return $envData[$Key]
+    }
+    return $Default
+}
+
+# NUM_ACCOUNTS and IMAGE_TAG are also exposed as parameters, so an explicit
+# argument outranks that chain. Until #315 these two skipped the environment
+# step entirely and consulted .env alone, so NUM_ACCOUNTS=5 in the environment
+# produced two services here while generate-compose.sh produced five.
 if ($NumAccounts -eq 0) {
-    $fromEnv = $envData['NUM_ACCOUNTS']
-    if ($fromEnv -and $fromEnv -match '^\d+$') {
+    $fromEnv = Resolve-EnvOrDefault 'NUM_ACCOUNTS' ''
+    if ($fromEnv -match '^\d+$') {
         $NumAccounts = [int]$fromEnv
     } else {
         $NumAccounts = 2
@@ -43,10 +60,8 @@ if ($NumAccounts -eq 0) {
 }
 
 if ([string]::IsNullOrEmpty($ImageTag)) {
-    $fromEnv = $envData['IMAGE_TAG']
-    if ($fromEnv) {
-        $ImageTag = $fromEnv
-    } else {
+    $ImageTag = Resolve-EnvOrDefault 'IMAGE_TAG' ''
+    if ([string]::IsNullOrEmpty($ImageTag)) {
         # Fall back to the repo-root VERSION file — single source of truth
         # shared with install.ps1 and the "Bumping the Base Image" README
         # procedure. Final fallback is 'latest' if VERSION is absent.
@@ -101,14 +116,6 @@ $RtHostConfigBasename  = '.' + ($RtContainerConfigMount -split '\.')[-1]
 # Container resource envelope (override via .env or host env). Defaults
 # reproduce the historical hardcoded values so existing installs see no
 # behavior change after regenerating.
-function Resolve-EnvOrDefault([string]$Key, [string]$Default) {
-    $val = [Environment]::GetEnvironmentVariable($Key)
-    if (-not [string]::IsNullOrEmpty($val)) { return $val }
-    if ($envData.ContainsKey($Key) -and -not [string]::IsNullOrEmpty($envData[$Key])) {
-        return $envData[$Key]
-    }
-    return $Default
-}
 $CpuLimit       = Resolve-EnvOrDefault 'CONTAINER_CPU_LIMIT' '2'
 $CpuReservation = Resolve-EnvOrDefault 'CONTAINER_CPU_RESERVATION' '1'
 $MemLimit       = Resolve-EnvOrDefault 'CONTAINER_MEM_LIMIT' '4G'


### PR DESCRIPTION
Closes #315

## Summary

`generate-compose.ps1` resolved `NUM_ACCOUNTS` and `IMAGE_TAG` from `.env` alone, while `generate-compose.sh` reads the caller's environment first. The two generators therefore produced different compose files from the same environment, with no error on either side.

Both now resolve through `Resolve-EnvOrDefault`, which already implemented the environment-then-`.env` precedence for the container resource envelope in this same file. Its definition moves above the first use. An explicit script parameter still outranks both sources.

## What was measured

Both generators were run inside a container providing bash and pwsh, against a sandbox holding only the files they read, so no run touched the committed compose files.

Before:

| Input | bash | pwsh |
|-------|------|------|
| `NUM_ACCOUNTS=5`, no `.env` | 5 services | 2 services |
| `NUM_ACCOUNTS=5` in env, `2` in `.env` | 5 services | 2 services |
| `IMAGE_TAG=probe-tag`, no `.env` | `probe-tag` | `2026.04.17` (the VERSION file) |

Every other configuration value already agreed on both paths: the `CONTAINER_*` resource envelope, `AGENT_RUNTIME`, and per-account `CLAUDE_API_KEY_<letter>`. The two divergent values were exactly the two exposed as script parameters.

## Test Plan

The verification is not committed here. The repository-resident equivalence guard is #316, which this PR unblocks; adding a second one now would duplicate it. What ran in this session:

| Check | Result |
|-------|--------|
| Environment-supplied values agree between generators | pass |
| Environment beats `.env`, matching bash | pass |
| An explicit parameter beats both environment and `.env` | pass |
| The four `.env` fixtures (claude, codex, gemini, 5 accounts) still agree byte-for-byte | pass |

10 assertions, 0 failures. Each was mutation-tested rather than assumed load-bearing:

| Mutation | Assertions turned red |
|----------|:---:|
| Revert the `NUM_ACCOUNTS` resolution | 2 |
| Revert the `IMAGE_TAG` resolution | 2 |
| Drop the parameter-precedence check | 1 |

Every mutation was verified to have actually applied before its result was read, and the suite returned to green after each was reverted.

## Also in this PR

`README.md`: the Compose Overrides section described `NUM_ACCOUNTS` as coming from `.env`, which understated both generators, not just the PowerShell one.

## Out of scope, filed separately

#317 records a precedence split the gap audit surfaced: the CLI wrappers (`get_num_accounts` in `scripts/claude-docker`, `Get-NumAccounts` in `ClaudeDocker.psm1`) read `.env` only, so they disagree with the generators. This pre-existed on the bash side; the change here made it symmetric across the two languages rather than creating it. Which layer should move is a design decision, not a mechanical fix.
