### PR TITLE
fix(tui): align default service count

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,7 +648,8 @@ range, so the wrappers never enumerate a topology the generators would reject.
 The TUI dashboard sits outside this rule by design. `Env.NumAccounts()` in
 `tui/internal/config/env.go` reads `.env` alone, because `Env` is the document
 the TUI edits and writes back, and it treats the value as a floor rather than an
-exact count: `discoverStateDirs` raises it to cover any account state directory
+exact count. Missing or unusable values start from the generator default of `2`,
+and `discoverStateDirs` raises that floor to cover any account state directory
 it finds on disk.
 
 `tests/test_num_accounts_precedence.sh` pins all four shell-side readers to the

--- a/tui/internal/account/manager_helpers_test.go
+++ b/tui/internal/account/manager_helpers_test.go
@@ -66,14 +66,14 @@ func TestDiscoverStateDirs(t *testing.T) {
 	}
 }
 
-// TestDiscoverStateDirs_EmptyHome covers the first-run case where the user
-// has no .claude-state directory yet. NUM_ACCOUNTS still drives the count.
-func TestDiscoverStateDirs_EmptyHome(t *testing.T) {
+// TestDiscoverStateDirs_EmptyHomeUsesGeneratorDefault covers the first-run
+// case where the user has no .claude-state directory or NUM_ACCOUNTS yet. The
+// generator default still drives the count.
+func TestDiscoverStateDirs_EmptyHomeUsesGeneratorDefault(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 
 	env := config.NewEmptyEnv(filepath.Join(tmp, ".env"))
-	env.Set("NUM_ACCOUNTS", "2")
 	m := newTestManager(t, env)
 
 	stateDirs, n := m.discoverStateDirs()

--- a/tui/internal/config/env.go
+++ b/tui/internal/config/env.go
@@ -11,9 +11,11 @@ import (
 )
 
 const (
-	RuntimeClaude = "claude"
-	RuntimeCodex  = "codex"
-	RuntimeGemini = "gemini"
+	// DefaultNumAccounts matches the compose generator fallback.
+	DefaultNumAccounts = 2
+	RuntimeClaude      = "claude"
+	RuntimeCodex       = "codex"
+	RuntimeGemini      = "gemini"
 )
 
 // Env holds parsed .env configuration with order-preserving entries.
@@ -135,15 +137,15 @@ func (e *Env) Save() error {
 	return nil
 }
 
-// NumAccounts returns the NUM_ACCOUNTS value from .env (default 1).
+// NumAccounts returns the NUM_ACCOUNTS value from .env (default 2).
 func (e *Env) NumAccounts() int {
 	v := e.Get("NUM_ACCOUNTS")
 	if v == "" {
-		return 1
+		return DefaultNumAccounts
 	}
 	n, err := strconv.Atoi(v)
 	if err != nil || n < 1 {
-		return 1
+		return DefaultNumAccounts
 	}
 	return n
 }

--- a/tui/internal/config/env_test.go
+++ b/tui/internal/config/env_test.go
@@ -186,14 +186,14 @@ func TestNewEmptyEnv_SetGetSave(t *testing.T) {
 
 func TestNumAccounts_Fallback(t *testing.T) {
 	// Missing key, non-numeric, and negative all fall back to the
-	// documented default (1).
+	// generator default (2).
 	cases := []struct {
 		content string
 		want    int
 	}{
-		{"", 1},
-		{"NUM_ACCOUNTS=abc\n", 1},
-		{"NUM_ACCOUNTS=-3\n", 1},
+		{"", 2},
+		{"NUM_ACCOUNTS=abc\n", 2},
+		{"NUM_ACCOUNTS=-3\n", 2},
 		{"NUM_ACCOUNTS=4\n", 4},
 	}
 	for _, c := range cases {

--- a/tui/internal/docker/client.go
+++ b/tui/internal/docker/client.go
@@ -135,7 +135,7 @@ func (c *Client) HasRunningContainers() bool {
 
 // ServiceNames returns the expected service names based on NUM_ACCOUNTS.
 func (c *Client) ServiceNames() []string {
-	n := 1
+	n := config.DefaultNumAccounts
 	prefix := config.RuntimeClaude
 	if c.env != nil {
 		n = c.env.NumAccounts()

--- a/tui/internal/docker/docker_test.go
+++ b/tui/internal/docker/docker_test.go
@@ -170,6 +170,22 @@ func TestServiceNames_CodexRuntime(t *testing.T) {
 	}
 }
 
+func TestServiceNames_DefaultMatchesGenerator(t *testing.T) {
+	env := config.NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+	c := NewClient("/tmp/proj", env)
+
+	got := c.ServiceNames()
+	want := []string{"claude-a", "claude-b"}
+	if len(got) != len(want) {
+		t.Fatalf("ServiceNames len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("ServiceNames[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 // TestBuildArgs verifies the binary is "docker", "build" is always present,
 // and "--no-cache" is added only when noCache is true.
 func TestBuildArgs(t *testing.T) {


### PR DESCRIPTION
## What

- Align the TUI account-count fallback with the compose generator default of two.
- Reuse one Go default for `Env.NumAccounts()` and `Client.ServiceNames()`.
- Pin the fresh-install service list and account discovery behavior in tests.
- Document the TUI fallback in the compose precedence section.

## Why

With no `.env` or account state directories, the TUI started from one account even though the committed compose files define `claude-a` and `claude-b`. State-directory discovery could only correct that floor after directories existed, so a fresh dashboard omitted the second service.

## Scope

This changes only missing or unusable `NUM_ACCOUNTS` values from a fallback of one to two. Explicit valid values are unchanged, and state-directory discovery still extends beyond the configured count.

## Verification

- `go test ./internal/config ./internal/docker`
- `go test ./internal/account -run '^TestDiscoverStateDirs'`
- `go test ./... -skip '^TestGHAuthVerdict$'` on Windows; the skipped existing test invokes Unix `true` and `false`
- `gofmt -l .`
- `git diff --check`

## Risk

Low. The behavior change is limited to the TUI fallback path, and regression tests cover both generated service names and fresh-install account discovery.

Closes #321