### PR TITLE
test(compose): guard bash-vs-PowerShell generator equivalence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,7 @@ jobs:
           - tests/test_parse_env.sh
           - tests/test_parse_env_equivalence.sh
           - tests/test_runtime_registry_equivalence.sh
+          - tests/test_compose_generator_equivalence.sh
           - tests/test_agent_attach_argv.sh
           - tests/test_transform_syntax_check.sh
           - tests/test_cleanup_backups.sh

--- a/tests/env_fixtures/README.md
+++ b/tests/env_fixtures/README.md
@@ -4,6 +4,12 @@ Used by `.github/workflows/ci.yml` `compose-validate` matrix. Each `*.env` file
 is copied to the repo root as `.env`, then `scripts/generate-compose.sh` and
 `docker compose config` run against it.
 
+`tests/test_compose_generator_equivalence.sh` is a second consumer: it stages
+`minimal`, `codex`, `gemini` and `n5` into throwaway sandboxes and asserts the
+bash and PowerShell generators produce the same files. It adds one input the
+table below cannot express — `NUM_ACCOUNTS` and `IMAGE_TAG` supplied through the
+environment instead of a `.env` file, which is the path #315 fixed.
+
 | Fixture | Exercises |
 |---------|-----------|
 | `minimal.env` | Default 2-account Tier A setup without API keys |

--- a/tests/test_compose_generator_equivalence.sh
+++ b/tests/test_compose_generator_equivalence.sh
@@ -42,13 +42,17 @@ OUTPUTS=(docker-compose.yml docker-compose.worktree.yml docker-compose.linux.yml
 # minimal/codex/gemini cover the runtime-conditional branches (the claude
 # baseline with its CLAUDE_NORMALIZE_CRLF line, the codex mountsAgentsSkills
 # extra volume, and gemini's configDirEnvValue decoupled from
-# containerConfigMount). n5 covers multi-account letter enumeration.
-# env-override covers the environment path that #315 fixed.
+# containerConfigMount). n5 covers multi-account letter enumeration and n30 its
+# two-letter regime -- scripts/lib/index.ps1 says it "mirrors" index.sh, so the
+# Excel-style enumeration added by #178 is two independent implementations and
+# n5 alone would only ever compare single letters. env-override covers the
+# environment path that #315 fixed.
 FIXTURES=(
     "minimal|minimal.env|"
     "codex|codex.env|"
     "gemini|gemini.env|"
     "n5|n5.env|"
+    "n30|n30.env|"
     "env-override|-|NUM_ACCOUNTS=5 IMAGE_TAG=probe-tag"
 )
 

--- a/tests/test_compose_generator_equivalence.sh
+++ b/tests/test_compose_generator_equivalence.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# test_compose_generator_equivalence.sh -- Verify scripts/generate-compose.sh
+# and scripts/generate-compose.ps1 emit identical compose files for the same
+# input.
+#
+# #243 aligned the two generators once; nothing kept them aligned. The
+# `Compose files are current` job added by #305 regenerates with the *bash*
+# generator only, so PowerShell-side drift leaves CI green and only Windows
+# users regenerate to something different. This test closes that gap the way
+# test_parse_env_equivalence.sh and test_runtime_registry_equivalence.sh
+# already guard their cross-language readers of a shared input.
+#
+# The fixture axis matters as much as the runtime axis. Configuration reaches a
+# generator two ways -- through `.env` and through the caller's environment --
+# and the four `.env` fixtures below agreed byte-for-byte even while the
+# environment path did not (#315). A `.env`-only fixture set would therefore
+# have passed on day one and missed that defect entirely, which is why
+# `env-override` is here.
+#
+# Both generators write into their own project root, so every run gets a
+# throwaway sandbox holding only the files a generator reads. Running them in
+# the repository would overwrite the committed compose files -- the trap
+# tests/test_windows_platform_guard.sh had to avoid.
+#
+# Line endings are normalized before comparison. On Windows the PowerShell
+# generator's StringBuilder appends [Environment]::NewLine (CRLF) while bash
+# emits LF; that is a property of the host running the test rather than drift
+# between the generators, and the axis under test here is content.
+#
+# Run:  bash tests/test_compose_generator_equivalence.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+FIXTURE_DIR="$PROJECT_ROOT/tests/env_fixtures"
+OUTPUTS=(docker-compose.yml docker-compose.worktree.yml docker-compose.linux.yml)
+
+# name | .env fixture basename ('-' for no .env) | environment assignments
+#
+# minimal/codex/gemini cover the runtime-conditional branches (the claude
+# baseline with its CLAUDE_NORMALIZE_CRLF line, the codex mountsAgentsSkills
+# extra volume, and gemini's configDirEnvValue decoupled from
+# containerConfigMount). n5 covers multi-account letter enumeration.
+# env-override covers the environment path that #315 fixed.
+FIXTURES=(
+    "minimal|minimal.env|"
+    "codex|codex.env|"
+    "gemini|gemini.env|"
+    "n5|n5.env|"
+    "env-override|-|NUM_ACCOUNTS=5 IMAGE_TAG=probe-tag"
+)
+
+PASS=0
+FAIL=0
+
+# pwsh is preinstalled on ubuntu-latest runners; require it in CI. Unlike
+# test_runtime_registry_equivalence.sh there is no bash-only leg worth running
+# on its own here -- without pwsh there is nothing to compare -- so a dev host
+# without PowerShell skips the whole test rather than reporting a hollow pass.
+if ! command -v pwsh >/dev/null 2>&1; then
+    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+        echo "FAIL: pwsh unavailable in CI (was preinstalled on ubuntu-latest)" >&2
+        exit 1
+    fi
+    echo "NOTE: pwsh not installed locally; skipping generator equivalence" >&2
+    echo "== Summary: SKIPPED (pwsh unavailable) =="
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Digest of the committed compose files, sampled before and after the run. The
+# sandbox already makes it structurally impossible to touch them; this makes
+# that observable, so a future edit that reintroduces an in-repo generator run
+# fails here instead of silently rewriting the working tree.
+compose_digest() {
+    local f
+    for f in "${OUTPUTS[@]}"; do
+        if [[ -f "$PROJECT_ROOT/$f" ]]; then
+            cksum <"$PROJECT_ROOT/$f"
+        else
+            echo "absent $f"
+        fi
+    done
+}
+
+DIGEST_BEFORE="$(compose_digest)"
+
+# make_sandbox NAME -- create a project root containing only what a generator
+# reads and echo its path. scripts/ is copied wholesale rather than enumerated
+# so the sandbox stays correct when a new lib module is added.
+make_sandbox() {
+    local dir="$WORK/$1"
+    mkdir -p "$dir/tui/internal/config"
+    cp -r "$PROJECT_ROOT/scripts" "$dir/scripts"
+    cp "$PROJECT_ROOT/tui/internal/config/runtimes.json" "$dir/tui/internal/config/"
+    if [[ -f "$PROJECT_ROOT/VERSION" ]]; then
+        cp "$PROJECT_ROOT/VERSION" "$dir/"
+    fi
+    printf '%s' "$dir"
+}
+
+# stage_and_run SANDBOX ENVFILE ASSIGNS LANG
+# NUM_ACCOUNTS and IMAGE_TAG are unset for every run before ASSIGNS is applied,
+# so a value left in the developer's shell cannot silently change what a
+# fixture means.
+stage_and_run() {
+    local dir="$1" envfile="$2" assigns="$3" lang="$4"
+    if [[ "$envfile" != "-" ]]; then
+        cp "$FIXTURE_DIR/$envfile" "$dir/.env"
+    fi
+    local rc=0
+    if [[ "$lang" == "bash" ]]; then
+        # shellcheck disable=SC2086  # assigns is a deliberate word-split list
+        env -u NUM_ACCOUNTS -u IMAGE_TAG $assigns \
+            bash "$dir/scripts/generate-compose.sh" >"$dir/.gen.log" 2>&1 || rc=$?
+    else
+        # shellcheck disable=SC2086  # assigns is a deliberate word-split list
+        env -u NUM_ACCOUNTS -u IMAGE_TAG $assigns \
+            pwsh -NoProfile -File "$dir/scripts/generate-compose.ps1" >"$dir/.gen.log" 2>&1 || rc=$?
+    fi
+    return "$rc"
+}
+
+for entry in "${FIXTURES[@]}"; do
+    IFS='|' read -r name envfile assigns <<<"$entry"
+    echo "== $name =="
+
+    bash_dir="$(make_sandbox "$name-bash")"
+    pwsh_dir="$(make_sandbox "$name-pwsh")"
+
+    brc=0; stage_and_run "$bash_dir" "$envfile" "$assigns" bash || brc=$?
+    prc=0; stage_and_run "$pwsh_dir" "$envfile" "$assigns" pwsh || prc=$?
+
+    if [[ "$brc" -ne 0 || "$prc" -ne 0 ]]; then
+        printf '  FAIL  %s: generator exited non-zero (bash=%d pwsh=%d)\n' "$name" "$brc" "$prc"
+        sed 's/^/        /' "$bash_dir/.gen.log" "$pwsh_dir/.gen.log" || true
+        FAIL=$((FAIL + 1))
+        continue
+    fi
+
+    # Equivalence alone cannot catch a regression that makes *both* generators
+    # ignore an input: two identically-wrong outputs still match. env-override
+    # exists precisely because that path was broken (#315), so anchor it. If the
+    # environment stopped reaching either generator this fixture would otherwise
+    # keep passing while covering nothing.
+    if [[ "$name" == "env-override" ]]; then
+        services=$(grep -c '^    image: claude-code-base:' "$bash_dir/docker-compose.yml" || true)
+        if [[ "$services" -eq 5 ]] && grep -q 'IMAGE_TAG:-probe-tag' "$bash_dir/docker-compose.yml"; then
+            printf '  PASS  %s: environment NUM_ACCOUNTS and IMAGE_TAG reached the output\n' "$name"
+            PASS=$((PASS + 1))
+        else
+            printf '  FAIL  %s: environment values did not reach the output (services=%s)\n' \
+                "$name" "$services"
+            grep -m1 'image: claude-code-base:' "$bash_dir/docker-compose.yml" | sed 's/^/        /' || true
+            FAIL=$((FAIL + 1))
+        fi
+    fi
+
+    for out in "${OUTPUTS[@]}"; do
+        if [[ ! -f "$bash_dir/$out" || ! -f "$pwsh_dir/$out" ]]; then
+            printf '  FAIL  %s/%s: not produced (bash=%s pwsh=%s)\n' "$name" "$out" \
+                "$([[ -f "$bash_dir/$out" ]] && echo yes || echo no)" \
+                "$([[ -f "$pwsh_dir/$out" ]] && echo yes || echo no)"
+            FAIL=$((FAIL + 1))
+            continue
+        fi
+        tr -d '\r' <"$bash_dir/$out" >"$WORK/lhs"
+        tr -d '\r' <"$pwsh_dir/$out" >"$WORK/rhs"
+        if diff -u --label "bash/$out" --label "pwsh/$out" "$WORK/lhs" "$WORK/rhs" >"$WORK/delta"; then
+            printf '  PASS  %s/%s\n' "$name" "$out"
+            PASS=$((PASS + 1))
+        else
+            printf '  FAIL  %s/%s\n' "$name" "$out"
+            sed 's/^/        /' "$WORK/delta"
+            FAIL=$((FAIL + 1))
+        fi
+    done
+done
+
+echo "== committed compose files =="
+if [[ "$(compose_digest)" == "$DIGEST_BEFORE" ]]; then
+    echo "  PASS  untouched by this run"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL  a generator ran outside its sandbox and rewrote them"
+    FAIL=$((FAIL + 1))
+fi
+
+echo
+printf '== Summary: PASS=%d FAIL=%d ==\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #316

## Summary

`tests/test_compose_generator_equivalence.sh` fails when `scripts/generate-compose.sh` and `scripts/generate-compose.ps1` produce different content for the same input, and is registered in the `bash-tests` CI matrix.

#243 aligned the two generators once and nothing kept them aligned. The `Compose files are current` job added by #305 regenerates with the bash generator only, so PowerShell-side drift leaves CI green and only Windows users regenerate to something different.

Each generator runs against a throwaway sandbox holding only the files it reads, so a run cannot rewrite the committed compose files. The test samples their digest before and after and asserts they are untouched, rather than relying on that being structurally true forever.

## Fixtures

| Fixture | Branch it exercises |
|---------|--------------------|
| `minimal` | claude baseline, including the `CLAUDE_NORMALIZE_CRLF` line |
| `codex` | `mountsAgentsSkills` extra volume |
| `gemini` | `configDirEnvValue` decoupled from `containerConfigMount` |
| `n5` | multi-account letter enumeration |
| `n30` | the two-letter regime of that enumeration |
| `env-override` | `NUM_ACCOUNTS` and `IMAGE_TAG` supplied through the environment |

`n30` is not in the issue's table; see "Gap audit" below.

`env-override` also carries a witness assertion. Equivalence alone cannot catch a regression that makes *both* generators ignore an input, since two identically-wrong outputs still match. That fixture exists because the environment path was broken (#315), so the test asserts the environment actually reached the output before comparing the two sides — otherwise the fixture could keep passing while covering nothing.

## Test Plan

20 assertions, 0 failures, run in a container providing bash and pwsh. The acceptance criterion asks for mutation rather than assertion, so each generator was perturbed independently and the resulting failure set recorded:

| Mutation | Assertions turned red | Which |
|----------|:---:|-------|
| M1 — bash emits a different `docker-compose.yml` header | 5 | every fixture, that file only |
| M2 — pwsh emits a different `docker-compose.worktree.yml` header | 5 | every fixture, that file only |
| M3 — pwsh drops the `mountsAgentsSkills` volume | 1 | `codex` only |
| M4 — pwsh reverts #315 and reads `NUM_ACCOUNTS` from `.env` alone | 3 | `env-override` only |
| M5 — off-by-one in `index.ps1`'s Excel enumeration | 3 | `n30` only |

Every mutation was verified to have actually applied before its result was read, and the working tree was verified clean after each revert.

The localization matters as much as the detection. M3, M4 and M5 each turn exactly one fixture red, which is what distinguishes fixtures aimed at distinct branches from a suite that merely breaks whenever anything moves. M4 is the direct evidence for the issue's premise: reverting #315 leaves all four `.env` fixtures green and reddens only `env-override`, so a fixture set drawn from `.env` alone would indeed have missed that defect.

## Gap audit

Adding `n30` came out of the pre-PR gap audit rather than the issue text. `scripts/lib/index.ps1` documents itself as mirroring `scripts/lib/index.sh`, so the Excel-style enumeration added by #178 is two independent implementations, and no cross-language test covered it — `test_parse_env_equivalence.sh` and `test_runtime_registry_equivalence.sh` guard different axes. `n5` only ever compares single letters, so the regime where such a mirror typically diverges was the one place this guard would have stayed silent. M5 confirms the fixture is load-bearing. No divergence exists today.

## Line endings

Output is compared after stripping CR. On Windows the PowerShell generator's `StringBuilder` appends `[Environment]::NewLine` while bash emits LF; that is a property of the host running the test, not drift between the generators, and the axis under test here is content. The test therefore does not guard line endings.
