### PR TITLE
fix(scripts): guard PowerShell lifecycle scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,7 @@ jobs:
       matrix:
         test:
           - tests/test_parse_env.ps1
+          - tests/test_powershell_platform_guard.ps1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run ${{ matrix.test }}

--- a/scripts/cleanup.ps1
+++ b/scripts/cleanup.ps1
@@ -31,6 +31,15 @@ param(
     [int]$BackupAgeDays = 7
 )
 
+# Platform guard: PowerShell 7 runs on Linux and macOS, but this script resolves
+# runtime state through USERPROFILE. That is not the state root created by the
+# bash installer, so cleanup can report success while leaving the real state
+# behind.
+if ($PSVersionTable.PSEdition -eq 'Core' -and $PSVersionTable.OS -and $PSVersionTable.OS -notlike '*Windows*') {
+    Write-Error "cleanup.ps1 is Windows-only. Use ./scripts/cleanup.sh on macOS or Linux."
+    exit 1
+}
+
 if ($Force -and $SkipState) {
     Write-Error '-Force and -SkipState are mutually exclusive.'
     exit 2

--- a/scripts/generate-compose.ps1
+++ b/scripts/generate-compose.ps1
@@ -19,6 +19,15 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# Platform guard: PowerShell 7 runs on Linux and macOS, but this Windows port
+# can persist Windows host paths into compose files that the bash lifecycle
+# then reads as Unix paths. Refuse before reading configuration or writing any
+# compose file.
+if ($PSVersionTable.PSEdition -eq 'Core' -and $PSVersionTable.OS -and $PSVersionTable.OS -notlike '*Windows*') {
+    Write-Error "generate-compose.ps1 is Windows-only. Use ./scripts/generate-compose.sh on macOS or Linux."
+    exit 1
+}
+
 $ScriptDir  = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $ProjectRoot = Split-Path -Parent $ScriptDir
 

--- a/scripts/remove.ps1
+++ b/scripts/remove.ps1
@@ -13,6 +13,16 @@
 param()
 
 $ErrorActionPreference = 'Stop'
+
+# Platform guard: PowerShell 7 runs on Linux and macOS, but this remover searches
+# USERPROFILE and Windows-only tool locations and omits the Linux compose
+# overlay. On Unix it can leave state and resources behind while reporting a
+# completed removal.
+if ($PSVersionTable.PSEdition -eq 'Core' -and $PSVersionTable.OS -and $PSVersionTable.OS -notlike '*Windows*') {
+    Write-Error "remove.ps1 is Windows-only. Use ./scripts/remove.sh on macOS or Linux."
+    exit 1
+}
+
 Import-Module "$PSScriptRoot\ClaudeDocker.psm1" -Force
 
 $ProjectRoot = Split-Path $PSScriptRoot -Parent

--- a/scripts/setup-worktrees.ps1
+++ b/scripts/setup-worktrees.ps1
@@ -23,6 +23,14 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# Platform guard: PowerShell 7 runs on Linux and macOS, but this helper emits
+# worktree paths for the Windows Docker Desktop workflow. Mixing those paths
+# into the Unix bash lifecycle can leave Tier B compose mounts unusable.
+if ($PSVersionTable.PSEdition -eq 'Core' -and $PSVersionTable.OS -and $PSVersionTable.OS -notlike '*Windows*') {
+    Write-Error "setup-worktrees.ps1 is Windows-only. Use ./scripts/setup-worktrees.sh on macOS or Linux."
+    exit 1
+}
+
 $RepoDir = $RepoDir.TrimEnd('\', '/')
 
 # Validate

--- a/scripts/test-concurrent-git.ps1
+++ b/scripts/test-concurrent-git.ps1
@@ -14,6 +14,14 @@ param()
 
 $ErrorActionPreference = 'Stop'
 
+# Platform guard: PowerShell 7 runs on Linux and macOS, but this Windows harness
+# invokes Compose without docker-compose.linux.yml. On Linux that skips UID/GID
+# mapping, so a pass can hide incorrect ownership in the generated worktrees.
+if ($PSVersionTable.PSEdition -eq 'Core' -and $PSVersionTable.OS -and $PSVersionTable.OS -notlike '*Windows*') {
+    Write-Error "test-concurrent-git.ps1 is Windows-only. Use ./scripts/test-concurrent-git.sh on macOS or Linux."
+    exit 1
+}
+
 $ScriptDir = $PSScriptRoot
 $ProjectDir = Split-Path $ScriptDir -Parent
 $TempDir = Join-Path $env:TEMP "claude-docker-test-$(New-Guid)"

--- a/tests/test_compose_generator_equivalence.sh
+++ b/tests/test_compose_generator_equivalence.sh
@@ -73,6 +73,13 @@ if ! command -v pwsh >/dev/null 2>&1; then
     exit 0
 fi
 
+# The PowerShell entry point correctly refuses on this Linux runner. Its guard
+# is exercised against the real OS by test_powershell_platform_guard.ps1; this
+# content-parity test needs to reach the generator body, so its child process
+# presents a Windows OS value only for that invocation. There is no production
+# bypass flag for callers to inherit or enable accidentally.
+PWSH_GENERATOR_COMMAND="\$PSVersionTable.OS = 'Microsoft Windows'; & \$env:CLAUDE_DOCKER_PWSH_ENTRYPOINT"
+
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
@@ -124,7 +131,8 @@ stage_and_run() {
     else
         # shellcheck disable=SC2086  # assigns is a deliberate word-split list
         env -u NUM_ACCOUNTS -u IMAGE_TAG $assigns \
-            pwsh -NoProfile -File "$dir/scripts/generate-compose.ps1" >"$dir/.gen.log" 2>&1 || rc=$?
+            CLAUDE_DOCKER_PWSH_ENTRYPOINT="$dir/scripts/generate-compose.ps1" \
+            pwsh -NoProfile -Command "$PWSH_GENERATOR_COMMAND" >"$dir/.gen.log" 2>&1 || rc=$?
     fi
     return "$rc"
 }

--- a/tests/test_num_accounts_precedence.sh
+++ b/tests/test_num_accounts_precedence.sh
@@ -54,6 +54,12 @@ if ! command -v pwsh >/dev/null 2>&1; then
     exit 0
 fi
 
+# The guarded PowerShell generator is Windows-only, while this Linux CI test
+# still needs to exercise its configuration logic. The dedicated platform
+# guard test uses the real OS value; generator probes below change it only in
+# their child process, avoiding a production bypass switch.
+PWSH_GENERATOR_COMMAND="\$PSVersionTable.OS = 'Microsoft Windows'; & \$env:CLAUDE_DOCKER_PWSH_ENTRYPOINT"
+
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
@@ -136,7 +142,9 @@ read_bash_gen() {
 
 read_pwsh_gen() {
     local dir="$1" envval="$2"
-    run_with_env "$envval" pwsh -NoProfile -File "$dir/scripts/generate-compose.ps1" >/dev/null 2>&1 || return 0
+    run_with_env "$envval" env \
+        "CLAUDE_DOCKER_PWSH_ENTRYPOINT=$dir/scripts/generate-compose.ps1" \
+        pwsh -NoProfile -Command "$PWSH_GENERATOR_COMMAND" >/dev/null 2>&1 || return 0
     count_services "$dir"
 }
 
@@ -213,7 +221,9 @@ diag_bgen_dir=$(make_sandbox "diagnostic-gen-bash" "-")
 diag_pgen_dir=$(make_sandbox "diagnostic-gen-pwsh" "-")
 bash_gen_out=$(run_with_env abc bash "$diag_bgen_dir/scripts/generate-compose.sh" 2>&1)
 bash_gen_status=$?
-pwsh_gen_out=$(run_with_env abc pwsh -NoProfile -File "$diag_pgen_dir/scripts/generate-compose.ps1" 2>&1)
+pwsh_gen_out=$(run_with_env abc env \
+    "CLAUDE_DOCKER_PWSH_ENTRYPOINT=$diag_pgen_dir/scripts/generate-compose.ps1" \
+    pwsh -NoProfile -Command "$PWSH_GENERATOR_COMMAND" 2>&1)
 pwsh_gen_status=$?
 check "diagnostic" "bash-exit" "$bash_gen_status" "1"
 check "diagnostic" "pwsh-exit" "$pwsh_gen_status" "1"

--- a/tests/test_powershell_platform_guard.ps1
+++ b/tests/test_powershell_platform_guard.ps1
@@ -1,0 +1,129 @@
+# test_powershell_platform_guard.ps1 — Verifies the non-Windows platform guard
+# on every PowerShell entry point that has a bash counterpart.
+#
+# The pwsh-tests CI job runs this file on Ubuntu, where PSVersionTable.OS
+# exercises the real guard predicate. Each entry point is copied into an
+# isolated directory before invocation so a missing or late guard fails on a
+# missing dependency instead of reaching repository, Docker, or user state.
+#
+# Run:  pwsh -NoProfile -File tests/test_powershell_platform_guard.ps1
+# Exits non-zero on any failure; prints a summary at the end.
+
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent $ScriptDir
+
+$script:Pass = 0
+$script:Fail = 0
+
+function Write-Pass {
+    param([Parameter(Mandatory)][string]$Label)
+
+    Write-Host ("  PASS  {0}" -f $Label)
+    $script:Pass++
+}
+
+function Write-Fail {
+    param(
+        [Parameter(Mandatory)][string]$Label,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Detail
+    )
+
+    Write-Host ("  FAIL  {0}`n        {1}" -f $Label, $Detail)
+    $script:Fail++
+}
+
+# Keep this list explicit so every new PowerShell entry point requires a
+# deliberate guard decision rather than silently inheriting one from a glob.
+$Guarded = @(
+    [pscustomobject]@{ Path = 'scripts/install.ps1'; Counterpart = './scripts/install.sh' }
+    [pscustomobject]@{ Path = 'scripts/claude-docker.ps1'; Counterpart = './scripts/claude-docker' }
+    [pscustomobject]@{ Path = 'scripts/generate-compose.ps1'; Counterpart = './scripts/generate-compose.sh' }
+    [pscustomobject]@{ Path = 'scripts/cleanup.ps1'; Counterpart = './scripts/cleanup.sh' }
+    [pscustomobject]@{ Path = 'scripts/remove.ps1'; Counterpart = './scripts/remove.sh' }
+    [pscustomobject]@{ Path = 'scripts/setup-worktrees.ps1'; Counterpart = './scripts/setup-worktrees.sh' }
+    [pscustomobject]@{ Path = 'scripts/test-concurrent-git.ps1'; Counterpart = './scripts/test-concurrent-git.sh' }
+)
+
+$isNonWindowsCore = $PSVersionTable.PSEdition -eq 'Core' -and
+    $PSVersionTable.OS -and $PSVersionTable.OS -notlike '*Windows*'
+if (-not $isNonWindowsCore) {
+    Write-Host 'SKIP: the PowerShell platform guard requires PowerShell Core on Linux or macOS.'
+    exit 0
+}
+
+$pwsh = (Get-Command pwsh -ErrorAction Stop).Source
+$sandboxRoot = Join-Path ([System.IO.Path]::GetTempPath()) "claude-docker-pwsh-guard-$PID-$(New-Guid)"
+New-Item -ItemType Directory -Path $sandboxRoot | Out-Null
+
+try {
+    Write-Host '=== Non-Windows PowerShell platform guard ==='
+
+    foreach ($entry in $Guarded) {
+        $source = Join-Path $ProjectRoot $entry.Path
+        if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
+            Write-Fail "$($entry.Path) exists" 'no such file'
+            continue
+        }
+
+        $leaf = Split-Path $source -Leaf
+        $caseRoot = Join-Path $sandboxRoot ([System.IO.Path]::GetFileNameWithoutExtension($leaf))
+        New-Item -ItemType Directory -Path $caseRoot | Out-Null
+        $isolatedScript = Join-Path $caseRoot $leaf
+        Copy-Item -LiteralPath $source -Destination $isolatedScript
+
+        $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+        $startInfo.FileName = $pwsh
+        $startInfo.UseShellExecute = $false
+        $startInfo.RedirectStandardOutput = $true
+        $startInfo.RedirectStandardError = $true
+        [void]$startInfo.ArgumentList.Add('-NoLogo')
+        [void]$startInfo.ArgumentList.Add('-NoProfile')
+        [void]$startInfo.ArgumentList.Add('-NonInteractive')
+        [void]$startInfo.ArgumentList.Add('-File')
+        [void]$startInfo.ArgumentList.Add($isolatedScript)
+
+        # Mandatory parameter binding precedes a script body, so give the
+        # worktree helper a harmless path. If its guard is absent, validation
+        # fails inside the sandbox without touching a real repository.
+        if ($entry.Path -eq 'scripts/setup-worktrees.ps1') {
+            [void]$startInfo.ArgumentList.Add('-RepoDir')
+            [void]$startInfo.ArgumentList.Add((Join-Path $caseRoot 'missing-repository'))
+        }
+
+        $process = [System.Diagnostics.Process]::Start($startInfo)
+        $stdout = $process.StandardOutput.ReadToEnd()
+        $stderr = $process.StandardError.ReadToEnd()
+        $process.WaitForExit()
+        $output = "$stdout`n$stderr".Trim()
+
+        if ($process.ExitCode -eq 1) {
+            Write-Pass "$($entry.Path) refuses with exit 1"
+        } else {
+            Write-Fail "$($entry.Path) refuses with exit 1" "actual exit status: $($process.ExitCode)"
+        }
+
+        $refusal = "$leaf is Windows-only"
+        if ($output.Contains($refusal, [System.StringComparison]::Ordinal)) {
+            Write-Pass "$($entry.Path) says why it refused"
+        } else {
+            Write-Fail "$($entry.Path) says why it refused" "output was: $($output ?? '<empty>')"
+        }
+
+        if ($output.Contains($entry.Counterpart, [System.StringComparison]::Ordinal)) {
+            Write-Pass "$($entry.Path) points at $($entry.Counterpart)"
+        } else {
+            Write-Fail "$($entry.Path) points at $($entry.Counterpart)" "output did not name it: $($output ?? '<empty>')"
+        }
+    }
+}
+finally {
+    Remove-Item -LiteralPath $sandboxRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ''
+Write-Host ("Passed: {0}  Failed: {1}" -f $script:Pass, $script:Fail)
+if ($script:Fail -gt 0) { exit 1 }


### PR DESCRIPTION
## What

- Add non-Windows PowerShell guards to the five unguarded lifecycle scripts.
- Add an Ubuntu PowerShell regression test covering all seven guarded `.ps1` entry points.
- Register the new test in the `pwsh-tests` matrix.
- Keep the existing cross-language generator tests focused on generator behavior by overriding `PSVersionTable.OS` only inside their isolated child processes.

## Why

PowerShell Core runs on Linux and macOS, so Windows-oriented lifecycle scripts were reachable on unsupported hosts. Those scripts rely on Windows state roots, tool locations, compose overlays, and worktree assumptions, which could produce misleading success or incorrect generated state.

The root cause was guard inventory drift: the installer and CLI wrapper were protected, while later lifecycle entry points were not.

## Impact

Unsupported PowerShell invocations now fail immediately with exit code 1 and name the matching bash entry point. Native Windows behavior remains unchanged.

## Verification

- PowerShell platform guard test: 21 passed, 0 failed
- PowerShell environment parser test: 20 passed, 0 failed
- Compose generator equivalence: 20 passed, 0 failed
- Account precedence regression suite: 52 passed, 0 failed
- Bash platform guard test: 30 passed, 0 failed
- PSScriptAnalyzer CI rules: passed
- Mutation checks: deleting each of the five new guards made the regression test fail

## Risk

Low. The runtime change is a top-of-file platform predicate matching the two existing PowerShell guards. Test-only OS substitution is process-local and exposes no production bypass.

Closes #313