### PR TITLE
fix(scripts): guard Windows bash entry points

### DIFF
--- a/scripts/setup-worktrees.sh
+++ b/scripts/setup-worktrees.sh
@@ -7,6 +7,16 @@
 # If no branch names are provided, defaults to worktree-a and worktree-b.
 set -euo pipefail
 
+# Platform guard: refuse to run on native Windows shells (Git Bash, MSYS,
+# Cygwin). `git worktree add` receives MSYS-flavored /c/... paths there, which
+# compose volume mounts cannot resolve, leaving Tier B worktrees unusable.
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+        echo "Error: setup-worktrees.sh is not supported on native Windows shells." >&2
+        echo "Use: powershell -ExecutionPolicy Bypass -File scripts\\setup-worktrees.ps1" >&2
+        exit 1 ;;
+esac
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/index.sh
 . "$SCRIPT_DIR/lib/index.sh"

--- a/scripts/test-concurrent-git.sh
+++ b/scripts/test-concurrent-git.sh
@@ -7,6 +7,17 @@
 #   NUM_TEST_ACCOUNTS=3 scripts/test-concurrent-git.sh
 set -euo pipefail
 
+# Platform guard: refuse to run on native Windows shells (Git Bash, MSYS,
+# Cygwin). This harness drives the worktree compose override directly, where
+# MSYS path conversion exercises paths the PowerShell setup never produces and
+# makes a passing result misleading.
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+        echo "Error: test-concurrent-git.sh is not supported on native Windows shells." >&2
+        echo "Use: powershell -ExecutionPolicy Bypass -File scripts\\test-concurrent-git.ps1" >&2
+        exit 1 ;;
+esac
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEMP_DIR="$(mktemp -d)"

--- a/tests/test_windows_platform_guard.sh
+++ b/tests/test_windows_platform_guard.sh
@@ -40,14 +40,14 @@ fail() {
 # Deliberately absent:
 #   scripts/entrypoint.sh                runs only inside the container
 #   scripts/test-entrypoint-settings.sh  no .ps1 counterpart to redirect to
-#   scripts/setup-worktrees.sh           counterpart exists, guard pending (#310)
-#   scripts/test-concurrent-git.sh       counterpart exists, guard pending (#310)
 GUARDED=(
     "scripts/install.sh|install.ps1"
     "scripts/claude-docker|claude-docker.ps1"
     "scripts/generate-compose.sh|generate-compose.ps1"
     "scripts/cleanup.sh|cleanup.ps1"
     "scripts/remove.sh|remove.ps1"
+    "scripts/setup-worktrees.sh|setup-worktrees.ps1"
+    "scripts/test-concurrent-git.sh|test-concurrent-git.ps1"
 )
 
 STUB_ROOT="$(mktemp -d)"


### PR DESCRIPTION
## What

- Add native-Windows guards to `setup-worktrees.sh` and `test-concurrent-git.sh` before any argument handling, filesystem setup, or Docker work.
- Direct users to the matching PowerShell entry points.
- Extend the platform-guard regression test and narrow its documented exclusions.

## Why

MSYS-style path conversion can create Tier B worktree paths that Docker Compose cannot mount. The concurrent-git harness can also exercise paths that the supported PowerShell setup never produces, making a passing E2E result misleading.

## Impact

Native Windows Bash invocations now fail fast with actionable guidance. Supported Linux and macOS execution remains unchanged.

## Verification

- `bash tests/test_windows_platform_guard.sh` (30 passed, 0 failed)
- `bash -n scripts/setup-worktrees.sh scripts/test-concurrent-git.sh tests/test_windows_platform_guard.sh`
- Mutation check: removing the `setup-worktrees.sh` guard fails 2 assertions
- Mutation check: removing the `test-concurrent-git.sh` guard fails 1 assertion with Docker stubbed

Closes #312