### PR TITLE
fix(scripts): align account count validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,8 +575,9 @@ The `scale` command automatically:
 Each additional container needs ~4 GB RAM (2 GB reserved, 4 GB limit).
 
 Account names follow Excel-style letters: 1→`a`, 26→`z`, 27→`aa`, 52→`az`,
-53→`ba`, ..., 702→`zz`. You can set `NUM_ACCOUNTS` up to 702, though host
-memory is usually the binding constraint well before then.
+53→`ba`, ..., 702→`zz`. The `scale` command and both compose generators accept
+`NUM_ACCOUNTS` values from 1 through 702, though host memory is usually the
+binding constraint well before then.
 
 On Windows (PowerShell):
 ```powershell
@@ -639,8 +640,10 @@ is the rule `scripts/lib/parse_env.sh` documents for `load_env_file`, and the on
 The first source holding a **non-empty** value wins even if that value is
 unusable: an exported `NUM_ACCOUNTS=abc` does not fall through to `.env`. What
 happens next differs by layer on purpose. The generators abort, because they
-write files that CI then checks. The CLI wrappers fall back to `2`, because
-listing the default pair beats refusing to print a service list.
+write files that CI then checks. The CLI wrappers warn and fall back to `2`,
+because listing the default pair beats refusing to print a service list. This
+applies to non-numeric values and integers outside the supported `1..702`
+range, so the wrappers never enumerate a topology the generators would reject.
 
 The TUI dashboard sits outside this rule by design. `Env.NumAccounts()` in
 `tui/internal/config/env.go` reads `.env` alone, because `Env` is the document

--- a/scripts/ClaudeDocker.psm1
+++ b/scripts/ClaudeDocker.psm1
@@ -307,22 +307,30 @@ function Get-NumAccounts {
 
     The first source holding a non-empty value wins even if that value is
     invalid, so an exported NUM_ACCOUNTS=abc does not fall through to .env.
-    An unusable value yields the default rather than an error, because the
-    callers enumerate services for display.
+    An unusable value emits a warning and yields the default rather than an
+    error, because the callers enumerate services for display.
     #>
     [CmdletBinding()]
     param([Parameter(Mandatory)][string]$ProjectRoot)
 
     $n = [Environment]::GetEnvironmentVariable('NUM_ACCOUNTS')
-    if ([string]::IsNullOrWhiteSpace($n)) {
+    if ([string]::IsNullOrEmpty($n)) {
         $envFile = Join-Path $ProjectRoot '.env'
         if (Test-Path $envFile) {
             $envData = Read-EnvFile -Path $envFile
             $n = $envData['NUM_ACCOUNTS']
         }
     }
-    if ($n -match '^\d+$' -and [int]$n -ge 1) { return [int]$n }
-    return 2
+    if ([string]::IsNullOrEmpty($n)) { return 2 }
+
+    $parsedNumAccounts = 0
+    if ($n -notmatch '^\d+$' -or
+        -not [int]::TryParse([string]$n, [ref]$parsedNumAccounts) -or
+        $parsedNumAccounts -lt 1 -or $parsedNumAccounts -gt 702) {
+        Write-Warning "NUM_ACCOUNTS must be an integer between 1 and 702 (got: $n); using default 2."
+        return 2
+    }
+    return $parsedNumAccounts
 }
 
 # --- Runtime registry --------------------------------------------------------

--- a/scripts/claude-docker
+++ b/scripts/claude-docker
@@ -96,18 +96,24 @@ get_primary_service() {
 # that value is invalid, so an exported NUM_ACCOUNTS=abc does not silently
 # fall through to .env.
 #
-# An unusable value falls back to the default instead of aborting: this feeds
-# service enumeration for read-only commands like `help`, where printing the
-# default pair beats printing nothing. The generators do abort, because they
-# write files. Reading the environment is what makes the guard necessary --
-# until #317 only .env could reach this function.
+# An unusable value emits a warning and falls back to the default instead of
+# aborting: this feeds service enumeration for read-only commands like `help`,
+# where printing the default pair beats printing nothing. The generators do
+# abort, because they write files. Reading the environment is what makes the
+# guard necessary -- until #317 only .env could reach this function.
 get_num_accounts() {
-    local n="${NUM_ACCOUNTS:-}"
+    local n="${NUM_ACCOUNTS:-}" raw_n
     if [[ -z "$n" && -n "${PROJECT_ROOT:-}" ]]; then
         n=$(parse_env_value "${PROJECT_ROOT}/.env" "NUM_ACCOUNTS")
     fi
-    if [[ ! "$n" =~ ^[0-9]+$ ]] || (( n < 1 )); then
+    if [[ -z "$n" ]]; then
         n=2
+    else
+        raw_n="$n"
+        if ! n=$(normalize_account_count "$raw_n"); then
+            log_warn "NUM_ACCOUNTS must be an integer between 1 and 702 (got: $raw_n); using default 2." >&2
+            n=2
+        fi
     fi
     printf '%s' "$n"
 }
@@ -507,11 +513,12 @@ cmd_update() {
 }
 
 cmd_scale() {
-    local new_count="${1:?Usage: claude-docker scale <N> (1-26)}"
+    local new_count="${1:?Usage: claude-docker scale <N> (1-702)}"
+    local raw_count="$new_count"
 
     # Validate
-    if ! [[ "$new_count" =~ ^[0-9]+$ ]] || [[ "$new_count" -lt 1 || "$new_count" -gt 26 ]]; then
-        log_error "Account count must be between 1 and 26 (got: $new_count)"
+    if ! new_count=$(normalize_account_count "$raw_count"); then
+        log_error "Account count must be between 1 and 702 (got: $raw_count)"
         exit 1
     fi
 
@@ -758,7 +765,7 @@ ${BOLD}USAGE TRACKING${NC}
   ${GREEN}build-tui${NC}             Rebuild TUI dashboard binary (requires Go 1.21+)
 
 ${BOLD}SCALING${NC}
-  ${GREEN}scale${NC} <N>             Set number of accounts (1-26) and regenerate
+  ${GREEN}scale${NC} <N>             Set number of accounts (1-702) and regenerate
 
 ${BOLD}ADVANCED${NC}
   ${GREEN}config${NC}                Show resolved compose configuration

--- a/scripts/claude-docker.ps1
+++ b/scripts/claude-docker.ps1
@@ -384,13 +384,16 @@ function Invoke-Update {
 
 function Invoke-Scale {
     if ($Arguments.Count -eq 0) {
-        Write-LogError 'Usage: claude-docker scale <N> (1-26)'
+        Write-LogError 'Usage: claude-docker scale <N> (1-702)'
         exit 1
     }
 
-    $newCount = [int]$Arguments[0]
-    if ($newCount -lt 1 -or $newCount -gt 26) {
-        Write-LogError "Account count must be between 1 and 26 (got: $newCount)"
+    $rawCount = $Arguments[0]
+    $newCount = 0
+    if ($rawCount -notmatch '^\d+$' -or
+        -not [int]::TryParse($rawCount, [ref]$newCount) -or
+        $newCount -lt 1 -or $newCount -gt 702) {
+        Write-LogError "Account count must be between 1 and 702 (got: $rawCount)"
         exit 1
     }
 
@@ -564,7 +567,7 @@ function Show-Help {
     Write-Host '                        Types: daily, monthly, session, blocks, statusline'
     Write-Host ''
     Write-Host 'SCALING' -ForegroundColor White
-    Write-Host '  scale <N>             ' -ForegroundColor Green -NoNewline; Write-Host 'Set number of accounts (1-26) and regenerate'
+    Write-Host '  scale <N>             ' -ForegroundColor Green -NoNewline; Write-Host 'Set number of accounts (1-702) and regenerate'
     Write-Host ''
     Write-Host 'ADVANCED' -ForegroundColor White
     Write-Host '  config                ' -ForegroundColor Green -NoNewline; Write-Host 'Show resolved compose configuration'

--- a/scripts/generate-compose.ps1
+++ b/scripts/generate-compose.ps1
@@ -52,10 +52,17 @@ function Resolve-EnvOrDefault([string]$Key, [string]$Default) {
 # produced two services here while generate-compose.sh produced five.
 if ($NumAccounts -eq 0) {
     $fromEnv = Resolve-EnvOrDefault 'NUM_ACCOUNTS' ''
-    if ($fromEnv -match '^\d+$') {
-        $NumAccounts = [int]$fromEnv
-    } else {
+    if ([string]::IsNullOrEmpty($fromEnv)) {
         $NumAccounts = 2
+    }
+    else {
+        $parsedNumAccounts = 0
+        if ($fromEnv -notmatch '^\d+$' -or
+            -not [int]::TryParse([string]$fromEnv, [ref]$parsedNumAccounts)) {
+            Write-Error "NUM_ACCOUNTS must be an integer between 1 and 702 (got: $fromEnv)"
+            exit 1
+        }
+        $NumAccounts = $parsedNumAccounts
     }
 }
 
@@ -76,7 +83,7 @@ if ([string]::IsNullOrEmpty($ImageTag)) {
 }
 
 if ($NumAccounts -lt 1 -or $NumAccounts -gt 702) {
-    Write-Error "NUM_ACCOUNTS must be between 1 and 702 (got: $NumAccounts)"
+    Write-Error "NUM_ACCOUNTS must be an integer between 1 and 702 (got: $NumAccounts)"
     exit 1
 }
 

--- a/scripts/generate-compose.sh
+++ b/scripts/generate-compose.sh
@@ -41,6 +41,14 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 load_env_file "$PROJECT_ROOT/.env"
 
 NUM_ACCOUNTS="${NUM_ACCOUNTS:-2}"
+# Validate before any registry lookup so unusable input always reaches this
+# generator-owned diagnostic and cannot flow into arithmetic below.
+RAW_NUM_ACCOUNTS="$NUM_ACCOUNTS"
+if ! NUM_ACCOUNTS=$(normalize_account_count "$RAW_NUM_ACCOUNTS"); then
+    echo "Error: NUM_ACCOUNTS must be an integer between 1 and 702 (got: $RAW_NUM_ACCOUNTS)" >&2
+    exit 1
+fi
+
 AGENT_RUNTIME="$(agent_runtime)"
 SERVICE_PREFIX="$(agent_service_prefix)"
 PRIMARY_SERVICE="${SERVICE_PREFIX}-a"
@@ -80,13 +88,6 @@ if [[ -z "${IMAGE_TAG:-}" ]]; then
         IMAGE_TAG="$(head -n1 "$PROJECT_ROOT/VERSION" | tr -d '[:space:]')"
     fi
     IMAGE_TAG="${IMAGE_TAG:-latest}"
-fi
-
-# Validate. Practical upper bound is "zz" (702) from Excel-style letter
-# enumeration; keep the cap well below that to catch typos like 2600.
-if [[ "$NUM_ACCOUNTS" -lt 1 || "$NUM_ACCOUNTS" -gt 702 ]]; then
-    echo "Error: NUM_ACCOUNTS must be between 1 and 702 (got: $NUM_ACCOUNTS)" >&2
-    exit 1
 fi
 
 # Container resource envelope (override via .env or host env). Defaults

--- a/scripts/lib/index.sh
+++ b/scripts/lib/index.sh
@@ -2,10 +2,11 @@
 # index.sh — Shared account-index helpers.
 #
 # Library file meant to be `source`d. The shebang doubles as a shellcheck
-# shell directive (SC2148). Provides a single definition of:
+# shell directive (SC2148). Provides shared definitions of:
 #
-#   index_to_letter N   1-based index → Excel-style lowercase (a, z, aa, zz)
-#   index_to_upper  N   1-based index → Excel-style uppercase (A, Z, AA, ZZ)
+#   normalize_account_count VALUE   validated decimal count in 1..702
+#   index_to_letter N               1-based index → lowercase (a, z, aa, zz)
+#   index_to_upper  N               1-based index → uppercase (A, Z, AA, ZZ)
 #
 # Values 1-26 are bit-for-bit identical to the former single-letter
 # implementation that used to live in each consumer. The upper bound 702
@@ -19,6 +20,14 @@ if [[ -n "${_CLAUDE_DOCKER_INDEX_SH_SOURCED:-}" ]]; then
     return 0 2>/dev/null || exit 0
 fi
 _CLAUDE_DOCKER_INDEX_SH_SOURCED=1
+
+normalize_account_count() {
+    local value="$1"
+    [[ "$value" =~ ^0*([0-9]{1,3})$ ]] || return 1
+    value="${BASH_REMATCH[1]}"
+    (( 10#$value >= 1 && 10#$value <= 702 )) || return 1
+    printf '%d' "$((10#$value))"
+}
 
 index_to_letter() {
     local n="$1"

--- a/tests/test_num_accounts_precedence.sh
+++ b/tests/test_num_accounts_precedence.sh
@@ -13,11 +13,11 @@
 # wrong together, and the whole point of the fixture set is the one row where
 # they used to disagree.
 #
-# Scope: precedence, with values every reader accepts. Invalid-value handling is
-# deliberately outside it, because the two layers differ there by design -- the
-# generators abort (they write files) while the CLI wrappers fall back to the
-# default (they enumerate services for display). The generators also differ from
-# each other on that axis, which is filed separately.
+# Scope: precedence plus unusable-value handling. The two layers differ there by
+# design: generators abort before writing files, while CLI wrappers warn and
+# fall back to the default because they enumerate services for display. Both
+# languages must make the same choice within a layer, including at the shared
+# upper bound of 702.
 #
 # The TUI is a fifth reader and is deliberately not covered. Env.NumAccounts()
 # in tui/internal/config/env.go reads .env alone because Env is the document the
@@ -57,17 +57,20 @@ fi
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
-# name | .env NUM_ACCOUNTS ('-' for no .env file) | environment ('-' for unset) | expected
+# name | .env value ('-' for no file) | environment ('-' for unset) | CLI expected | generator expected
 #
-# Row 4 is the discriminating one: it is the only row where the two sources
-# disagree, so it is the only row the pre-#317 CLI wrappers failed. Rows 1-3
-# passed before this change and still do, which is what keeps a regression in
-# the default or the .env path visible instead of being masked.
+# Row 4 is the precedence discriminator where the two sources disagree. The
+# remaining rows pin normalization and the policy for unusable values.
 SCENARIOS=(
-    "neither|-|-|2"
-    "dotenv-only|3|-|3"
-    "env-only|-|5|5"
-    "env-wins|3|5|5"
+    "neither|-|-|2|2"
+    "dotenv-only|3|-|3|3"
+    "env-only|-|5|5|5"
+    "env-wins|3|5|5|5"
+    "leading-zero|-|008|8|8"
+    "non-numeric|-|abc|2|reject"
+    "whitespace|-|   |2|reject"
+    "over-limit|-|703|2|reject"
+    "overflow|-|99999999999999999999|2|reject"
 )
 
 # Stage a sandbox holding only what a reader reads: the scripts tree, the
@@ -121,7 +124,7 @@ read_bash_cli() {
 read_pwsh_cli() {
     local dir="$1" envval="$2"
     run_with_env "$envval" pwsh -NoProfile -Command \
-        "Import-Module '$dir/scripts/ClaudeDocker.psm1' -Force; (Get-NumAccounts -ProjectRoot '$dir')" \
+        "Import-Module '$dir/scripts/ClaudeDocker.psm1' -Force; (Get-NumAccounts -ProjectRoot '$dir' -WarningAction SilentlyContinue)" \
         2>/dev/null | tr -d '\r' | head -n1
 }
 
@@ -164,26 +167,90 @@ check() {
     fi
 }
 
+check_contains() {
+    local scenario="$1" reader="$2" got="$3" want="$4"
+    if [[ "$got" == *"$want"* ]]; then
+        printf '  PASS  %-12s %-10s contains expected diagnostic\n' "$scenario" "$reader"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL  %-12s %-10s missing: %s\n' "$scenario" "$reader" "$want"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
 echo "== NUM_ACCOUNTS precedence: environment > .env > 2 =="
 
 for row in "${SCENARIOS[@]}"; do
-    IFS='|' read -r name dotenv envval want <<<"$row"
+    IFS='|' read -r name dotenv envval cli_want gen_want <<<"$row"
+    [[ "$gen_want" == "reject" ]] && gen_want=""
 
-    printf '\n-- %s (.env=%s, environment=%s, expected %s)\n' \
-        "$name" "$dotenv" "$envval" "$want"
+    printf '\n-- %s (.env=%s, environment=%s)\n' "$name" "$dotenv" "$envval"
 
     # The CLI readers write nothing, so they share one sandbox. Each generator
     # gets its own, because both write the same three filenames.
     cli_dir=$(make_sandbox "${name}-cli" "$dotenv")
-    check "$name" "bash-cli"  "$(read_bash_cli "$cli_dir" "$envval")"  "$want"
-    check "$name" "pwsh-cli"  "$(read_pwsh_cli "$cli_dir" "$envval")"  "$want"
+    check "$name" "bash-cli"  "$(read_bash_cli "$cli_dir" "$envval")"  "$cli_want"
+    check "$name" "pwsh-cli"  "$(read_pwsh_cli "$cli_dir" "$envval")"  "$cli_want"
 
     bgen_dir=$(make_sandbox "${name}-gen-bash" "$dotenv")
-    check "$name" "bash-gen"  "$(read_bash_gen "$bgen_dir" "$envval")"  "$want"
+    check "$name" "bash-gen"  "$(read_bash_gen "$bgen_dir" "$envval")"  "$gen_want"
 
     pgen_dir=$(make_sandbox "${name}-gen-pwsh" "$dotenv")
-    check "$name" "pwsh-gen"  "$(read_pwsh_gen "$pgen_dir" "$envval")"  "$want"
+    check "$name" "pwsh-gen"  "$(read_pwsh_gen "$pgen_dir" "$envval")"  "$gen_want"
 done
+
+echo ""
+echo "== non-numeric diagnostics come from each reader =="
+expected="NUM_ACCOUNTS must be an integer between 1 and 702 (got: abc)"
+diag_cli_dir=$(make_sandbox "diagnostic-cli" "-")
+bash_cli_out=$(run_with_env abc bash "$diag_cli_dir/scripts/claude-docker" help 2>&1)
+pwsh_cli_out=$(run_with_env abc pwsh -NoProfile -Command \
+    "Import-Module '$diag_cli_dir/scripts/ClaudeDocker.psm1' -Force; Get-NumAccounts -ProjectRoot '$diag_cli_dir' | Out-Null" 2>&1)
+check_contains "diagnostic" "bash-warn" "$bash_cli_out" "$expected"
+check_contains "diagnostic" "pwsh-warn" "$pwsh_cli_out" "$expected"
+
+diag_bgen_dir=$(make_sandbox "diagnostic-gen-bash" "-")
+diag_pgen_dir=$(make_sandbox "diagnostic-gen-pwsh" "-")
+bash_gen_out=$(run_with_env abc bash "$diag_bgen_dir/scripts/generate-compose.sh" 2>&1)
+bash_gen_status=$?
+pwsh_gen_out=$(run_with_env abc pwsh -NoProfile -File "$diag_pgen_dir/scripts/generate-compose.ps1" 2>&1)
+pwsh_gen_status=$?
+check "diagnostic" "bash-exit" "$bash_gen_status" "1"
+check "diagnostic" "pwsh-exit" "$pwsh_gen_status" "1"
+check_contains "diagnostic" "bash-error" "$bash_gen_out" "$expected"
+check_contains "diagnostic" "pwsh-error" "$pwsh_gen_out" "$expected"
+check "diagnostic" "gen-files" "$([[ -e "$diag_bgen_dir/docker-compose.yml" || -e "$diag_pgen_dir/docker-compose.yml" ]] && echo 1 || echo 0)" "0"
+
+echo ""
+echo "== scale range: 1..702 with double-letter state directories =="
+
+scale_dir=$(make_sandbox "scale-bash" "26")
+mkdir -p "$scale_dir/bin" "$scale_dir/home"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$scale_dir/bin/docker"
+chmod +x "$scale_dir/bin/docker"
+scale_out=$(env -u NUM_ACCOUNTS -u AGENT_RUNTIME HOME="$scale_dir/home" \
+    PATH="$scale_dir/bin:$PATH" bash "$scale_dir/scripts/claude-docker" scale 27 2>&1)
+scale_status=$?
+check "scale-27" "bash-exit" "$scale_status" "0"
+check "scale-27" "bash-aa-dir" "$([[ -d "$scale_dir/home/.claude-state/account-aa" ]] && echo 1 || echo 0)" "1"
+
+max_dir=$(make_sandbox "scale-max" "-")
+bash_max_out=$(run_with_env "-" bash "$max_dir/scripts/claude-docker" scale 702 2>&1)
+check_contains "scale-702" "bash" "$bash_max_out" ".env not found"
+bash_over_out=$(run_with_env "-" bash "$max_dir/scripts/claude-docker" scale 703 2>&1)
+check_contains "scale-703" "bash" "$bash_over_out" "between 1 and 702"
+
+pwsh_letter=$(pwsh -NoProfile -Command \
+    "Import-Module '$max_dir/scripts/ClaudeDocker.psm1' -Force; ConvertTo-AccountLetter -Index 27" \
+    2>/dev/null | tr -d '\r')
+check "scale-27" "pwsh-letter" "$pwsh_letter" "aa"
+
+bash_help=$(run_with_env "-" bash "$max_dir/scripts/claude-docker" help 2>&1)
+check_contains "scale-help" "bash" "$bash_help" "Set number of accounts (1-702)"
+pwsh_source=$(tr -d '\r' < "$max_dir/scripts/claude-docker.ps1")
+check_contains "scale-help" "pwsh" "$pwsh_source" "Set number of accounts (1-702)"
+pwsh_scale=$(sed -n '/^function Invoke-Scale {/,/^}/p' "$max_dir/scripts/claude-docker.ps1")
+check_contains "scale-702" "pwsh" "$pwsh_scale" '$newCount -gt 702'
 
 printf '\n-- checkout untouched\n'
 if [[ "$(compose_digest)" == "$DIGEST_BEFORE" ]]; then


### PR DESCRIPTION
## What

- reject unusable `NUM_ACCOUNTS` values consistently in both compose generators before any files are written
- warn and fall back to the default of 2 in both CLI readers for non-numeric, out-of-range, whitespace-only, or overflowing values
- raise both `scale` commands and help texts from 26 to the documented 702-account ceiling
- add regression coverage for precedence, diagnostics, numeric normalization, overflow, the 702 boundary, and `account-aa` creation
- document the intentional generator/CLI policy difference

## Why

The Bash generator evaluated invalid input arithmetically under `set -u`, the PowerShell generator silently defaulted it, and the CLI wrappers could enumerate more services than either generator could create. The scale commands also retained the pre-Excel-suffix limit of 26.

## Verification

- `git diff --check`
- Bash and PowerShell syntax parsing
- manual Bash and PowerShell probes for `abc`, whitespace, `0`, `703`, long numeric overflow, leading zeroes, and scaling to `account-aa`
- `tests/test_parse_env.ps1`
- all locally runnable Bash CI-matrix tests
- compose freshness probe in an isolated sandbox
- `gofmt -l .`

Local environment limitations:
- WSL lacks `jq` and Linux `pwsh`, so the affected cross-language Bash tests use their documented local skip paths.
- Windows `go test ./...` reaches the known Unix-command assumption in `TestGHAuthVerdict`; Ubuntu CI is authoritative for that job.

## Risk

Low. Changes are limited to account-count parsing, validation, help text, documentation, and regression tests. Valid values keep the existing precedence and output.

Closes #320
Closes #323
Closes #324
Closes #325