### PR TITLE
fix(scripts): reconcile NUM_ACCOUNTS precedence between the generators and the CLI wrappers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
           - tests/test_parse_env_equivalence.sh
           - tests/test_runtime_registry_equivalence.sh
           - tests/test_compose_generator_equivalence.sh
+          - tests/test_num_accounts_precedence.sh
           - tests/test_agent_attach_argv.sh
           - tests/test_transform_syntax_check.sh
           - tests/test_cleanup_backups.sh

--- a/README.md
+++ b/README.md
@@ -600,8 +600,9 @@ All state is preserved across container restarts via Docker volume mounts:
 ## Compose Overrides
 
 All compose files are **generated** by `scripts/generate-compose.sh` (or `.ps1`)
-based on `NUM_ACCOUNTS`, which both generators read from the environment first
-and then from `.env`. Do not edit them manually.
+based on `NUM_ACCOUNTS`, resolved as described under
+[`NUM_ACCOUNTS` precedence](#num_accounts-precedence) below. Do not edit them
+manually.
 
 They are nonetheless **tracked in Git** as the committed source of truth, so
 what is committed has to match generator output. The committed copies represent
@@ -621,6 +622,34 @@ is expected, but do not commit the result — restore the committed copies first
 ```bash
 git checkout -- docker-compose.yml docker-compose.linux.yml docker-compose.worktree.yml
 ```
+
+### `NUM_ACCOUNTS` precedence
+
+Every shell-side reader resolves `NUM_ACCOUNTS` the same way: **an exported
+environment variable wins, then `.env`, then the built-in default of `2`.** This
+is the rule `scripts/lib/parse_env.sh` documents for `load_env_file`, and the one
+`AGENT_RUNTIME` has always followed in both languages.
+
+| Reader | Decides |
+|--------|---------|
+| `scripts/generate-compose.sh`, `scripts/generate-compose.ps1` | how many services get written |
+| `get_num_accounts` in `scripts/claude-docker` | which services the CLI acts on |
+| `Get-NumAccounts` in `scripts/ClaudeDocker.psm1` | the same, on Windows |
+
+The first source holding a **non-empty** value wins even if that value is
+unusable: an exported `NUM_ACCOUNTS=abc` does not fall through to `.env`. What
+happens next differs by layer on purpose. The generators abort, because they
+write files that CI then checks. The CLI wrappers fall back to `2`, because
+listing the default pair beats refusing to print a service list.
+
+The TUI dashboard sits outside this rule by design. `Env.NumAccounts()` in
+`tui/internal/config/env.go` reads `.env` alone, because `Env` is the document
+the TUI edits and writes back, and it treats the value as a floor rather than an
+exact count: `discoverStateDirs` raises it to cover any account state directory
+it finds on disk.
+
+`tests/test_num_accounts_precedence.sh` pins all four shell-side readers to the
+table above and runs in the `Bash Tests` CI matrix.
 
 | File | Purpose | When active |
 |------|---------|-------------|

--- a/scripts/ClaudeDocker.psm1
+++ b/scripts/ClaudeDocker.psm1
@@ -299,17 +299,29 @@ function Set-EnvValue {
 function Get-NumAccounts {
     <#
     .SYNOPSIS
-    Read NUM_ACCOUNTS from .env (default: 2).
+    Resolve NUM_ACCOUNTS: environment, then .env, then 2.
+    .DESCRIPTION
+    Mirrors get_num_accounts in scripts/claude-docker and the order both
+    compose generators use (#317). Get-AgentRuntime below already resolved
+    AGENT_RUNTIME this way; NUM_ACCOUNTS was the one value that did not.
+
+    The first source holding a non-empty value wins even if that value is
+    invalid, so an exported NUM_ACCOUNTS=abc does not fall through to .env.
+    An unusable value yields the default rather than an error, because the
+    callers enumerate services for display.
     #>
     [CmdletBinding()]
     param([Parameter(Mandatory)][string]$ProjectRoot)
 
-    $envFile = Join-Path $ProjectRoot '.env'
-    if (Test-Path $envFile) {
-        $envData = Read-EnvFile -Path $envFile
-        $n = $envData['NUM_ACCOUNTS']
-        if ($n -and $n -match '^\d+$') { return [int]$n }
+    $n = [Environment]::GetEnvironmentVariable('NUM_ACCOUNTS')
+    if ([string]::IsNullOrWhiteSpace($n)) {
+        $envFile = Join-Path $ProjectRoot '.env'
+        if (Test-Path $envFile) {
+            $envData = Read-EnvFile -Path $envFile
+            $n = $envData['NUM_ACCOUNTS']
+        }
     }
+    if ($n -match '^\d+$' -and [int]$n -ge 1) { return [int]$n }
     return 2
 }
 

--- a/scripts/claude-docker
+++ b/scripts/claude-docker
@@ -89,11 +89,27 @@ get_primary_service() {
 
 # --- Account Helpers ----------------------------------------------------------
 
-# Read NUM_ACCOUNTS from .env (default: 2)
+# Resolve NUM_ACCOUNTS: environment, then .env, then 2.
+#
+# Same order as agent_runtime() in lib/runtime.sh and as both compose
+# generators (#317). The first source holding a non-empty value wins even if
+# that value is invalid, so an exported NUM_ACCOUNTS=abc does not silently
+# fall through to .env.
+#
+# An unusable value falls back to the default instead of aborting: this feeds
+# service enumeration for read-only commands like `help`, where printing the
+# default pair beats printing nothing. The generators do abort, because they
+# write files. Reading the environment is what makes the guard necessary --
+# until #317 only .env could reach this function.
 get_num_accounts() {
-    local n
-    n=$(parse_env_value "${PROJECT_ROOT}/.env" "NUM_ACCOUNTS")
-    echo "${n:-2}"
+    local n="${NUM_ACCOUNTS:-}"
+    if [[ -z "$n" && -n "${PROJECT_ROOT:-}" ]]; then
+        n=$(parse_env_value "${PROJECT_ROOT}/.env" "NUM_ACCOUNTS")
+    fi
+    if [[ ! "$n" =~ ^[0-9]+$ ]] || (( n < 1 )); then
+        n=2
+    fi
+    printf '%s' "$n"
 }
 
 # Back-compat alias: claude-docker historically exposed the underscore

--- a/tests/test_num_accounts_precedence.sh
+++ b/tests/test_num_accounts_precedence.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# test_num_accounts_precedence.sh -- Pin every shell-side NUM_ACCOUNTS reader to
+# one precedence: environment, then .env, then the default of 2.
+#
+# Four readers resolve this value independently, in two languages and two
+# layers. Until #317 the two generators consulted the environment and the two
+# CLI wrappers did not, so exporting NUM_ACCOUNTS=5 and regenerating wrote five
+# services while `claude-docker` kept enumerating two -- commands that iterate
+# accounts silently skipped services that existed.
+#
+# The test asserts each reader against an expected value rather than only
+# against the other three. Agreement alone is satisfied by four readers that are
+# wrong together, and the whole point of the fixture set is the one row where
+# they used to disagree.
+#
+# Scope: precedence, with values every reader accepts. Invalid-value handling is
+# deliberately outside it, because the two layers differ there by design -- the
+# generators abort (they write files) while the CLI wrappers fall back to the
+# default (they enumerate services for display). The generators also differ from
+# each other on that axis, which is filed separately.
+#
+# The TUI is a fifth reader and is deliberately not covered. Env.NumAccounts()
+# in tui/internal/config/env.go reads .env alone because Env is the document the
+# TUI edits and writes back, and it treats the value as a floor rather than an
+# exact count -- discoverStateDirs raises it to cover state directories found on
+# disk. See the README's Compose Overrides section.
+#
+# Both generators write compose files into the project root they derive from
+# their own location, so every reader runs against a throwaway sandbox holding
+# only the files it reads. The repository checkout is never written to; the
+# committed compose files are digest-checked at the end to prove it.
+#
+# Run:  bash tests/test_num_accounts_precedence.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+# pwsh carries two of the four readers, so a run without it compares nothing
+# worth comparing. Locally that is a skip; in CI it is a failure, because the
+# bash-tests matrix runs on a runner that ships pwsh and a silent skip there
+# would look identical to a pass.
+if ! command -v pwsh >/dev/null 2>&1; then
+    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+        echo "FAIL: pwsh unavailable in CI (was preinstalled on ubuntu-latest)" >&2
+        exit 1
+    fi
+    echo "NOTE: pwsh not installed locally; skipping NUM_ACCOUNTS precedence" >&2
+    echo "== Summary: SKIPPED (pwsh unavailable) =="
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# name | .env NUM_ACCOUNTS ('-' for no .env file) | environment ('-' for unset) | expected
+#
+# Row 4 is the discriminating one: it is the only row where the two sources
+# disagree, so it is the only row the pre-#317 CLI wrappers failed. Rows 1-3
+# passed before this change and still do, which is what keeps a regression in
+# the default or the .env path visible instead of being masked.
+SCENARIOS=(
+    "neither|-|-|2"
+    "dotenv-only|3|-|3"
+    "env-only|-|5|5"
+    "env-wins|3|5|5"
+)
+
+# Stage a sandbox holding only what a reader reads: the scripts tree, the
+# runtime registry (resolved relative to the project root), and VERSION (the
+# generators' IMAGE_TAG fallback).
+make_sandbox() {
+    local dir="$WORK/$1"
+    mkdir -p "$dir/tui/internal/config"
+    cp -r "$PROJECT_ROOT/scripts" "$dir/scripts"
+    cp "$PROJECT_ROOT/tui/internal/config/runtimes.json" "$dir/tui/internal/config/"
+    if [[ -f "$PROJECT_ROOT/VERSION" ]]; then
+        cp "$PROJECT_ROOT/VERSION" "$dir/"
+    fi
+    if [[ "$2" != "-" ]]; then
+        printf 'NUM_ACCOUNTS=%s\n' "$2" > "$dir/.env"
+    fi
+    printf '%s' "$dir"
+}
+
+# Run a command with NUM_ACCOUNTS either exported or removed, and with
+# AGENT_RUNTIME always removed so the host environment cannot change which
+# service prefix the readers enumerate.
+run_with_env() {
+    local envval="$1"
+    shift
+    if [[ "$envval" == "-" ]]; then
+        env -u NUM_ACCOUNTS -u AGENT_RUNTIME "$@"
+    else
+        env -u AGENT_RUNTIME "NUM_ACCOUNTS=$envval" "$@"
+    fi
+}
+
+# Count generated services. Every service carries exactly one `image:` line.
+count_services() {
+    grep -c '^    image: claude-code-base:' "$1/docker-compose.yml" 2>/dev/null || echo 0
+}
+
+# --- The four readers ---------------------------------------------------------
+# Each returns the account count it resolved, or the empty string if the probe
+# itself failed. Probing through the real entrypoints keeps the resolution
+# path honest: nothing here reimplements the precedence it is checking.
+
+# `help` prints "SERVICES (N configured)" from get_num_accounts and needs no
+# Docker daemon.
+read_bash_cli() {
+    local dir="$1" envval="$2" out
+    out=$(run_with_env "$envval" bash "$dir/scripts/claude-docker" help 2>/dev/null)
+    printf '%s' "$out" | sed -n 's/.*SERVICES (\([0-9][0-9]*\) configured).*/\1/p' | head -n1
+}
+
+read_pwsh_cli() {
+    local dir="$1" envval="$2"
+    run_with_env "$envval" pwsh -NoProfile -Command \
+        "Import-Module '$dir/scripts/ClaudeDocker.psm1' -Force; (Get-NumAccounts -ProjectRoot '$dir')" \
+        2>/dev/null | tr -d '\r' | head -n1
+}
+
+read_bash_gen() {
+    local dir="$1" envval="$2"
+    run_with_env "$envval" bash "$dir/scripts/generate-compose.sh" >/dev/null 2>&1 || return 0
+    count_services "$dir"
+}
+
+read_pwsh_gen() {
+    local dir="$1" envval="$2"
+    run_with_env "$envval" pwsh -NoProfile -File "$dir/scripts/generate-compose.ps1" >/dev/null 2>&1 || return 0
+    count_services "$dir"
+}
+
+# Digest the committed compose files so the closing assertion can prove no
+# reader wrote into the checkout.
+OUTPUTS=(docker-compose.yml docker-compose.worktree.yml docker-compose.linux.yml)
+compose_digest() {
+    local f
+    for f in "${OUTPUTS[@]}"; do
+        if [[ -f "$PROJECT_ROOT/$f" ]]; then
+            cksum <"$PROJECT_ROOT/$f"
+        else
+            echo "absent $f"
+        fi
+    done
+}
+DIGEST_BEFORE="$(compose_digest)"
+
+check() {
+    local scenario="$1" reader="$2" got="$3" want="$4"
+    if [[ "$got" == "$want" ]]; then
+        printf '  PASS  %-12s %-10s -> %s\n' "$scenario" "$reader" "$got"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL  %-12s %-10s -> %s (expected %s)\n' \
+            "$scenario" "$reader" "${got:-<probe failed>}" "$want"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "== NUM_ACCOUNTS precedence: environment > .env > 2 =="
+
+for row in "${SCENARIOS[@]}"; do
+    IFS='|' read -r name dotenv envval want <<<"$row"
+
+    printf '\n-- %s (.env=%s, environment=%s, expected %s)\n' \
+        "$name" "$dotenv" "$envval" "$want"
+
+    # The CLI readers write nothing, so they share one sandbox. Each generator
+    # gets its own, because both write the same three filenames.
+    cli_dir=$(make_sandbox "${name}-cli" "$dotenv")
+    check "$name" "bash-cli"  "$(read_bash_cli "$cli_dir" "$envval")"  "$want"
+    check "$name" "pwsh-cli"  "$(read_pwsh_cli "$cli_dir" "$envval")"  "$want"
+
+    bgen_dir=$(make_sandbox "${name}-gen-bash" "$dotenv")
+    check "$name" "bash-gen"  "$(read_bash_gen "$bgen_dir" "$envval")"  "$want"
+
+    pgen_dir=$(make_sandbox "${name}-gen-pwsh" "$dotenv")
+    check "$name" "pwsh-gen"  "$(read_pwsh_gen "$pgen_dir" "$envval")"  "$want"
+done
+
+printf '\n-- checkout untouched\n'
+if [[ "$(compose_digest)" == "$DIGEST_BEFORE" ]]; then
+    echo "  PASS  committed compose files unchanged"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL  a reader wrote into the repository checkout"
+    FAIL=$((FAIL + 1))
+fi
+
+printf '\n== Summary: %d passed, %d failed ==\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #317

## Summary

`NUM_ACCOUNTS` now resolves the same way in all four shell-side readers:
**environment, then `.env`, then `2`.** The two CLI wrappers move; the two
generators already did this.

The issue framed this as a choice between two layers. Reading the code made it a
one-sided one. `agent_runtime()` in `scripts/lib/runtime.sh` and
`Get-AgentRuntime` in `scripts/ClaudeDocker.psm1` already resolve `AGENT_RUNTIME`
as environment then `.env` then default, and they sit in the *same CLI layer* as
`get_num_accounts` and `Get-NumAccounts` -- eight lines away, in one case. So the
split was never "generator layer vs CLI layer"; it was `NUM_ACCOUNTS` being the
single value that did not follow a convention `parse_env.sh` documents for
`load_env_file` and that every other value already followed. Moving the
generators to `.env`-only would have meant making three readers wrong to match
one.

Reading the environment opens a new path for unusable values to reach service
enumeration, so both wrappers now guard the result and fall back to `2`. They do
not abort the way the generators do: the generators write files that CI checks,
while the wrappers enumerate services for display, where printing the default
pair beats printing nothing.

## Test Plan

`tests/test_num_accounts_precedence.sh`, added to the `Bash Tests` matrix. Four
scenarios across the full precedence truth table, four readers each, plus a
digest assertion that no reader wrote into the checkout: **17 assertions, 0
failures**.

Each reader is probed through its real entrypoint -- `claude-docker help` for
`get_num_accounts`, the exported module function for `Get-NumAccounts`, and a
service count from the generated file for each generator. Nothing here
reimplements the precedence it checks.

The test asserts each reader against an **expected value**, not only against the
other three. Mutual agreement is satisfied by four readers that are wrong
together, and the whole point of the fixture set is the one row where they used
to disagree.

Five mutations, each verified to have actually applied before its result was
read:

| Mutation | Assertions red | Which |
|----------|:---:|-------|
| bash CLI ignores the environment (pre-#317) | 2 | `bash-cli`, the two rows where the environment matters |
| pwsh CLI ignores the environment (pre-#317) | 2 | `pwsh-cli`, the same two rows |
| bash generator lets `.env` override the environment | 1 | `bash-gen`, `env-wins` only |
| pwsh generator reverts #315 to `.env` only | 2 | `pwsh-gen` |
| the `help` line the bash probe reads is renamed | 4 | `bash-cli` everywhere, as `<probe failed>` |

The first two reproduce the exact pre-change behavior and are caught. The last
one matters for a different reason: it shows that a broken probe fails loudly
instead of quietly reporting agreement it never measured.

Also run green: `test_compose_generator_equivalence.sh` (20),
`test_agent_attach_argv.sh` (9), `test_parse_env.sh` (21),
`test_parse_env_equivalence.sh` (44), `test_runtime_registry_equivalence.sh`
(70), `test_parse_env.ps1` (20). Shellcheck reports nothing on the new file.

## Notes

**The issue asked for a fixture in #316's guard instead of a new test.** That
guard compares generator against generator, so a fixture there cannot express
what a CLI wrapper thinks. Its existing `env-override` fixture already pins the
generator half of this precedence; the CLI half had no harness, which is what
this file adds.

**`scale` reads the environment now.** Both wrappers call the resolver before
writing the new count, only to display `Scaling: X -> Y` and to decide which
state directories to create. With `NUM_ACCOUNTS` exported, `X` is now the value
the generators used, so the CLI and the compose files agree on what "current"
means. That is the alignment the issue asked for, not a side effect of it.

**The TUI is a fifth reader and is deliberately unchanged.**
`Env.NumAccounts()` reads `.env` alone because `Env` is the document the TUI
edits and writes back, and it treats the value as a floor rather than an exact
count -- `discoverStateDirs` raises it to cover state directories found on disk.
The README now records the exemption rather than leaving it as a reader nobody
mentioned.

Two gaps found during the audit are filed rather than folded in, because each
needs a decision this issue did not make:

- #320 -- unusable values are handled three different ways. `NUM_ACCOUNTS=abc` kills the bash generator with `line 87: abc: unbound variable` before its own validation branch runs, while the PowerShell generator exits 0 with two services; and the wrappers accept `900` where the generators refuse it.
- #321 -- `ServiceNames()` in the TUI enumerates one service where the committed compose files define two.
