### PR TITLE
feat(auth): support per-container GitHub accounts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,8 @@
 #     runtime's SDK key variable at container runtime — CLAUDE_API_KEY_* ->
 #     ANTHROPIC_API_KEY, CODEX_API_KEY_* -> OPENAI_API_KEY,
 #     GEMINI_API_KEY_* -> GEMINI_API_KEY)
-#   - GH_TOKEN                  (GitHub CLI token)
+#   - GH_TOKEN                  (shared GitHub CLI token)
+#   - GH_TOKEN_A / _B / ...     (per-account GitHub CLI tokens)
 # Recommended rotation cadence: every 90 days for production keys.
 #
 # install.sh creates .env.backup.<unix_ts> on every run, capturing the
@@ -63,6 +64,27 @@ PROJECT_DIR=/absolute/path/to/your/project
 # Used for git commits inside containers
 # GIT_USER_NAME=Your Name
 # GIT_USER_EMAIL=you@example.com
+# Optional per-account overrides (global values remain the fallback)
+# GIT_USER_NAME_A=Account A Name
+# GIT_USER_EMAIL_A=account-a@example.com
+# GIT_USER_NAME_B=Account B Name
+# GIT_USER_EMAIL_B=account-b@example.com
+
+# ==== GitHub authentication (optional) ====
+# Shared mode is the backward-compatible default. All services use GH_TOKEN
+# and may read the shared, read-only GH_CONFIG_DIR mount.
+# GH_AUTH_MODE=shared
+# GH_TOKEN=
+# GH_CONFIG_DIR=/absolute/path/to/gh-config
+#
+# Per-account mode requires both a login and token for every configured
+# account. The compose generator maps only the matching token into each
+# service and omits the shared GH_CONFIG_DIR mount.
+# GH_AUTH_MODE=per-account
+# GH_USER_A=github-login-a
+# GH_TOKEN_A=
+# GH_USER_B=github-login-b
+# GH_TOKEN_B=
 
 # ==== Linux: UID/GID (auto-set by install.sh) ====
 # UID=1000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fixture: [minimal, tier-b, n5, n30, with-special-chars, codex, gemini]
+        fixture: [minimal, tier-b, n5, n30, with-special-chars, codex, gemini, github-per-account]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Stage fixture
@@ -173,6 +173,10 @@ jobs:
           - tests/test_parse_env_equivalence.sh
           - tests/test_runtime_registry_equivalence.sh
           - tests/test_compose_generator_equivalence.sh
+          - tests/test_github_per_account_compose.sh
+          - tests/test_github_account_selection.sh
+          - tests/test_entrypoint_github_auth.sh
+          - tests/test_installer_github_equivalence.sh
           - tests/test_num_accounts_precedence.sh
           - tests/test_agent_attach_argv.sh
           - tests/test_transform_syntax_check.sh
@@ -192,6 +196,7 @@ jobs:
       matrix:
         test:
           - tests/test_parse_env.ps1
+          - tests/test_github_account_selection.ps1
           - tests/test_powershell_platform_guard.ps1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,13 +196,21 @@ jobs:
       matrix:
         test:
           - tests/test_parse_env.ps1
-          - tests/test_github_account_selection.ps1
           - tests/test_powershell_platform_guard.ps1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run ${{ matrix.test }}
         shell: pwsh
         run: pwsh -NoProfile -File "${{ matrix.test }}"
+
+  pwsh-windows-tests:
+    name: PowerShell Windows Tests (GitHub account selection)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Run GitHub account selection test
+        shell: pwsh
+        run: pwsh -NoProfile -File tests/test_github_account_selection.ps1
 
   # Live keyless smoke test for Epic #267 AC3 #1 and the keyless half of AC3 #2:
   # AGENT_RUNTIME=gemini + `claude-docker up` brings the gemini container to a

--- a/README.md
+++ b/README.md
@@ -343,20 +343,80 @@ limitations, switch to API keys in `.env`.
 > it with an empty string would otherwise make the SDK ignore the
 > `.credentials.json` from OAuth.
 
-**GitHub CLI (`gh`)** is automatically available inside containers. The
-preferred container auth path is the `GH_TOKEN` environment variable:
-`scripts/claude-docker gh-auth` extracts a token from the host `gh` CLI and
-injects it into `.env`, and the installer auto-detects one on first run.
+**GitHub CLI (`gh`)** is automatically available inside containers. Shared
+authentication remains the default: all services receive the same `GH_TOKEN`,
+and the host's `GH_CONFIG_DIR` is mounted read-only as a Linux fallback. On
+Windows and macOS, `gh` normally stores tokens in the OS credential store,
+which the Linux container cannot read, so importing `GH_TOKEN` is required.
 
-The host's `~/.config/gh/` is still bind-mounted read-only as a fallback for
-Linux hosts that keep their token in `hosts.yml`. On **Windows and macOS**,
-`gh` stores the token in the OS credential store (Credential Manager /
-Keychain), not in `hosts.yml` — the Linux container cannot read those stores,
-so `GH_TOKEN` is required there.
+To isolate GitHub identities by container, configure every account explicitly:
 
-Because the mounted host config can expose an unusable `default` account
-alongside a working `GH_TOKEN`, verify auth with `gh api user` (which checks
-the credential `gh` actually uses for API calls) rather than `gh auth status`:
+```dotenv
+GH_AUTH_MODE=per-account
+
+GH_USER_A=github-login-a
+GH_TOKEN_A=...
+GH_USER_B=github-login-b
+GH_TOKEN_B=...
+
+# Optional commit identity overrides; global values remain the fallback.
+GIT_USER_NAME_A=Account A Name
+GIT_USER_EMAIL_A=account-a@example.com
+```
+
+Per-account mode has fail-closed behavior:
+
+- both `GH_USER_<LETTER>` and `GH_TOKEN_<LETTER>` are required through the
+  configured `NUM_ACCOUNTS` range (`A` through `ZZ`);
+- each service receives only its matching token as the standard in-container
+  `GH_TOKEN` variable, never the global token as a fallback;
+- the shared `GH_CONFIG_DIR` mount is omitted, so one service cannot read a
+  different account's `hosts.yml` credential; and
+- startup, update, and the TUI compare `gh api user --jq .login` with the
+  configured login and show the actual login or a distinct mismatch.
+
+Import a named account already stored by the host `gh` CLI without changing
+which host account is active:
+
+```bash
+# Bash / macOS / Linux
+scripts/claude-docker gh-auth a --user github-login-a
+scripts/claude-docker gh-auth claude-b --user github-login-b
+scripts/claude-docker gh-auth --all
+
+# Windows PowerShell equivalents
+.\scripts\claude-docker.ps1 gh-auth a --user github-login-a
+.\scripts\claude-docker.ps1 gh-auth --all
+```
+
+The targeted form recreates only that service when it is running. `--all` and
+`update` retrieve each token with
+`gh auth token --hostname github.com --user <login>`; they never call
+`gh auth switch`. The TUI's `g` action applies the same operation to the
+selected row.
+
+To migrate an existing installation, add the per-account mappings, set
+`GH_AUTH_MODE=per-account`, regenerate compose files, then recreate services:
+
+```bash
+scripts/generate-compose.sh       # use generate-compose.ps1 on Windows
+scripts/claude-docker up --force-recreate
+```
+
+Rotate a single credential by re-authenticating that login on the host and
+running targeted `gh-auth`; rotate all configured mappings with
+`gh-auth --all`. Tokens remain plaintext in the host `.env`, which is
+permission-hardened but should still be backed up, retained, and rotated as a
+secret.
+
+This feature covers `gh` and **HTTPS Git operations only** through `gh auth
+setup-git`; it does not isolate SSH keys or SSH agents. It protects accounts
+from other account containers by removing shared credential sources, but not
+from host administrators or anyone with Docker daemon access, who can inspect
+container environments.
+
+Verify auth with `gh api user` (which checks the credential `gh` actually uses
+for API calls) rather than `gh auth status`:
 
 ```bash
 # Verify gh auth inside container
@@ -500,7 +560,10 @@ scripts/claude-docker usage daily --since 20260301 --json    # Date filter + JSO
 ### Multi-account dashboard (TUI)
 
 A Bubble Tea-based terminal dashboard surfaces per-account container state,
-authentication status, recent activity, and live token usage in one view.
+authentication status, the actual GitHub login (including mismatch state),
+recent activity, and live token usage in one view. In per-account GitHub mode,
+the `g` action refreshes only the selected account and recreates only that
+service when it is running.
 
 ```bash
 scripts/claude-docker tui            # Launch dashboard (auto-fetches binary if missing)
@@ -592,7 +655,7 @@ All state is preserved across container restarts via Docker volume mounts:
 | Credentials | `~/.claude-state/account-a/.credentials.json` | `/home/node/.claude/.credentials.json` | Read-write |
 | Memory | `~/.claude-state/account-a/projects/*/memory/` | `/home/node/.claude/projects/*/memory/` | Read-write |
 | Host config (claude-config) | `~/.claude/` | `/home/node/.claude-host/` (symlinked) | Read-only |
-| GitHub CLI auth | `~/.config/gh/` | `/home/node/.config/gh/` | Read-only |
+| GitHub CLI auth (shared mode only) | `~/.config/gh/` | `/home/node/.config/gh/` | Read-only |
 | node_modules | Named volume `node_modules_a` | `${PROJECT_DIR}/node_modules/` | Read-write |
 | Project files | `${PROJECT_DIR}` bind mount | `${PROJECT_DIR}/` (mirrors host path) | Read-write |
 

--- a/scripts/ClaudeDocker.psm1
+++ b/scripts/ClaudeDocker.psm1
@@ -246,6 +246,24 @@ function Write-EnvContent {
     [System.IO.File]::WriteAllText($Path, $Content, $utf8NoBom)
 }
 
+function Protect-EnvFile {
+    <#
+    .SYNOPSIS
+    Restrict a secret-bearing env file to the current Windows user.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Path)
+
+    if ([Environment]::OSVersion.Platform -ne [PlatformID]::Win32NT -or
+        -not (Test-Path -LiteralPath $Path)) {
+        return
+    }
+    & icacls $Path /inheritance:r /grant:r "${env:USERNAME}:(M)" 2>$null | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to restrict permissions on $Path"
+    }
+}
+
 function Set-EnvValue {
     <#
     .SYNOPSIS
@@ -272,6 +290,7 @@ function Set-EnvValue {
 
     if (-not (Test-Path $Path)) {
         Write-EnvContent -Path $Path -Content "$line`n"
+        Protect-EnvFile -Path $Path
         return
     }
 
@@ -292,6 +311,7 @@ function Set-EnvValue {
     }
 
     Write-EnvContent -Path $Path -Content (($lines -join "`n") + "`n")
+    Protect-EnvFile -Path $Path
 }
 
 # --- Account Helpers ---------------------------------------------------------
@@ -586,7 +606,7 @@ Export-ModuleMember -Function @(
     # Prompts
     'Read-Selection', 'Read-Input', 'Read-Secret', 'Read-Confirmation',
     # Utilities
-    'Test-Command', 'ConvertTo-ForwardSlash',
+    'Test-Command', 'ConvertTo-ForwardSlash', 'Protect-EnvFile',
     # Accounts
     'Get-NumAccounts', 'Get-AgentRuntime', 'Get-ServicePrefix',
     'Get-PrimaryService', 'Get-AgentStateRoot', 'Get-ServiceNames',

--- a/scripts/claude-docker
+++ b/scripts/claude-docker
@@ -139,6 +139,53 @@ get_service_names() {
     echo "${names[@]}"
 }
 
+# Resolve GitHub auth mode from the caller environment, then .env, then the
+# backward-compatible shared default.
+get_gh_auth_mode() {
+    local mode="${GH_AUTH_MODE:-}"
+    if [[ -z "$mode" ]]; then
+        mode=$(parse_env_value "$PROJECT_ROOT/.env" "GH_AUTH_MODE")
+    fi
+    mode="${mode:-shared}"
+    case "$mode" in
+        shared|per-account) printf '%s' "$mode" ;;
+        *)
+            log_error "GH_AUTH_MODE must be shared or per-account (got: $mode)" >&2
+            return 1
+            ;;
+    esac
+}
+
+# Resolve a CLI target (account letter or full service name) to a configured
+# lowercase Excel-style account suffix. Enumeration avoids accepting a suffix
+# beyond NUM_ACCOUNTS while reusing the canonical index implementation.
+target_to_account_letter() {
+    local target
+    target=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+    local prefix
+    prefix=$(agent_service_prefix)
+    target="${target#"${prefix}"-}"
+
+    local n i letter
+    n=$(get_num_accounts)
+    for i in $(seq 1 "$n"); do
+        letter=$(index_to_letter "$i")
+        if [[ "$target" == "$letter" ]]; then
+            printf '%s' "$letter"
+            return 0
+        fi
+    done
+    return 1
+}
+
+account_service_name() {
+    printf '%s-%s' "$(agent_service_prefix)" "$1"
+}
+
+account_env_suffix() {
+    printf '%s' "$1" | tr '[:lower:]' '[:upper:]'
+}
+
 # --- Config Dir Path Builder ---------------------------------------------------
 
 # List account state directories under ~/.claude-state/account-*.
@@ -193,13 +240,11 @@ cmd_up() {
 
     # Lightweight post-start GitHub auth check (non-blocking)
     echo ""
-    local cid
     local primary
     primary=$(get_primary_service)
-    cid=$(get_container_id "$primary")
-    if [[ -n "$cid" ]]; then
+    if [[ -n "$(get_container_id "$primary")" ]]; then
         sleep 2  # wait for entrypoint gh auth setup
-        verify_container_gh_auth "$primary" || true
+        verify_all_container_gh_auth || true
     fi
 }
 
@@ -315,10 +360,20 @@ get_container_id() {
 
 # --- GitHub Auth Helpers -------------------------------------------------------
 
-# Refresh GH_TOKEN in .env from the host's gh CLI.
-# Returns 0 if token was verified/refreshed, 1 if gh is unavailable or unauthenticated.
-# Non-blocking: callers should treat return 1 as a warning, not an error.
-refresh_gh_token() {
+# Return the stored host token for a specific login without changing the
+# active host account. Passing an empty login preserves the legacy active-
+# account lookup.
+host_gh_token() {
+    local login="${1:-}"
+    if [[ -n "$login" ]]; then
+        gh auth token --hostname github.com --user "$login" 2>/dev/null
+    else
+        gh auth token 2>/dev/null
+    fi
+}
+
+# Refresh shared GH_TOKEN in .env from the host's active gh account.
+refresh_shared_gh_token() {
     local env_file="$PROJECT_ROOT/.env"
 
     if ! command -v gh &>/dev/null; then
@@ -334,7 +389,7 @@ refresh_gh_token() {
     fi
 
     local fresh_token
-    fresh_token=$(gh auth token 2>/dev/null)
+    fresh_token=$(host_gh_token "")
     if [[ -z "$fresh_token" ]]; then
         log_warn "Could not extract GitHub token from host gh CLI."
         return 1
@@ -367,6 +422,66 @@ refresh_gh_token() {
     return 0
 }
 
+# Refresh every configured per-account token using its explicit host login.
+# Tokens are collected before any write, so a missing host account cannot
+# leave only a prefix of the mappings updated.
+refresh_per_account_gh_tokens() {
+    local env_file="$PROJECT_ROOT/.env"
+    if ! command -v gh &>/dev/null; then
+        log_info "gh CLI not found on host — skipping GitHub token refresh."
+        return 1
+    fi
+    if [[ ! -f "$env_file" ]]; then
+        log_warn ".env not found — cannot refresh per-account GitHub tokens."
+        return 1
+    fi
+
+    local n i letter upper user token
+    local users=() tokens=() suffixes=()
+    n=$(get_num_accounts)
+    for i in $(seq 1 "$n"); do
+        letter=$(index_to_letter "$i")
+        upper=$(account_env_suffix "$letter")
+        user=$(parse_env_value "$env_file" "GH_USER_${upper}")
+        if [[ -z "$user" ]]; then
+            log_warn "GH_USER_${upper} is missing; per-account token refresh skipped."
+            return 1
+        fi
+        if ! token=$(host_gh_token "$user") || [[ -z "$token" ]]; then
+            log_warn "Could not extract a GitHub token for configured login '$user' (Account $upper)."
+            return 1
+        fi
+        users+=("$user")
+        tokens+=("$token")
+        suffixes+=("$upper")
+    done
+
+    local changed=0 current
+    for i in "${!suffixes[@]}"; do
+        upper="${suffixes[$i]}"
+        current=$(parse_env_value "$env_file" "GH_TOKEN_${upper}")
+        if [[ "$current" != "${tokens[$i]}" ]]; then
+            set_env_value "$env_file" "GH_TOKEN_${upper}" "${tokens[$i]}"
+            changed=$((changed + 1))
+        fi
+    done
+    chmod 600 "$env_file"
+    echo -e "  ${GREEN}*${NC} Per-account GitHub tokens verified (${#users[@]} account(s), $changed updated)."
+    return 0
+}
+
+# Refresh whichever token model the installation uses. Non-blocking callers
+# should treat a non-zero result as a warning.
+refresh_gh_token() {
+    local mode
+    mode=$(get_gh_auth_mode) || return 1
+    if [[ "$mode" == "per-account" ]]; then
+        refresh_per_account_gh_tokens
+    else
+        refresh_shared_gh_token
+    fi
+}
+
 # Verify GitHub auth inside a running container.
 # Uses `gh api user` rather than `gh auth status`: when GH_TOKEN coexists with
 # a mounted host gh config, `gh auth status` also evaluates the unusable
@@ -381,49 +496,72 @@ verify_container_gh_auth() {
         return 1
     fi
 
-    if docker exec "$cid" gh api user --jq .login >/dev/null 2>&1; then
-        echo -e "  ${GREEN}*${NC} GitHub auth: OK ($svc)"
-        return 0
-    else
+    local actual
+    if ! actual=$(docker exec "$cid" gh api user --jq .login 2>/dev/null) || [[ -z "$actual" ]]; then
         echo -e "  ${YELLOW}!${NC} GitHub auth: not configured ($svc)"
         echo -e "    ${DIM}git push/pull and gh commands may fail.${NC}"
         echo -e "    Fix: ${DIM}scripts/claude-docker gh-auth${NC}"
         return 1
     fi
+
+    local mode expected="" letter upper actual_lower expected_lower
+    mode=$(get_gh_auth_mode) || return 1
+    if [[ "$mode" == "per-account" ]]; then
+        letter="${svc#"$(agent_service_prefix)"-}"
+        upper=$(account_env_suffix "$letter")
+        expected=$(parse_env_value "$PROJECT_ROOT/.env" "GH_USER_${upper}")
+        actual_lower=$(printf '%s' "$actual" | tr '[:upper:]' '[:lower:]')
+        expected_lower=$(printf '%s' "$expected" | tr '[:upper:]' '[:lower:]')
+        if [[ -n "$expected" && "$actual_lower" != "$expected_lower" ]]; then
+            echo -e "  ${YELLOW}!${NC} GitHub auth: MISMATCH ($svc)"
+            echo -e "    actual: ${BOLD}${actual}${NC}"
+            echo -e "    expected: ${BOLD}${expected}${NC} (GH_USER_${upper})"
+            return 2
+        fi
+    fi
+
+    echo -e "  ${GREEN}*${NC} GitHub auth: ${BOLD}${actual}${NC} ($svc)"
+    return 0
 }
 
-cmd_gh_auth() {
-    # Extract GitHub token from host's gh CLI and inject as GH_TOKEN in .env
+# Verify every configured service that currently has a running container.
+verify_all_container_gh_auth() {
+    local failed=0 svc
+    read -ra services <<< "$(get_service_names)"
+    for svc in "${services[@]}"; do
+        if [[ -n "$(get_container_id "$svc")" ]]; then
+            verify_container_gh_auth "$svc" || failed=1
+        fi
+    done
+    return "$failed"
+}
+
+cmd_gh_auth_shared() {
     if ! command -v gh &>/dev/null; then
         log_error "gh CLI not found on host."
-        exit 1
+        return 1
     fi
 
     if ! gh auth status >/dev/null 2>&1; then
         log_error "GitHub CLI not authenticated on host."
         echo -e "  Run first: ${DIM}gh auth login -h github.com${NC}"
-        exit 1
+        return 1
     fi
 
     local token
-    token=$(gh auth token 2>/dev/null)
+    token=$(host_gh_token "")
     if [[ -z "$token" ]]; then
         log_error "Could not extract GitHub token from gh CLI."
-        exit 1
+        return 1
     fi
 
     local env_file="$PROJECT_ROOT/.env"
     if [[ ! -f "$env_file" ]]; then
         log_error ".env file not found at $env_file"
-        exit 1
+        return 1
     fi
 
-    # Update or append GH_TOKEN in .env
-    if grep -q '^GH_TOKEN=' "$env_file" 2>/dev/null; then
-        perl -i -pe "s|^GH_TOKEN=.*|GH_TOKEN=${token}|" "$env_file"
-    else
-        echo "GH_TOKEN=${token}" >> "$env_file"
-    fi
+    set_env_value "$env_file" "GH_TOKEN" "$token"
     chmod 600 "$env_file"
 
     echo -e "${GREEN}GitHub token injected into .env${NC}"
@@ -433,8 +571,8 @@ cmd_gh_auth() {
     local running
     running=$("${COMPOSE_CMD[@]}" ps -q 2>/dev/null | head -1)
     if [[ -n "$running" ]]; then
-        echo -e "${CYAN}Restarting containers to apply...${NC}"
-        "${COMPOSE_CMD[@]}" down && "${COMPOSE_CMD[@]}" up -d
+        echo -e "${CYAN}Recreating containers to apply...${NC}"
+        "${COMPOSE_CMD[@]}" up -d --force-recreate
 
         # Verify inside container
         sleep 2
@@ -445,10 +583,137 @@ cmd_gh_auth() {
         if [[ -n "$cid" ]]; then
             echo ""
             echo -e "${BOLD}Verifying GitHub auth in ${primary}:${NC}"
-            docker exec "$cid" gh auth status 2>&1 || true
+            verify_all_container_gh_auth || true
         fi
     else
         log_info "Containers not running. Token will be available on next start."
+    fi
+}
+
+cmd_gh_auth_per_account() {
+    if ! command -v gh &>/dev/null; then
+        log_error "gh CLI not found on host."
+        return 1
+    fi
+
+    local all=false target="" login=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --all) all=true; shift ;;
+            --user)
+                if [[ $# -lt 2 || -z "$2" ]]; then
+                    log_error "--user requires a GitHub login."
+                    return 1
+                fi
+                login="$2"
+                shift 2
+                ;;
+            --*)
+                log_error "Unknown gh-auth option: $1"
+                return 1
+                ;;
+            *)
+                if [[ -n "$target" ]]; then
+                    log_error "Only one service or account letter may be selected."
+                    return 1
+                fi
+                target="$1"
+                shift
+                ;;
+        esac
+    done
+
+    local env_file="$PROJECT_ROOT/.env"
+    if [[ ! -f "$env_file" ]]; then
+        log_error ".env file not found at $env_file"
+        return 1
+    fi
+
+    local letters=() users=() tokens=() services=()
+    local letter upper token i n user
+    if [[ "$all" == true ]]; then
+        if [[ -n "$target" || -n "$login" ]]; then
+            log_error "gh-auth --all cannot be combined with a target or --user."
+            return 1
+        fi
+        n=$(get_num_accounts)
+        for i in $(seq 1 "$n"); do
+            letter=$(index_to_letter "$i")
+            upper=$(account_env_suffix "$letter")
+            user=$(parse_env_value "$env_file" "GH_USER_${upper}")
+            if [[ -z "$user" ]]; then
+                log_error "GH_USER_${upper} is required for gh-auth --all."
+                return 1
+            fi
+            if ! token=$(host_gh_token "$user") || [[ -z "$token" ]]; then
+                log_error "Could not extract a GitHub token for login '$user' (Account $upper)."
+                return 1
+            fi
+            letters+=("$letter")
+            users+=("$user")
+            tokens+=("$token")
+            services+=("$(account_service_name "$letter")")
+        done
+    else
+        if [[ -z "$target" || -z "$login" ]]; then
+            log_error "Usage: claude-docker gh-auth <service-or-letter> --user <login>"
+            return 1
+        fi
+        if ! letter=$(target_to_account_letter "$target"); then
+            log_error "Unknown or unconfigured account target: $target"
+            return 1
+        fi
+        upper=$(account_env_suffix "$letter")
+        if ! token=$(host_gh_token "$login") || [[ -z "$token" ]]; then
+            log_error "Could not extract a GitHub token for login '$login' (Account $upper)."
+            return 1
+        fi
+        letters+=("$letter")
+        users+=("$login")
+        tokens+=("$token")
+        services+=("$(account_service_name "$letter")")
+    fi
+
+    # Persist only after every requested host token has been retrieved.
+    for i in "${!letters[@]}"; do
+        upper=$(account_env_suffix "${letters[$i]}")
+        set_env_value "$env_file" "GH_USER_${upper}" "${users[$i]}"
+        set_env_value "$env_file" "GH_TOKEN_${upper}" "${tokens[$i]}"
+        echo -e "  ${GREEN}*${NC} Account $upper mapped to GitHub login '${users[$i]}'."
+    done
+    chmod 600 "$env_file"
+
+    ensure_compose_cmd
+    local running_services=()
+    for i in "${!services[@]}"; do
+        if [[ -n "$(get_container_id "${services[$i]}")" ]]; then
+            running_services+=("${services[$i]}")
+        fi
+    done
+    if [[ ${#running_services[@]} -eq 0 ]]; then
+        log_info "Selected containers are not running. Tokens will be available on next start."
+        return 0
+    fi
+
+    echo -e "${CYAN}Recreating selected container(s) to apply...${NC}"
+    "${COMPOSE_CMD[@]}" up -d --force-recreate "${running_services[@]}"
+    sleep 2
+    for i in "${!running_services[@]}"; do
+        verify_container_gh_auth "${running_services[$i]}" || true
+    done
+}
+
+cmd_gh_auth() {
+    local mode
+    mode=$(get_gh_auth_mode) || return 1
+    if [[ "$mode" == "per-account" ]]; then
+        cmd_gh_auth_per_account "$@"
+    else
+        if [[ $# -gt 0 && "$1" != "--all" ]]; then
+            log_error "Targeted gh-auth requires GH_AUTH_MODE=per-account."
+            return 1
+        fi
+        cmd_gh_auth_shared
     fi
 }
 
@@ -502,7 +767,7 @@ cmd_update() {
 
         # Wait briefly for entrypoint to complete gh auth setup
         sleep 2
-        verify_container_gh_auth "$primary" || true
+        verify_all_container_gh_auth || true
 
         echo ""
         echo -e "${GREEN}Update complete.${NC}"
@@ -755,7 +1020,8 @@ ${BOLD}INTERACTIVE${NC}
   ${GREEN}claude${NC} [service]      Start Claude Code (default: claude-a)
   ${GREEN}codex${NC} [service]       Start OpenAI Codex CLI (default: codex-a)
   ${GREEN}tui${NC}                   Launch multi-account dashboard TUI
-  ${GREEN}gh-auth${NC}               Inject GitHub token from host gh CLI into containers
+  ${GREEN}gh-auth${NC} [target]      Import shared or per-account host gh credentials
+                        Per-account: <service-or-letter> --user <login> | --all
   ${GREEN}exec${NC} <service>        Open shell in a service
 
 ${BOLD}USAGE TRACKING${NC}
@@ -780,7 +1046,7 @@ HELP
     prefix=$(agent_service_prefix)
     for idx in "${!svc_names[@]}"; do
         local svc="${svc_names[$idx]}"
-        local suffix="${svc#${prefix}-}"
+        local suffix="${svc#"${prefix}"-}"
         local label
         label="Account $(printf '%s' "$suffix" | tr '[:lower:]' '[:upper:]')"
         if [[ "$idx" -eq 0 ]]; then

--- a/scripts/claude-docker.ps1
+++ b/scripts/claude-docker.ps1
@@ -42,6 +42,40 @@ $ProjectRoot = Split-Path $PSScriptRoot -Parent
 
 # --- Account Directory Helpers -----------------------------------------------
 
+function Get-GhAuthMode {
+    $mode = [Environment]::GetEnvironmentVariable('GH_AUTH_MODE')
+    if ([string]::IsNullOrEmpty($mode)) {
+        $mode = Get-EnvValue -Path (Join-Path $ProjectRoot '.env') -Key 'GH_AUTH_MODE'
+    }
+    if ([string]::IsNullOrEmpty($mode)) { $mode = 'shared' }
+    $mode = $mode.ToLowerInvariant()
+    if ($mode -notin @('shared', 'per-account')) {
+        throw "GH_AUTH_MODE must be shared or per-account (got: $mode)"
+    }
+    return $mode
+}
+
+function Resolve-AccountLetter {
+    param([Parameter(Mandatory)][string]$Target)
+
+    $candidate = $Target.ToLowerInvariant()
+    $prefix = Get-ServicePrefix -ProjectRoot $ProjectRoot
+    if ($candidate.StartsWith("${prefix}-")) {
+        $candidate = $candidate.Substring($prefix.Length + 1)
+    }
+    $count = Get-NumAccounts -ProjectRoot $ProjectRoot
+    for ($i = 1; $i -le $count; $i++) {
+        $letter = ConvertTo-AccountLetter -Index $i
+        if ($candidate -eq $letter) { return $letter }
+    }
+    return $null
+}
+
+function Get-AccountEnvSuffix {
+    param([Parameter(Mandatory)][string]$Letter)
+    return $Letter.ToUpperInvariant()
+}
+
 function Get-AccountDirs {
     $stateBase = Get-AgentStateRoot -ProjectRoot $ProjectRoot
     if (-not (Test-Path $stateBase)) { return @() }
@@ -89,7 +123,7 @@ function Invoke-Up {
     $cid = Get-ContainerId -ProjectRoot $ProjectRoot -Service $primary
     if ($cid) {
         Start-Sleep -Seconds 2  # wait for entrypoint gh auth setup
-        Test-ContainerGhAuth -Service $primary | Out-Null
+        Test-AllContainerGhAuth | Out-Null
     }
 }
 
@@ -189,7 +223,20 @@ function Invoke-Agent {
     Invoke-Compose -ProjectRoot $ProjectRoot exec $service @agentArgs
 }
 
-function Invoke-GhAuth {
+function Get-HostGhToken {
+    param([string]$User = '')
+
+    if ($User) {
+        $token = & gh auth token --hostname github.com --user $User 2>$null
+    }
+    else {
+        $token = & gh auth token 2>$null
+    }
+    if ($LASTEXITCODE -ne 0) { return $null }
+    return ([string]($token | Select-Object -First 1)).Trim()
+}
+
+function Invoke-GhAuthShared {
     if (-not (Test-Command 'gh')) {
         Write-LogError 'gh CLI not found on host.'
         exit 1
@@ -202,7 +249,7 @@ function Invoke-GhAuth {
         exit 1
     }
 
-    $token = & gh auth token 2>$null
+    $token = Get-HostGhToken
     if (-not $token) {
         Write-LogError 'Could not extract GitHub token from gh CLI.'
         exit 1
@@ -221,16 +268,15 @@ function Invoke-GhAuth {
     $primary = Get-PrimaryService -ProjectRoot $ProjectRoot
     $running = Get-ContainerId -ProjectRoot $ProjectRoot -Service $primary
     if ($running) {
-        Write-Host 'Restarting containers to apply...' -ForegroundColor Cyan
-        Invoke-Compose -ProjectRoot $ProjectRoot down
-        Invoke-Compose -ProjectRoot $ProjectRoot up --detach
+        Write-Host 'Recreating containers to apply...' -ForegroundColor Cyan
+        Invoke-Compose -ProjectRoot $ProjectRoot up --detach --force-recreate
 
         Start-Sleep -Seconds 2
         $cid = Get-ContainerId -ProjectRoot $ProjectRoot -Service $primary
         if ($cid) {
             Write-Host ''
             Write-Host "Verifying GitHub auth in ${primary}:" -ForegroundColor White
-            & docker exec $cid gh auth status 2>&1
+            Test-AllContainerGhAuth | Out-Null
         }
     }
     else {
@@ -238,9 +284,141 @@ function Invoke-GhAuth {
     }
 }
 
+function Invoke-GhAuthPerAccount {
+    if (-not (Test-Command 'gh')) {
+        Write-LogError 'gh CLI not found on host.'
+        exit 1
+    }
+
+    $all = $false
+    $target = ''
+    $login = ''
+    for ($i = 0; $i -lt $Arguments.Count; $i++) {
+        switch ($Arguments[$i]) {
+            '--all' { $all = $true; break }
+            '--user' {
+                if ($i + 1 -ge $Arguments.Count -or [string]::IsNullOrEmpty($Arguments[$i + 1])) {
+                    Write-LogError '--user requires a GitHub login.'
+                    exit 1
+                }
+                $i++
+                $login = $Arguments[$i]
+                break
+            }
+            { $_.StartsWith('--') } {
+                Write-LogError "Unknown gh-auth option: $_"
+                exit 1
+            }
+            default {
+                if ($target) {
+                    Write-LogError 'Only one service or account letter may be selected.'
+                    exit 1
+                }
+                $target = $Arguments[$i]
+            }
+        }
+    }
+
+    $envFile = Join-Path $ProjectRoot '.env'
+    if (-not (Test-Path $envFile)) {
+        Write-LogError ".env file not found at $envFile"
+        exit 1
+    }
+
+    $letters = @()
+    $users = @()
+    $tokens = @()
+    $services = @()
+    if ($all) {
+        if ($target -or $login) {
+            Write-LogError 'gh-auth --all cannot be combined with a target or --user.'
+            exit 1
+        }
+        $count = Get-NumAccounts -ProjectRoot $ProjectRoot
+        for ($i = 1; $i -le $count; $i++) {
+            $letter = ConvertTo-AccountLetter -Index $i
+            $upper = Get-AccountEnvSuffix -Letter $letter
+            $user = Get-EnvValue -Path $envFile -Key "GH_USER_${upper}"
+            if (-not $user) {
+                Write-LogError "GH_USER_${upper} is required for gh-auth --all."
+                exit 1
+            }
+            $token = Get-HostGhToken -User $user
+            if (-not $token) {
+                Write-LogError "Could not extract a GitHub token for login '$user' (Account $upper)."
+                exit 1
+            }
+            $letters += $letter
+            $users += $user
+            $tokens += $token
+            $services += "$(Get-ServicePrefix -ProjectRoot $ProjectRoot)-$letter"
+        }
+    }
+    else {
+        if (-not $target -or -not $login) {
+            Write-LogError 'Usage: claude-docker gh-auth <service-or-letter> --user <login>'
+            exit 1
+        }
+        $letter = Resolve-AccountLetter -Target $target
+        if (-not $letter) {
+            Write-LogError "Unknown or unconfigured account target: $target"
+            exit 1
+        }
+        $upper = Get-AccountEnvSuffix -Letter $letter
+        $token = Get-HostGhToken -User $login
+        if (-not $token) {
+            Write-LogError "Could not extract a GitHub token for login '$login' (Account $upper)."
+            exit 1
+        }
+        $letters += $letter
+        $users += $login
+        $tokens += $token
+        $services += "$(Get-ServicePrefix -ProjectRoot $ProjectRoot)-$letter"
+    }
+
+    # Persist only after every requested token was retrieved successfully.
+    for ($i = 0; $i -lt $letters.Count; $i++) {
+        $upper = Get-AccountEnvSuffix -Letter $letters[$i]
+        Set-EnvValue -Path $envFile -Key "GH_USER_${upper}" -Value $users[$i]
+        Set-EnvValue -Path $envFile -Key "GH_TOKEN_${upper}" -Value $tokens[$i]
+        Write-Host "  * Account $upper mapped to GitHub login '$($users[$i])'." -ForegroundColor Green
+    }
+
+    $runningServices = @()
+    foreach ($service in $services) {
+        if (Get-ContainerId -ProjectRoot $ProjectRoot -Service $service) {
+            $runningServices += $service
+        }
+    }
+    if ($runningServices.Count -eq 0) {
+        Write-LogInfo 'Selected containers are not running. Tokens will be available on next start.'
+        return
+    }
+
+    Write-Host 'Recreating selected container(s) to apply...' -ForegroundColor Cyan
+    Invoke-Compose -ProjectRoot $ProjectRoot up --detach --force-recreate @runningServices
+    Start-Sleep -Seconds 2
+    foreach ($service in $runningServices) {
+        Test-ContainerGhAuth -Service $service | Out-Null
+    }
+}
+
+function Invoke-GhAuth {
+    $mode = Get-GhAuthMode
+    if ($mode -eq 'per-account') {
+        Invoke-GhAuthPerAccount
+        return
+    }
+    if ($Arguments.Count -gt 0 -and $Arguments[0] -ne '--all') {
+        Write-LogError 'Targeted gh-auth requires GH_AUTH_MODE=per-account.'
+        exit 1
+    }
+    Invoke-GhAuthShared
+}
+
 # --- GitHub Auth Helpers ------------------------------------------------------
 
-function Update-GhToken {
+function Update-SharedGhToken {
     <#
     .SYNOPSIS
     Refresh GH_TOKEN in .env from the host's gh CLI.
@@ -264,7 +442,7 @@ function Update-GhToken {
         return $false
     }
 
-    $freshToken = & gh auth token 2>$null
+    $freshToken = Get-HostGhToken
     if (-not $freshToken) {
         Write-LogWarn 'Could not extract GitHub token from host gh CLI.'
         return $false
@@ -298,6 +476,55 @@ function Update-GhToken {
     return $true
 }
 
+function Update-PerAccountGhTokens {
+    $envFile = Join-Path $ProjectRoot '.env'
+    if (-not (Test-Command 'gh')) {
+        Write-LogInfo 'gh CLI not found on host — skipping GitHub token refresh.'
+        return $false
+    }
+    if (-not (Test-Path $envFile)) {
+        Write-LogWarn '.env not found — cannot refresh per-account GitHub tokens.'
+        return $false
+    }
+
+    $suffixes = @()
+    $tokens = @()
+    $count = Get-NumAccounts -ProjectRoot $ProjectRoot
+    for ($i = 1; $i -le $count; $i++) {
+        $upper = (ConvertTo-AccountLetter -Index $i).ToUpperInvariant()
+        $user = Get-EnvValue -Path $envFile -Key "GH_USER_${upper}"
+        if (-not $user) {
+            Write-LogWarn "GH_USER_${upper} is missing; per-account token refresh skipped."
+            return $false
+        }
+        $token = Get-HostGhToken -User $user
+        if (-not $token) {
+            Write-LogWarn "Could not extract a GitHub token for configured login '$user' (Account $upper)."
+            return $false
+        }
+        $suffixes += $upper
+        $tokens += $token
+    }
+
+    $changed = 0
+    for ($i = 0; $i -lt $suffixes.Count; $i++) {
+        $key = "GH_TOKEN_$($suffixes[$i])"
+        if ((Get-EnvValue -Path $envFile -Key $key) -ne $tokens[$i]) {
+            Set-EnvValue -Path $envFile -Key $key -Value $tokens[$i]
+            $changed++
+        }
+    }
+    Write-Host "  * Per-account GitHub tokens verified ($($suffixes.Count) account(s), $changed updated)." -ForegroundColor Green
+    return $true
+}
+
+function Update-GhToken {
+    if ((Get-GhAuthMode) -eq 'per-account') {
+        return (Update-PerAccountGhTokens)
+    }
+    return (Update-SharedGhToken)
+}
+
 function Test-ContainerGhAuth {
     <#
     .SYNOPSIS
@@ -316,17 +543,41 @@ function Test-ContainerGhAuth {
     $cid = Get-ContainerId -ProjectRoot $ProjectRoot -Service $Service
     if (-not $cid) { return $false }
 
-    $null = & docker exec $cid gh api user --jq .login 2>&1
-    if ($LASTEXITCODE -eq 0) {
-        Write-Host "  * GitHub auth: OK ($Service)" -ForegroundColor Green
-        return $true
-    }
-    else {
+    $output = @(& docker exec $cid gh api user --jq .login 2>$null)
+    $exitCode = $LASTEXITCODE
+    $actual = ($output -join '').Trim()
+    if ($exitCode -ne 0 -or -not $actual) {
         Write-Host "  ! GitHub auth: not configured ($Service)" -ForegroundColor Yellow
         Write-Host '    git push/pull and gh commands may fail.' -ForegroundColor DarkGray
         Write-Host '    Fix: .\scripts\claude-docker.ps1 gh-auth' -ForegroundColor DarkGray
         return $false
     }
+
+    if ((Get-GhAuthMode) -eq 'per-account') {
+        $prefix = Get-ServicePrefix -ProjectRoot $ProjectRoot
+        $letter = $Service.Substring($prefix.Length + 1)
+        $upper = $letter.ToUpperInvariant()
+        $expected = Get-EnvValue -Path (Join-Path $ProjectRoot '.env') -Key "GH_USER_${upper}"
+        if ($expected -and -not $actual.Equals($expected, [StringComparison]::OrdinalIgnoreCase)) {
+            Write-Host "  ! GitHub auth: MISMATCH ($Service)" -ForegroundColor Yellow
+            Write-Host "    actual: $actual"
+            Write-Host "    expected: $expected (GH_USER_${upper})"
+            return $false
+        }
+    }
+
+    Write-Host "  * GitHub auth: $actual ($Service)" -ForegroundColor Green
+    return $true
+}
+
+function Test-AllContainerGhAuth {
+    $ok = $true
+    foreach ($service in (Get-ServiceNames -ProjectRoot $ProjectRoot)) {
+        if (Get-ContainerId -ProjectRoot $ProjectRoot -Service $service) {
+            if (-not (Test-ContainerGhAuth -Service $service)) { $ok = $false }
+        }
+    }
+    return $ok
 }
 
 function Invoke-Build {
@@ -370,7 +621,7 @@ function Invoke-Update {
 
         # Wait briefly for entrypoint to complete gh auth setup
         Start-Sleep -Seconds 2
-        Test-ContainerGhAuth -Service $primary | Out-Null
+        Test-AllContainerGhAuth | Out-Null
 
         Write-Host ''
         Write-Host 'Update complete.' -ForegroundColor Green
@@ -559,7 +810,8 @@ function Show-Help {
     Write-Host 'INTERACTIVE' -ForegroundColor White
     Write-Host '  claude [service]      ' -ForegroundColor Green -NoNewline; Write-Host 'Start Claude Code (default: claude-a)'
     Write-Host '  codex [service]       ' -ForegroundColor Green -NoNewline; Write-Host 'Start OpenAI Codex CLI (default: codex-a)'
-    Write-Host '  gh-auth               ' -ForegroundColor Green -NoNewline; Write-Host 'Inject GitHub token from host gh CLI'
+    Write-Host '  gh-auth [target]      ' -ForegroundColor Green -NoNewline; Write-Host 'Import shared or per-account host gh credentials'
+    Write-Host '                        Per-account: <service-or-letter> --user <login> | --all'
     Write-Host '  exec <service>        ' -ForegroundColor Green -NoNewline; Write-Host 'Open shell in a service'
     Write-Host ''
     Write-Host 'USAGE TRACKING' -ForegroundColor White

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -58,11 +58,16 @@ fi
 runtime_bootstrap
 
 # --- Git identity ----------------------------------------------------------------
-# Set git user from environment variables (if not already configured)
-if [ -n "${GIT_USER_NAME:-}" ] && [ -z "$(git config --global user.name 2>/dev/null)" ]; then
+# Shared mode preserves the existing initialize-once behavior. Per-account
+# mode reapplies the selected account identity on each start so changing an
+# account-specific override cannot be masked by an older value in persistent
+# runtime state.
+if [ -n "${GIT_USER_NAME:-}" ] && \
+   { [ "${GH_AUTH_MODE:-shared}" = "per-account" ] || [ -z "$(git config --global user.name 2>/dev/null)" ]; }; then
     git config --global user.name "$GIT_USER_NAME"
 fi
-if [ -n "${GIT_USER_EMAIL:-}" ] && [ -z "$(git config --global user.email 2>/dev/null)" ]; then
+if [ -n "${GIT_USER_EMAIL:-}" ] && \
+   { [ "${GH_AUTH_MODE:-shared}" = "per-account" ] || [ -z "$(git config --global user.email 2>/dev/null)" ]; }; then
     git config --global user.email "$GIT_USER_EMAIL"
 fi
 
@@ -86,12 +91,37 @@ if [ -d /project ] && [ "${CLAUDE_NORMALIZE_CRLF:-0}" = "1" ]; then
 fi
 
 # --- Git credential helper (gh) -------------------------------------------------
-# Wire gh as git credential helper so git push/pull uses the mounted gh token
+# Validate the credential used for API calls and, when configured, compare its
+# canonical login with the account expected by the host configuration.
+verify_github_login() {
+    local actual actual_lower expected_lower
+    if ! actual=$(gh api user --jq .login 2>/dev/null) || [ -z "$actual" ]; then
+        echo "[entrypoint] WARNING: GitHub token is invalid or missing."
+        return 1
+    fi
+
+    if [ -n "${GH_USER:-}" ]; then
+        actual_lower=$(printf '%s' "$actual" | tr '[:upper:]' '[:lower:]')
+        expected_lower=$(printf '%s' "$GH_USER" | tr '[:upper:]' '[:lower:]')
+        if [ "$actual_lower" != "$expected_lower" ]; then
+            echo "[entrypoint] WARNING: GitHub login mismatch."
+            echo "  actual: $actual"
+            echo "  expected: $GH_USER"
+            return 2
+        fi
+    fi
+
+    echo "[entrypoint] GitHub auth: authenticated as $actual"
+    return 0
+}
+
+# Wire gh as git credential helper so git push/pull uses the selected token.
 if command -v gh >/dev/null 2>&1; then
     if [ -n "${GH_TOKEN:-}" ]; then
         # GH_TOKEN env var takes precedence — no hosts.yml needed
         gh auth setup-git 2>/dev/null || true
         echo "[entrypoint] GitHub auth: using GH_TOKEN environment variable"
+        verify_github_login || true
     elif [ -f /home/node/.config/gh/hosts.yml ]; then
         gh auth setup-git 2>/dev/null || true
         # Validate the credential gh actually uses for API calls. `gh api user`
@@ -99,8 +129,7 @@ if command -v gh >/dev/null 2>&1; then
         # evaluates the unusable mounted `default` account and exits non-zero.
         # macOS Keychain / Windows Credential Manager tokens are NOT in
         # hosts.yml — only the host config structure is present.
-        if ! gh api user --jq .login >/dev/null 2>&1; then
-            echo "[entrypoint] WARNING: GitHub token is invalid or missing."
+        if ! verify_github_login; then
             echo "  On macOS/Windows, gh stores tokens in OS credential stores"
             echo "  (Keychain / Credential Manager), not in hosts.yml."
             echo "  The read-only bind mount cannot access these tokens."

--- a/scripts/generate-compose.ps1
+++ b/scripts/generate-compose.ps1
@@ -137,6 +137,26 @@ $CpuReservation = Resolve-EnvOrDefault 'CONTAINER_CPU_RESERVATION' '1'
 $MemLimit       = Resolve-EnvOrDefault 'CONTAINER_MEM_LIMIT' '4G'
 $MemReservation = Resolve-EnvOrDefault 'CONTAINER_MEM_RESERVATION' '2G'
 
+# GitHub authentication is shared by default for backward compatibility.
+# Validate per-account mappings before opening any output file so failures do
+# not leave partially regenerated compose files behind.
+$GhAuthMode = (Resolve-EnvOrDefault 'GH_AUTH_MODE' 'shared').ToLowerInvariant()
+if ($GhAuthMode -notin @('shared', 'per-account')) {
+    Write-Error "GH_AUTH_MODE must be shared or per-account (got: $GhAuthMode)"
+    exit 1
+}
+if ($GhAuthMode -eq 'per-account') {
+    for ($i = 1; $i -le $NumAccounts; $i++) {
+        $upper = Get-AccountLetterUpper -Index $i
+        foreach ($key in @("GH_USER_${upper}", "GH_TOKEN_${upper}")) {
+            if ([string]::IsNullOrEmpty((Resolve-EnvOrDefault $key ''))) {
+                Write-Error "$key is required when GH_AUTH_MODE=per-account"
+                exit 1
+            }
+        }
+    }
+}
+
 # Thin wrappers around the shared helpers in lib/index.ps1 so legacy call
 # sites below keep working without rewriting each loop. Both helpers accept
 # indices 1..702 and throw out-of-range otherwise.
@@ -201,7 +221,9 @@ function New-BaseCompose {
         if ($RtMountsAgentsSkills -eq $true) {
             [void]$sb.AppendLine('      - ${AGENTS_SKILLS_DIR:-${HOME}/.agents/skills}:/home/node/.agents/skills:ro')
         }
-        [void]$sb.AppendLine('      - ${GH_CONFIG_DIR:-${HOME}/.config/gh}:/home/node/.config/gh:ro')
+        if ($GhAuthMode -eq 'shared') {
+            [void]$sb.AppendLine('      - ${GH_CONFIG_DIR:-${HOME}/.config/gh}:/home/node/.config/gh:ro')
+        }
         [void]$sb.AppendLine("      - node_modules_${letter}:`${CONTAINER_PROJECT_DIR:-/project}/node_modules")
         [void]$sb.AppendLine('    environment:')
         [void]$sb.AppendLine('      - TERM=xterm-256color')
@@ -235,9 +257,22 @@ function New-BaseCompose {
         if (-not [string]::IsNullOrEmpty($keyValue)) {
             [void]$sb.AppendLine("      - ${RtSdkApiKeyVar}=`${${keyVarName}}")
         }
-        [void]$sb.AppendLine('      - GH_TOKEN=${GH_TOKEN:-}')
-        [void]$sb.AppendLine('      - GIT_USER_NAME=${GIT_USER_NAME:-}')
-        [void]$sb.AppendLine('      - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}')
+        if ($GhAuthMode -eq 'per-account') {
+            $ghUserVar = "GH_USER_${upper}"
+            $ghTokenVar = "GH_TOKEN_${upper}"
+            $gitNameVar = "GIT_USER_NAME_${upper}"
+            $gitEmailVar = "GIT_USER_EMAIL_${upper}"
+            [void]$sb.AppendLine('      - GH_AUTH_MODE=per-account')
+            [void]$sb.AppendLine("      - GH_USER=`${${ghUserVar}}")
+            [void]$sb.AppendLine("      - GH_TOKEN=`${${ghTokenVar}}")
+            [void]$sb.AppendLine("      - GIT_USER_NAME=`${${gitNameVar}:-`${GIT_USER_NAME:-}}")
+            [void]$sb.AppendLine("      - GIT_USER_EMAIL=`${${gitEmailVar}:-`${GIT_USER_EMAIL:-}}")
+        }
+        else {
+            [void]$sb.AppendLine('      - GH_TOKEN=${GH_TOKEN:-}')
+            [void]$sb.AppendLine('      - GIT_USER_NAME=${GIT_USER_NAME:-}')
+            [void]$sb.AppendLine('      - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}')
+        }
         [void]$sb.AppendLine('    deploy:')
         [void]$sb.AppendLine('      resources:')
         [void]$sb.AppendLine('        limits:')

--- a/scripts/generate-compose.sh
+++ b/scripts/generate-compose.sh
@@ -98,6 +98,34 @@ CPU_RESERVATION="${CONTAINER_CPU_RESERVATION:-1}"
 MEM_LIMIT="${CONTAINER_MEM_LIMIT:-4G}"
 MEM_RESERVATION="${CONTAINER_MEM_RESERVATION:-2G}"
 
+# GitHub authentication is shared by default for backward compatibility.
+# Per-account mode is validated before any compose file is opened so a missing
+# mapping cannot leave a partially regenerated output behind.
+GH_AUTH_MODE="${GH_AUTH_MODE:-shared}"
+case "$GH_AUTH_MODE" in
+    shared|per-account) ;;
+    *)
+        echo "Error: GH_AUTH_MODE must be shared or per-account (got: $GH_AUTH_MODE)" >&2
+        exit 1
+        ;;
+esac
+
+if [[ "$GH_AUTH_MODE" == "per-account" ]]; then
+    for i in $(seq 1 "$NUM_ACCOUNTS"); do
+        upper=$(index_to_upper "$i")
+        user_var="GH_USER_${upper}"
+        token_var="GH_TOKEN_${upper}"
+        if [[ -z "${!user_var:-}" ]]; then
+            echo "Error: $user_var is required when GH_AUTH_MODE=per-account" >&2
+            exit 1
+        fi
+        if [[ -z "${!token_var:-}" ]]; then
+            echo "Error: $token_var is required when GH_AUTH_MODE=per-account" >&2
+            exit 1
+        fi
+    done
+fi
+
 # index_to_letter and index_to_upper provided by scripts/lib/index.sh.
 
 # --- Generate docker-compose.yml ---------------------------------------------
@@ -154,7 +182,9 @@ generate_base() {
             if [[ "$RT_MOUNTS_AGENTS_SKILLS" == "true" ]]; then
                 echo '      - ${AGENTS_SKILLS_DIR:-${HOME}/.agents/skills}:/home/node/.agents/skills:ro'
             fi
-            echo "      - \${GH_CONFIG_DIR:-\${HOME}/.config/gh}:/home/node/.config/gh:ro"
+            if [[ "$GH_AUTH_MODE" == "shared" ]]; then
+                echo "      - \${GH_CONFIG_DIR:-\${HOME}/.config/gh}:/home/node/.config/gh:ro"
+            fi
             echo "      - node_modules_${letter}:\${CONTAINER_PROJECT_DIR:-/project}/node_modules"
             echo "    environment:"
             echo "      - TERM=xterm-256color"
@@ -185,9 +215,21 @@ generate_base() {
             if [[ -n "${!key_var:-}" ]]; then
                 echo "      - ${RT_SDK_API_KEY_VAR}=\${${key_var}}"
             fi
-            echo "      - GH_TOKEN=\${GH_TOKEN:-}"
-            echo "      - GIT_USER_NAME=\${GIT_USER_NAME:-}"
-            echo "      - GIT_USER_EMAIL=\${GIT_USER_EMAIL:-}"
+            if [[ "$GH_AUTH_MODE" == "per-account" ]]; then
+                local gh_user_var="GH_USER_${upper}"
+                local gh_token_var="GH_TOKEN_${upper}"
+                local git_name_var="GIT_USER_NAME_${upper}"
+                local git_email_var="GIT_USER_EMAIL_${upper}"
+                echo "      - GH_AUTH_MODE=per-account"
+                echo "      - GH_USER=\${${gh_user_var}}"
+                echo "      - GH_TOKEN=\${${gh_token_var}}"
+                echo "      - GIT_USER_NAME=\${${git_name_var}:-\${GIT_USER_NAME:-}}"
+                echo "      - GIT_USER_EMAIL=\${${git_email_var}:-\${GIT_USER_EMAIL:-}}"
+            else
+                echo "      - GH_TOKEN=\${GH_TOKEN:-}"
+                echo "      - GIT_USER_NAME=\${GIT_USER_NAME:-}"
+                echo "      - GIT_USER_EMAIL=\${GIT_USER_EMAIL:-}"
+            fi
             echo "    deploy:"
             echo "      resources:"
             echo "        limits:"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -30,8 +30,8 @@ if ($PSVersionTable.PSEdition -eq 'Core' -and $PSVersionTable.OS -and $PSVersion
 #   CLAUDE_CODE_VERSION (optional), CLAUDE_API_KEY_A/B (Path B only),
 #   PROJECT_DIR_A/B + CONTAINER_PROJECT_DIR_A/B (Tier B only),
 #   GIT_USER_NAME, GIT_USER_EMAIL (optional),
-#   GH_TOKEN (optional — auto-detected from gh CLI),
-#   GH_CONFIG_DIR (optional — platform-specific gh config path for volume mount)
+#   GH_AUTH_MODE + GH_USER_<LETTER>/GH_TOKEN_<LETTER> (per-account only),
+#   GH_TOKEN + GH_CONFIG_DIR (optional shared-mode host gh configuration)
 #
 # Windows note: UID/GID are intentionally NOT written. Windows has no POSIX
 # UID/GID concept, and docker-compose.linux.yml (which consumes them) is not
@@ -56,6 +56,9 @@ $Script:ApiKeyB = ''
 # Selected agent runtime (claude, codex, gemini, ...). Defaults to claude so a
 # non-interactive or default install behaves exactly as before (see #273).
 $Script:Runtime = 'claude'
+$Script:GhAuthMode = 'shared'
+$Script:GhUsers = @()
+$Script:GhTokens = @()
 
 # --- I/O Latency Benchmark ---------------------------------------------------
 
@@ -350,6 +353,41 @@ function Get-Configuration {
     }
     Write-LogInfo "Accounts: $($Script:NumAccounts)"
 
+    # GitHub authentication mode. Per-account setup reads each explicitly
+    # named stored login without changing the active host account.
+    $ghChoice = Read-Selection `
+        -Question 'How should containers authenticate to GitHub?' `
+        -Options @(
+            "Shared account - use the host's active gh account in every container",
+            'Per-account - map a different stored gh login to each container'
+        )
+    if ($ghChoice -like 'Per-account*') {
+        $Script:GhAuthMode = 'per-account'
+        if (-not (Test-Command 'gh')) {
+            Write-LogError 'Per-account GitHub setup requires the host gh CLI.'
+            exit 1
+        }
+        Write-Host ''
+        Write-Host 'Enter host GitHub logins already stored by gh:' -ForegroundColor Cyan
+        for ($i = 1; $i -le $Script:NumAccounts; $i++) {
+            $upper = Get-AccountLetterUpper -Index $i
+            $login = Read-Input -Question "GitHub login for Account $upper"
+            $token = & gh auth token --hostname github.com --user $login 2>$null
+            if ($LASTEXITCODE -ne 0 -or -not $token) {
+                Write-LogError "Could not read a stored github.com token for '$login'."
+                Write-LogInfo 'Authenticate it first with: gh auth login --hostname github.com'
+                exit 1
+            }
+            $Script:GhUsers += $login
+            $Script:GhTokens += ([string]($token | Select-Object -First 1)).Trim()
+        }
+        Write-LogSuccess "Per-account GitHub mappings collected ($($Script:NumAccounts) accounts)"
+    }
+    else {
+        $Script:GhAuthMode = 'shared'
+        Write-LogInfo 'GitHub authentication: shared account'
+    }
+
     # API keys (Path B). The .env variable prefix is resolved from the runtime
     # registry (CLAUDE_API_KEY_ / CODEX_API_KEY_ / GEMINI_API_KEY_ / ...).
     $Script:ApiKeys = @()
@@ -506,25 +544,37 @@ function New-EnvFile {
         $lines += ''
     }
 
-    # GitHub CLI token and config directory (auto-detect from host)
-    if (Test-Command 'gh') {
-        $null = & gh auth status 2>&1
-        if ($LASTEXITCODE -eq 0) {
-            $ghToken = & gh auth token 2>$null
-            if ($ghToken) {
-                $lines += '# ==== GitHub CLI ===='
-                $lines += "GH_TOKEN=$ghToken"
-                $lines += ''
+    if ($Script:GhAuthMode -eq 'per-account') {
+        $lines += '# ==== GitHub CLI (per account) ===='
+        $lines += 'GH_AUTH_MODE=per-account'
+        for ($i = 1; $i -le $Script:NumAccounts; $i++) {
+            $upper = Get-AccountLetterUpper -Index $i
+            $lines += "GH_USER_${upper}=$($Script:GhUsers[$i - 1])"
+            $lines += "GH_TOKEN_${upper}=$($Script:GhTokens[$i - 1])"
+        }
+        $lines += ''
+    }
+    else {
+        # Shared GitHub CLI token (auto-detect from the active host account)
+        if (Test-Command 'gh') {
+            $null = & gh auth status 2>&1
+            if ($LASTEXITCODE -eq 0) {
+                $ghToken = & gh auth token 2>$null
+                if ($ghToken) {
+                    $lines += '# ==== GitHub CLI ===='
+                    $lines += "GH_TOKEN=$ghToken"
+                    $lines += ''
+                }
             }
         }
-    }
 
-    # GitHub CLI config directory for volume mount
-    # Windows: %APPDATA%\GitHub CLI (not ~/.config/gh)
-    $ghConfigDir = Join-Path $env:APPDATA 'GitHub CLI'
-    if (Test-Path $ghConfigDir) {
-        $lines += "GH_CONFIG_DIR=$(ConvertTo-ForwardSlash -Path $ghConfigDir)"
-        $lines += ''
+        # Shared GitHub CLI config directory for read-only volume mount.
+        # Windows: %APPDATA%\GitHub CLI (not ~/.config/gh)
+        $ghConfigDir = Join-Path $env:APPDATA 'GitHub CLI'
+        if (Test-Path $ghConfigDir) {
+            $lines += "GH_CONFIG_DIR=$(ConvertTo-ForwardSlash -Path $ghConfigDir)"
+            $lines += ''
+        }
     }
 
     $content = ($lines -join "`n") + "`n"
@@ -533,7 +583,7 @@ function New-EnvFile {
     # Restrict file permissions (Windows ACL equivalent of chmod 600).
     # Modify (M) = R,W,D — needed so remove.ps1 can delete the .env later.
     # R,W alone blocks deletion because DELETE is a separate Windows ACL bit.
-    & icacls $envFile /inheritance:r /grant:r "${env:USERNAME}:(M)" 2>$null | Out-Null
+    Protect-EnvFile -Path $envFile
 
     Write-LogSuccess ".env generated at $envFile"
 
@@ -861,6 +911,31 @@ function Invoke-Verification {
     else {
         Write-LogWarn 'Authentication not verified (may need browser login or API key check)'
     }
+
+    # Verify GitHub independently in every running service. A missing or
+    # mismatched login remains non-blocking but is rendered explicitly.
+    for ($i = 1; $i -le $Script:NumAccounts; $i++) {
+        $letter = Get-AccountLetter -Index $i
+        $upper = Get-AccountLetterUpper -Index $i
+        $svc = "$servicePrefix-$letter"
+        if (-not (Get-ContainerId -ProjectRoot $ProjectRoot -Service $svc)) { continue }
+
+        $output = @(Invoke-Compose -ProjectRoot $ProjectRoot exec -T $svc gh api user --jq .login 2>$null)
+        $ghExit = $LASTEXITCODE
+        $actual = ($output -join '').Trim()
+        if ($ghExit -ne 0 -or -not $actual) {
+            Write-LogWarn "${svc}: GitHub authentication is not configured"
+            continue
+        }
+        if ($Script:GhAuthMode -eq 'per-account') {
+            $expected = $Script:GhUsers[$i - 1]
+            if (-not $actual.Equals($expected, [StringComparison]::OrdinalIgnoreCase)) {
+                Write-LogWarn "${svc}: GitHub login mismatch (actual: $actual, expected: $expected)"
+                continue
+            }
+        }
+        Write-LogSuccess "${svc}: GitHub login verified ($actual)"
+    }
 }
 
 # --- Summary ------------------------------------------------------------------
@@ -922,6 +997,10 @@ function Show-Summary {
 }
 
 # --- Main ---------------------------------------------------------------------
+
+if ($env:CLAUDE_DOCKER_INSTALL_LIBRARY_ONLY -eq '1') {
+    return
+}
 
 Write-Host ''
 Write-Host '============================================' -ForegroundColor Cyan

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,8 +29,8 @@ fi
 #   CLAUDE_CODE_VERSION (optional), CLAUDE_API_KEY_A/B (Path B only),
 #   PROJECT_DIR_A/B + CONTAINER_PROJECT_DIR_A/B (Tier B only),
 #   GIT_USER_NAME, GIT_USER_EMAIL (optional),
-#   GH_TOKEN (optional — auto-detected from gh CLI),
-#   GH_CONFIG_DIR (optional — platform-specific gh config path for volume mount)
+#   GH_AUTH_MODE + GH_USER_<LETTER>/GH_TOKEN_<LETTER> (per-account only),
+#   GH_TOKEN + GH_CONFIG_DIR (optional shared-mode host gh configuration)
 #
 # Linux-only keys (bash installer adds):
 #   UID, GID (consumed by docker-compose.linux.yml)
@@ -60,6 +60,9 @@ CLAUDE_VERSION=""
 # Selected agent runtime (claude, codex, gemini, ...). Defaults to claude so a
 # non-interactive or default install behaves exactly as before (see #273).
 RUNTIME="claude"
+GH_AUTH_MODE="shared"
+GH_USERS=()
+GH_TOKENS=()
 
 # --- Utility Functions --------------------------------------------------------
 
@@ -569,6 +572,39 @@ collect_configuration() {
     fi
     log_info "Accounts: $NUM_ACCOUNTS"
 
+    # GitHub authentication mode. Shared preserves the existing active-account
+    # import and read-only host config mount. Per-account mode requires every
+    # selected host login up front so compose generation can remain fail-closed.
+    local gh_choice
+    gh_choice=$(prompt_select \
+        "How should containers authenticate to GitHub?" \
+        "Shared account — use the host's active gh account in every container" \
+        "Per-account — map a different stored gh login to each container")
+    if [[ "$gh_choice" == Per-account* ]]; then
+        GH_AUTH_MODE="per-account"
+        if ! command -v gh >/dev/null 2>&1; then
+            log_error "Per-account GitHub setup requires the host gh CLI."
+            exit 1
+        fi
+        echo -e "\n${CYAN}Enter host GitHub logins already stored by gh:${NC}"
+        for i in $(seq 1 "$NUM_ACCOUNTS"); do
+            local upper login token
+            upper=$(index_to_upper "$i")
+            login=$(prompt_input "GitHub login for Account $upper")
+            if ! token=$(gh auth token --hostname github.com --user "$login" 2>/dev/null) || [[ -z "$token" ]]; then
+                log_error "Could not read a stored github.com token for '$login'."
+                log_info "Authenticate it first with: gh auth login --hostname github.com"
+                exit 1
+            fi
+            GH_USERS+=("$login")
+            GH_TOKENS+=("$token")
+        done
+        log_success "Per-account GitHub mappings collected ($NUM_ACCOUNTS accounts)"
+    else
+        GH_AUTH_MODE="shared"
+        log_info "GitHub authentication: shared account"
+    fi
+
     # API keys (Path B). The .env variable prefix is resolved from the runtime
     # registry (CLAUDE_API_KEY_ / CODEX_API_KEY_ / GEMINI_API_KEY_ / ...).
     API_KEYS=()
@@ -708,21 +744,33 @@ generate_env() {
             echo ""
         fi
 
-        # GitHub CLI token (auto-detect from host)
-        if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
-            local gh_token
-            gh_token=$(gh auth token 2>/dev/null || true)
-            if [[ -n "$gh_token" ]]; then
-                echo "# ==== GitHub CLI ===="
-                echo "GH_TOKEN=$gh_token"
+        if [[ "$GH_AUTH_MODE" == "per-account" ]]; then
+            echo "# ==== GitHub CLI (per account) ===="
+            echo "GH_AUTH_MODE=per-account"
+            for i in $(seq 1 "$NUM_ACCOUNTS"); do
+                local upper
+                upper=$(index_to_upper "$i")
+                echo "GH_USER_${upper}=${GH_USERS[$((i-1))]}"
+                echo "GH_TOKEN_${upper}=${GH_TOKENS[$((i-1))]}"
+            done
+            echo ""
+        else
+            # Shared GitHub CLI token (auto-detect from the active host account)
+            if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+                local gh_token
+                gh_token=$(gh auth token 2>/dev/null || true)
+                if [[ -n "$gh_token" ]]; then
+                    echo "# ==== GitHub CLI ===="
+                    echo "GH_TOKEN=$gh_token"
+                    echo ""
+                fi
+            fi
+
+            # Shared GitHub CLI config directory (for read-only volume mount)
+            if [[ -d "$HOME/.config/gh" ]]; then
+                echo "GH_CONFIG_DIR=$HOME/.config/gh"
                 echo ""
             fi
-        fi
-
-        # GitHub CLI config directory (for volume mount)
-        if [[ -d "$HOME/.config/gh" ]]; then
-            echo "GH_CONFIG_DIR=$HOME/.config/gh"
-            echo ""
         fi
 
         if [[ "$PLATFORM" == "linux" ]]; then
@@ -1076,6 +1124,31 @@ run_verification() {
     else
         log_warn "Authentication not verified (may need browser login or API key check)"
     fi
+
+    # Verify the GitHub login independently in every running service. Login
+    # mismatches are warnings so normal startup remains non-blocking.
+    local i letter upper svc actual expected
+    for i in $(seq 1 "$NUM_ACCOUNTS"); do
+        letter=$(index_to_letter "$i")
+        upper=$(index_to_upper "$i")
+        svc="${service_prefix}-${letter}"
+        if [[ -z "$("${COMPOSE_CMD[@]}" ps -q "$svc" 2>/dev/null)" ]]; then
+            continue
+        fi
+        if ! actual=$("${COMPOSE_CMD[@]}" exec -T "$svc" gh api user --jq .login 2>/dev/null) || [[ -z "$actual" ]]; then
+            log_warn "$svc: GitHub authentication is not configured"
+            continue
+        fi
+        if [[ "$GH_AUTH_MODE" == "per-account" ]]; then
+            expected="${GH_USERS[$((i-1))]}"
+            if [[ "$(printf '%s' "$actual" | tr '[:upper:]' '[:lower:]')" != \
+                  "$(printf '%s' "$expected" | tr '[:upper:]' '[:lower:]')" ]]; then
+                log_warn "$svc: GitHub login mismatch (actual: $actual, expected: $expected)"
+                continue
+            fi
+        fi
+        log_success "$svc: GitHub login verified ($actual)"
+    done
 }
 
 # --- Summary ------------------------------------------------------------------
@@ -1198,4 +1271,6 @@ main() {
     print_summary
 }
 
-main "$@"
+if [[ "${CLAUDE_DOCKER_INSTALL_LIBRARY_ONLY:-0}" != "1" ]]; then
+    main "$@"
+fi

--- a/tests/env_fixtures/README.md
+++ b/tests/env_fixtures/README.md
@@ -5,10 +5,11 @@ is copied to the repo root as `.env`, then `scripts/generate-compose.sh` and
 `docker compose config` run against it.
 
 `tests/test_compose_generator_equivalence.sh` is a second consumer: it stages
-`minimal`, `codex`, `gemini` and `n5` into throwaway sandboxes and asserts the
-bash and PowerShell generators produce the same files. It adds one input the
-table below cannot express — `NUM_ACCOUNTS` and `IMAGE_TAG` supplied through the
-environment instead of a `.env` file, which is the path #315 fixed.
+`minimal`, `codex`, `gemini`, `github-per-account`, and `n5` into throwaway
+sandboxes and asserts the bash and PowerShell generators produce the same
+files. It adds one input the table below cannot express — `NUM_ACCOUNTS` and
+`IMAGE_TAG` supplied through the environment instead of a `.env` file, which
+is the path #315 fixed.
 
 | Fixture | Exercises |
 |---------|-----------|
@@ -19,6 +20,7 @@ environment instead of a `.env` file, which is the path #315 fixed.
 | `with-special-chars.env` | Values containing `#`, `=`, quotes, whitespace — exercises the #170 parser |
 | `codex.env` | `AGENT_RUNTIME=codex` runtime selection (codex-a/codex-b services) |
 | `gemini.env` | `AGENT_RUNTIME=gemini` runtime selection (gemini-a/gemini-b services, #272) |
+| `github-per-account.env` | Two isolated GitHub logins/tokens and account A Git identity overrides |
 
 ## Running locally
 

--- a/tests/env_fixtures/github-per-account.env
+++ b/tests/env_fixtures/github-per-account.env
@@ -1,0 +1,14 @@
+# Non-secret fixture for per-account GitHub authentication.
+NUM_ACCOUNTS=2
+HOME=/tmp/claude-test
+PROJECT_DIR=/tmp/claude-test/project
+IMAGE_TAG=fixture
+GH_AUTH_MODE=per-account
+GH_USER_A=fixture-user-a
+GH_TOKEN_A=fixture-token-a
+GH_USER_B=fixture-user-b
+GH_TOKEN_B=fixture-token-b
+GIT_USER_NAME=Shared Fixture
+GIT_USER_EMAIL=shared@example.test
+GIT_USER_NAME_A=Fixture Account A
+GIT_USER_EMAIL_A=account-a@example.test

--- a/tests/test_compose_generator_equivalence.sh
+++ b/tests/test_compose_generator_equivalence.sh
@@ -51,6 +51,7 @@ FIXTURES=(
     "minimal|minimal.env|"
     "codex|codex.env|"
     "gemini|gemini.env|"
+    "github-per-account|github-per-account.env|"
     "n5|n5.env|"
     "n30|n30.env|"
     "env-override|-|NUM_ACCOUNTS=5 IMAGE_TAG=probe-tag"

--- a/tests/test_entrypoint_github_auth.sh
+++ b/tests/test_entrypoint_github_auth.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Verify entrypoint GitHub login comparison and per-account Git identity.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { printf '  PASS  %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  FAIL  %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/root/tui/internal/config" "$WORK/bin" "$WORK/home"
+cp -r "$PROJECT_ROOT/scripts" "$WORK/root/scripts"
+cp "$PROJECT_ROOT/tui/internal/config/runtimes.json" "$WORK/root/tui/internal/config/"
+
+cat > "$WORK/bin/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+case "$1 $2" in
+    'auth setup-git') exit 0 ;;
+    'api user') printf '%s\n' "${MOCK_GH_LOGIN:?}"; exit 0 ;;
+esac
+exit 1
+MOCK_GH
+
+cat > "$WORK/bin/git" <<'MOCK_GIT'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_GIT_LOG"
+if [[ "$*" == 'config --global user.name' ]]; then
+    printf '%s\n' 'stale-name'
+elif [[ "$*" == 'config --global user.email' ]]; then
+    printf '%s\n' 'stale@example.test'
+fi
+exit 0
+MOCK_GIT
+chmod +x "$WORK/bin/gh" "$WORK/bin/git"
+
+run_entrypoint() {
+    local login="$1" expected="$2" output="$3" git_log="$4"
+    env PATH="$WORK/bin:$PATH" HOME="$WORK/home" \
+        CLAUDE_DOCKER_ROOT="$WORK/root" AGENT_RUNTIME=gemini \
+        GEMINI_CLI_HOME="$WORK/home" GH_AUTH_MODE=per-account \
+        GH_TOKEN=fixture-token-value GH_USER="$expected" MOCK_GH_LOGIN="$login" \
+        GIT_USER_NAME='Fixture Account' GIT_USER_EMAIL='fixture@example.test' \
+        MOCK_GIT_LOG="$git_log" \
+        bash "$WORK/root/scripts/entrypoint.sh" true >"$output" 2>&1
+}
+
+echo '== matching login =='
+run_entrypoint 'Fixture-User' 'fixture-user' "$WORK/match.out" "$WORK/match.git"
+if grep -q 'authenticated as Fixture-User' "$WORK/match.out"; then
+    pass 'entrypoint reports the actual authenticated login'
+else
+    fail 'entrypoint reports the actual authenticated login'
+fi
+if grep -Fxq 'config --global user.name Fixture Account' "$WORK/match.git" &&
+   grep -Fxq 'config --global user.email fixture@example.test' "$WORK/match.git"; then
+    pass 'per-account Git identity replaces stale persistent values'
+else
+    fail 'per-account Git identity replaces stale persistent values'
+fi
+
+echo '== mismatch =='
+run_entrypoint 'actual-user' 'expected-user' "$WORK/mismatch.out" "$WORK/mismatch.git"
+if grep -q 'GitHub login mismatch' "$WORK/mismatch.out" &&
+   grep -q 'actual: actual-user' "$WORK/mismatch.out" &&
+   grep -q 'expected: expected-user' "$WORK/mismatch.out"; then
+    pass 'entrypoint renders actual and expected login on mismatch'
+else
+    fail 'entrypoint renders actual and expected login on mismatch'
+fi
+if grep -q 'fixture-token-value' "$WORK/match.out" "$WORK/mismatch.out"; then
+    fail 'entrypoint never prints token values'
+else
+    pass 'entrypoint never prints token values'
+fi
+
+echo
+printf '== Summary: PASS=%d FAIL=%d ==\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/test_github_account_selection.ps1
+++ b/tests/test_github_account_selection.ps1
@@ -1,0 +1,205 @@
+# PowerShell parity coverage for per-account gh-auth and update.
+param()
+
+$ErrorActionPreference = 'Stop'
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent $ScriptDir
+$script:Pass = 0
+$script:Fail = 0
+
+Import-Module (Join-Path $ProjectRoot 'scripts' 'ClaudeDocker.psm1') -Force
+
+function Assert-True([string]$Label, [bool]$Condition) {
+    if ($Condition) {
+        Write-Host "  PASS  $Label"
+        $script:Pass++
+    }
+    else {
+        Write-Host "  FAIL  $Label"
+        $script:Fail++
+    }
+}
+
+function Write-TestFile([string]$Path, [string]$Content) {
+    $utf8 = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::WriteAllText($Path, $Content, $utf8)
+}
+
+$work = Join-Path ([System.IO.Path]::GetTempPath()) "claude-docker-gh-test-$PID"
+New-Item -ItemType Directory -Path $work -Force | Out-Null
+$originalPath = $env:PATH
+$originalOS = $PSVersionTable.OS
+
+function New-TestSandbox([string]$Name) {
+    $dir = Join-Path $work $Name
+    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $dir 'tui\internal\config') -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $dir 'bin') -Force | Out-Null
+    Copy-Item (Join-Path $ProjectRoot 'scripts') $dir -Recurse
+    Copy-Item (Join-Path $ProjectRoot 'tui\internal\config\runtimes.json') `
+        (Join-Path $dir 'tui\internal\config\runtimes.json')
+    Copy-Item (Join-Path $ProjectRoot 'docker-compose*.yml') $dir
+    Copy-Item (Join-Path $ProjectRoot 'VERSION') $dir
+    Copy-Item (Join-Path $ScriptDir 'env_fixtures' 'github-per-account.env') (Join-Path $dir '.env')
+
+    $bin = Join-Path $dir 'bin'
+    if ([Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT) {
+        Write-TestFile (Join-Path $bin 'gh.cmd') @'
+@echo off
+echo %*>>"%GH_MOCK_LOG%"
+if "%~1 %~2"=="auth status" exit /b 0
+if "%~1 %~2"=="auth token" (
+  if "%~6"=="replacement-user-b" (
+    echo mock-value-b
+    exit /b 0
+  )
+  if "%~6"=="fixture-user-a" (
+    echo mock-value-a
+    exit /b 0
+  )
+  if "%~6"=="fixture-user-b" (
+    echo mock-value-b
+    exit /b 0
+  )
+)
+exit /b 1
+'@
+        Write-TestFile (Join-Path $bin 'docker.cmd') @'
+@echo off
+echo %*>>"%DOCKER_MOCK_LOG%"
+if "%~1"=="exec" (
+  if "%~2"=="cid-a" (
+    echo fixture-user-a
+    exit /b 0
+  )
+  if "%~2"=="cid-b" (
+    echo replacement-user-b
+    exit /b 0
+  )
+  exit /b 1
+)
+echo %*| findstr /C:" ps -q claude-a" >nul
+if not errorlevel 1 (
+  echo cid-a
+  exit /b 0
+)
+echo %*| findstr /C:" ps -q claude-b" >nul
+if not errorlevel 1 (
+  echo cid-b
+  exit /b 0
+)
+exit /b 0
+'@
+    }
+    else {
+        Write-TestFile (Join-Path $bin 'gh') @'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_MOCK_LOG"
+if [[ "$1 $2" == "auth status" ]]; then exit 0; fi
+if [[ "$1 $2" == "auth token" ]]; then
+  user=""
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "--user" ]]; then user="$2"; break; fi
+    shift
+  done
+  case "$user" in
+    replacement-user-b) printf '%s\n' 'mock-value-b' ;;
+    fixture-user-a) printf '%s\n' 'mock-value-a' ;;
+    fixture-user-b) printf '%s\n' 'mock-value-b' ;;
+    *) exit 1 ;;
+  esac
+  exit 0
+fi
+exit 1
+'@
+        Write-TestFile (Join-Path $bin 'docker') @'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$DOCKER_MOCK_LOG"
+if [[ "${1:-}" == "exec" ]]; then
+  case "${2:-}" in
+    cid-a) printf '%s\n' 'fixture-user-a' ;;
+    cid-b) printf '%s\n' 'replacement-user-b' ;;
+    *) exit 1 ;;
+  esac
+  exit 0
+fi
+case " $* " in
+  *" ps -q claude-a "*) printf '%s\n' 'cid-a' ;;
+  *" ps -q claude-b "*) printf '%s\n' 'cid-b' ;;
+  *" ps -q "*) printf '%s\n' 'cid-a' ;;
+esac
+exit 0
+'@
+        & chmod +x (Join-Path $bin 'gh') (Join-Path $bin 'docker')
+    }
+    return $dir
+}
+
+function Invoke-TestCLI([string]$Dir, [string[]]$CLIArgs) {
+    $env:GH_MOCK_LOG = Join-Path $Dir 'gh.log'
+    $env:DOCKER_MOCK_LOG = Join-Path $Dir 'docker.log'
+    $env:PATH = (Join-Path $Dir 'bin') + [System.IO.Path]::PathSeparator + $originalPath
+    if ($PSVersionTable.PSEdition -eq 'Core' -and $PSVersionTable.OS -and
+        $PSVersionTable.OS -notlike '*Windows*') {
+        $PSVersionTable.OS = 'Microsoft Windows'
+    }
+    $output = & (Join-Path $Dir 'scripts' 'claude-docker.ps1') @CLIArgs 2>&1 | Out-String
+    return $output
+}
+
+try {
+    Write-Host '== selected account =='
+    $selected = New-TestSandbox 'selected'
+    $selectedOutput = Invoke-TestCLI $selected @('gh-auth', 'b', '--user', 'replacement-user-b')
+    $selectedEnv = Read-EnvFile -Path (Join-Path $selected '.env')
+    Assert-True 'updates only selected mapping' (
+        $selectedEnv['GH_USER_B'] -eq 'replacement-user-b' -and
+        $selectedEnv['GH_TOKEN_B'] -eq 'mock-value-b' -and
+        $selectedEnv['GH_TOKEN_A'] -eq 'fixture-token-a')
+    $ghLog = (Get-Content -Raw (Join-Path $selected 'gh.log')) -replace "`r", ''
+    $dockerLog = (Get-Content -Raw (Join-Path $selected 'docker.log')) -replace "`r", ''
+    Assert-True 'uses explicit --hostname and --user without switch' (
+        $ghLog -match '(?m)^auth token --hostname github\.com --user replacement-user-b$' -and
+        $ghLog -notmatch 'auth switch')
+    Assert-True 'recreates only selected service' (
+        $dockerLog -match '(?m)^.*up .*--force-recreate.*claude-b$' -and
+        $dockerLog -notmatch '(?m)^.*up .*--force-recreate.*claude-a.*$')
+    Assert-True 'does not print imported value' ($selectedOutput -notmatch 'mock-value-b')
+    if ([Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT) {
+        Assert-True 'retains protected Windows ACL' ((Get-Acl (Join-Path $selected '.env')).AreAccessRulesProtected)
+    }
+
+    Write-Host '== all accounts =='
+    $all = New-TestSandbox 'all'
+    $allOutput = Invoke-TestCLI $all @('gh-auth', '--all')
+    $allGhLog = (Get-Content -Raw (Join-Path $all 'gh.log')) -replace "`r", ''
+    Assert-True '--all selects both configured users' (
+        $allGhLog -match '(?m)^auth token --hostname github\.com --user fixture-user-a$' -and
+        $allGhLog -match '(?m)^auth token --hostname github\.com --user fixture-user-b$' -and
+        $allGhLog -notmatch '(?m)^auth token$')
+    Assert-True '--all does not print imported values' ($allOutput -notmatch 'mock-value-a|mock-value-b')
+
+    Write-Host '== update =='
+    $update = New-TestSandbox 'update'
+    $updateOutput = Invoke-TestCLI $update @('update')
+    $updateGhLog = (Get-Content -Raw (Join-Path $update 'gh.log')) -replace "`r", ''
+    Assert-True 'update refreshes both configured users' (
+        $updateGhLog -match '(?m)^auth token --hostname github\.com --user fixture-user-a$' -and
+        $updateGhLog -match '(?m)^auth token --hostname github\.com --user fixture-user-b$')
+    Assert-True 'update does not print imported values' ($updateOutput -notmatch 'mock-value-a|mock-value-b')
+}
+finally {
+    $env:PATH = $originalPath
+    $env:GH_MOCK_LOG = $null
+    $env:DOCKER_MOCK_LOG = $null
+    if ($null -ne $originalOS -and $PSVersionTable.ContainsKey('OS')) {
+        $PSVersionTable.OS = $originalOS
+    }
+    if (Test-Path -LiteralPath $work) {
+        Remove-Item -LiteralPath $work -Recurse -Force
+    }
+}
+
+Write-Host ''
+Write-Host "== Summary: PASS=$($script:Pass) FAIL=$($script:Fail) =="
+if ($script:Fail -gt 0) { exit 1 }

--- a/tests/test_github_account_selection.ps1
+++ b/tests/test_github_account_selection.ps1
@@ -25,9 +25,9 @@ function Write-TestFile([string]$Path, [string]$Content) {
     [System.IO.File]::WriteAllText($Path, $Content, $utf8)
 }
 
-# Keep executable shims under the checked-out workspace. Some hosted Linux
-# runners mount the system temporary directory with noexec, which causes
-# command discovery to skip these mocks and fall through to the real gh CLI.
+# Keep executable shims under the checked-out workspace and bind aliases to
+# their absolute paths below. Hosted runners also provide real gh and docker
+# commands, which must never win command discovery in this isolated test.
 $work = Join-Path $ProjectRoot ".test-github-account-selection-$PID"
 New-Item -ItemType Directory -Path $work -Force | Out-Null
 $originalPath = $env:PATH
@@ -142,6 +142,9 @@ function Invoke-TestCLI([string]$Dir, [string[]]$CLIArgs) {
     $env:GH_MOCK_LOG = Join-Path $Dir 'gh.log'
     $env:DOCKER_MOCK_LOG = Join-Path $Dir 'docker.log'
     $env:PATH = (Join-Path $Dir 'bin') + [System.IO.Path]::PathSeparator + $originalPath
+    $mockExtension = if ([Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT) { '.cmd' } else { '' }
+    Set-Alias -Name gh -Value (Join-Path $Dir "bin/gh$mockExtension") -Scope Global -Force
+    Set-Alias -Name docker -Value (Join-Path $Dir "bin/docker$mockExtension") -Scope Global -Force
     if ($PSVersionTable.PSEdition -eq 'Core' -and $PSVersionTable.OS -and
         $PSVersionTable.OS -notlike '*Windows*') {
         $PSVersionTable.OS = 'Microsoft Windows'
@@ -195,6 +198,7 @@ finally {
     $env:PATH = $originalPath
     $env:GH_MOCK_LOG = $null
     $env:DOCKER_MOCK_LOG = $null
+    Remove-Item Alias:gh, Alias:docker -Force -ErrorAction SilentlyContinue
     if ($null -ne $originalOS -and $PSVersionTable.ContainsKey('OS')) {
         $PSVersionTable.OS = $originalOS
     }

--- a/tests/test_github_account_selection.ps1
+++ b/tests/test_github_account_selection.ps1
@@ -25,7 +25,10 @@ function Write-TestFile([string]$Path, [string]$Content) {
     [System.IO.File]::WriteAllText($Path, $Content, $utf8)
 }
 
-$work = Join-Path ([System.IO.Path]::GetTempPath()) "claude-docker-gh-test-$PID"
+# Keep executable shims under the checked-out workspace. Some hosted Linux
+# runners mount the system temporary directory with noexec, which causes
+# command discovery to skip these mocks and fall through to the real gh CLI.
+$work = Join-Path $ProjectRoot ".test-github-account-selection-$PID"
 New-Item -ItemType Directory -Path $work -Force | Out-Null
 $originalPath = $env:PATH
 $originalOS = $PSVersionTable.OS

--- a/tests/test_github_account_selection.sh
+++ b/tests/test_github_account_selection.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Verify targeted gh-auth uses the named stored account and updates only the
+# selected mapping. All credentials are non-secret placeholders.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { printf '  PASS  %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  FAIL  %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+make_sandbox() {
+    local name="$1"
+    local dir="$WORK/$name"
+    mkdir -p "$dir/tui/internal/config" "$dir/bin"
+    cp -r "$PROJECT_ROOT/scripts" "$dir/scripts"
+    cp "$PROJECT_ROOT/tui/internal/config/runtimes.json" "$dir/tui/internal/config/"
+    cp "$PROJECT_ROOT"/docker-compose*.yml "$dir/"
+    cp "$PROJECT_ROOT/VERSION" "$dir/"
+    cp "$SCRIPT_DIR/env_fixtures/github-per-account.env" "$dir/.env"
+
+    cat > "$dir/bin/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_MOCK_LOG"
+if [[ "$1 $2" == "auth status" ]]; then
+    exit 0
+fi
+if [[ "$1 $2" == "auth token" ]]; then
+    user=""
+    while [[ $# -gt 0 ]]; do
+        if [[ "$1" == "--user" ]]; then user="$2"; break; fi
+        shift
+    done
+    case "$user" in
+        replacement-user-b) printf '%s\n' 'mock-value-b' ;;
+        fixture-user-a) printf '%s\n' 'mock-value-a' ;;
+        fixture-user-b) printf '%s\n' 'mock-value-b' ;;
+        *) exit 1 ;;
+    esac
+    exit 0
+fi
+exit 1
+MOCK_GH
+
+    cat > "$dir/bin/docker" <<'MOCK_DOCKER'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$DOCKER_MOCK_LOG"
+if [[ "${1:-}" == "exec" ]]; then
+    case "${2:-}" in
+        cid-a) printf '%s\n' 'fixture-user-a' ;;
+        cid-b) printf '%s\n' 'replacement-user-b' ;;
+        *) exit 1 ;;
+    esac
+    exit 0
+fi
+case " $* " in
+    *" ps -q claude-a "*) printf '%s\n' 'cid-a' ;;
+    *" ps -q claude-b "*) printf '%s\n' 'cid-b' ;;
+    *" ps -q "*) printf '%s\n' 'cid-a' ;;
+esac
+exit 0
+MOCK_DOCKER
+    chmod +x "$dir/bin/gh" "$dir/bin/docker" "$dir/scripts/claude-docker"
+    printf '%s' "$dir"
+}
+
+assert_case() {
+    local language="$1" dir="$2"
+    # shellcheck source=../scripts/lib/parse_env.sh
+    . "$PROJECT_ROOT/scripts/lib/parse_env.sh"
+
+    if [[ "$(parse_env_value "$dir/.env" GH_USER_B)" == "replacement-user-b" &&
+          "$(parse_env_value "$dir/.env" GH_TOKEN_B)" == "mock-value-b" &&
+          "$(parse_env_value "$dir/.env" GH_TOKEN_A)" == "fixture-token-a" ]]; then
+        pass "$language updates only the selected account mapping"
+    else
+        fail "$language updates only the selected account mapping"
+    fi
+
+    if grep -Fxq 'auth token --hostname github.com --user replacement-user-b' "$dir/gh.log" &&
+       ! grep -q 'auth switch' "$dir/gh.log"; then
+        pass "$language selects the named host account without switching"
+    else
+        fail "$language selects the named host account without switching"
+    fi
+
+    if grep -q 'up .*--force-recreate.*claude-b' "$dir/docker.log" &&
+       ! grep 'up .*--force-recreate' "$dir/docker.log" | grep -q 'claude-a'; then
+        pass "$language recreates only the selected running service"
+    else
+        fail "$language recreates only the selected running service"
+    fi
+
+    if grep -q 'mock-value-b' "$dir/command.out"; then
+        fail "$language never prints the imported token value"
+    else
+        pass "$language never prints the imported token value"
+    fi
+}
+
+assert_all_case() {
+    local language="$1" dir="$2"
+    if grep -Fxq 'auth token --hostname github.com --user fixture-user-a' "$dir/gh.log" &&
+       grep -Fxq 'auth token --hostname github.com --user fixture-user-b' "$dir/gh.log" &&
+       ! grep -Fxq 'auth token' "$dir/gh.log" &&
+       ! grep -q 'auth switch' "$dir/gh.log"; then
+        pass "$language --all selects every configured login explicitly"
+    else
+        fail "$language --all selects every configured login explicitly"
+    fi
+    if grep -q 'up .*--force-recreate.*claude-a.*claude-b' "$dir/docker.log"; then
+        pass "$language --all recreates all affected running services"
+    else
+        fail "$language --all recreates all affected running services"
+    fi
+    if grep -q 'mock-value-a\|mock-value-b' "$dir/command.out"; then
+        fail "$language --all keeps token values out of output"
+    else
+        pass "$language --all keeps token values out of output"
+    fi
+}
+
+assert_update_case() {
+    local language="$1" dir="$2"
+    if grep -Fxq 'auth token --hostname github.com --user fixture-user-a' "$dir/gh.log" &&
+       grep -Fxq 'auth token --hostname github.com --user fixture-user-b' "$dir/gh.log" &&
+       ! grep -Fxq 'auth token' "$dir/gh.log"; then
+        pass "$language update refreshes every configured per-account mapping"
+    else
+        fail "$language update refreshes every configured per-account mapping"
+    fi
+    if grep -q 'mock-value-a\|mock-value-b' "$dir/command.out"; then
+        fail "$language update keeps token values out of output"
+    else
+        pass "$language update keeps token values out of output"
+    fi
+}
+
+echo '== Bash =='
+bash_dir="$(make_sandbox bash)"
+GH_MOCK_LOG="$bash_dir/gh.log" DOCKER_MOCK_LOG="$bash_dir/docker.log" \
+    PATH="$bash_dir/bin:$PATH" \
+    bash "$bash_dir/scripts/claude-docker" gh-auth b --user replacement-user-b \
+    >"$bash_dir/command.out" 2>&1
+assert_case Bash "$bash_dir"
+if [[ "$(stat -c '%a' "$bash_dir/.env")" == "600" ]]; then
+    pass 'Bash retains restrictive .env permissions'
+else
+    fail 'Bash retains restrictive .env permissions'
+fi
+
+bash_all_dir="$(make_sandbox bash-all)"
+GH_MOCK_LOG="$bash_all_dir/gh.log" DOCKER_MOCK_LOG="$bash_all_dir/docker.log" \
+    PATH="$bash_all_dir/bin:$PATH" \
+    bash "$bash_all_dir/scripts/claude-docker" gh-auth --all \
+    >"$bash_all_dir/command.out" 2>&1
+assert_all_case Bash "$bash_all_dir"
+
+bash_update_dir="$(make_sandbox bash-update)"
+GH_MOCK_LOG="$bash_update_dir/gh.log" DOCKER_MOCK_LOG="$bash_update_dir/docker.log" \
+    PATH="$bash_update_dir/bin:$PATH" \
+    bash "$bash_update_dir/scripts/claude-docker" update \
+    >"$bash_update_dir/command.out" 2>&1
+assert_update_case Bash "$bash_update_dir"
+
+echo '== PowerShell =='
+if ! command -v pwsh >/dev/null 2>&1; then
+    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+        fail 'pwsh is required for PowerShell account-selection coverage in CI'
+    else
+        echo '  NOTE  PowerShell case skipped (pwsh unavailable)'
+    fi
+else
+    pwsh_dir="$(make_sandbox pwsh)"
+    GH_MOCK_LOG="$pwsh_dir/gh.log" DOCKER_MOCK_LOG="$pwsh_dir/docker.log" \
+        PATH="$pwsh_dir/bin:$PATH" CLAUDE_DOCKER_PWSH_ENTRYPOINT="$pwsh_dir/scripts/claude-docker.ps1" \
+        pwsh -NoProfile -Command \
+        '$PSVersionTable.OS = "Microsoft Windows"; & $env:CLAUDE_DOCKER_PWSH_ENTRYPOINT gh-auth b --user replacement-user-b' \
+        >"$pwsh_dir/command.out" 2>&1
+    assert_case PowerShell "$pwsh_dir"
+
+    pwsh_all_dir="$(make_sandbox pwsh-all)"
+    GH_MOCK_LOG="$pwsh_all_dir/gh.log" DOCKER_MOCK_LOG="$pwsh_all_dir/docker.log" \
+        PATH="$pwsh_all_dir/bin:$PATH" CLAUDE_DOCKER_PWSH_ENTRYPOINT="$pwsh_all_dir/scripts/claude-docker.ps1" \
+        pwsh -NoProfile -Command \
+        '$PSVersionTable.OS = "Microsoft Windows"; & $env:CLAUDE_DOCKER_PWSH_ENTRYPOINT gh-auth --all' \
+        >"$pwsh_all_dir/command.out" 2>&1
+    assert_all_case PowerShell "$pwsh_all_dir"
+
+    pwsh_update_dir="$(make_sandbox pwsh-update)"
+    GH_MOCK_LOG="$pwsh_update_dir/gh.log" DOCKER_MOCK_LOG="$pwsh_update_dir/docker.log" \
+        PATH="$pwsh_update_dir/bin:$PATH" CLAUDE_DOCKER_PWSH_ENTRYPOINT="$pwsh_update_dir/scripts/claude-docker.ps1" \
+        pwsh -NoProfile -Command \
+        '$PSVersionTable.OS = "Microsoft Windows"; & $env:CLAUDE_DOCKER_PWSH_ENTRYPOINT update' \
+        >"$pwsh_update_dir/command.out" 2>&1
+    assert_update_case PowerShell "$pwsh_update_dir"
+fi
+
+echo
+printf '== Summary: PASS=%d FAIL=%d ==\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/test_github_per_account_compose.sh
+++ b/tests/test_github_per_account_compose.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Verify per-account GitHub compose isolation with placeholder credentials only.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURE="$SCRIPT_DIR/env_fixtures/github-per-account.env"
+PASS=0
+FAIL=0
+
+pass() { printf '  PASS  %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  FAIL  %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+make_sandbox() {
+    local name="$1"
+    local dir="$WORK/$name"
+    mkdir -p "$dir/tui/internal/config"
+    cp -r "$PROJECT_ROOT/scripts" "$dir/scripts"
+    cp "$PROJECT_ROOT/tui/internal/config/runtimes.json" "$dir/tui/internal/config/"
+    cp "$PROJECT_ROOT/VERSION" "$dir/"
+    printf '%s' "$dir"
+}
+
+echo '== isolated services =='
+isolated="$(make_sandbox isolated)"
+cp "$FIXTURE" "$isolated/.env"
+bash "$isolated/scripts/generate-compose.sh" >/dev/null
+
+if grep -q '/home/node/.config/gh' "$isolated/docker-compose.yml"; then
+    fail 'per-account compose omits shared gh config mount'
+else
+    pass 'per-account compose omits shared gh config mount'
+fi
+
+if ! command -v docker >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+        fail 'docker and jq are required for resolved compose assertions in CI'
+    else
+        echo '  NOTE  resolved compose assertions skipped (docker or jq unavailable)'
+    fi
+else
+    (
+        cd "$isolated"
+        docker compose config --format json > resolved.json
+    )
+    if jq -e '
+        .services["claude-a"].environment.GH_TOKEN == "fixture-token-a" and
+        .services["claude-b"].environment.GH_TOKEN == "fixture-token-b" and
+        .services["claude-a"].environment.GH_USER == "fixture-user-a" and
+        .services["claude-b"].environment.GH_USER == "fixture-user-b" and
+        (.services["claude-a"].environment | has("GH_TOKEN_A") | not) and
+        (.services["claude-a"].environment | has("GH_TOKEN_B") | not) and
+        (.services["claude-b"].environment | has("GH_TOKEN_A") | not) and
+        (.services["claude-b"].environment | has("GH_TOKEN_B") | not)
+    ' "$isolated/resolved.json" >/dev/null; then
+        pass 'each service receives only its matching standard GH_TOKEN'
+    else
+        fail 'each service receives only its matching standard GH_TOKEN'
+    fi
+
+    if jq -e '
+        .services["claude-a"].environment.GIT_USER_NAME == "Fixture Account A" and
+        .services["claude-a"].environment.GIT_USER_EMAIL == "account-a@example.test" and
+        .services["claude-b"].environment.GIT_USER_NAME == "Shared Fixture" and
+        .services["claude-b"].environment.GIT_USER_EMAIL == "shared@example.test"
+    ' "$isolated/resolved.json" >/dev/null; then
+        pass 'per-account Git identity overrides fall back to shared identity'
+    else
+        fail 'per-account Git identity overrides fall back to shared identity'
+    fi
+fi
+
+echo '== fail-closed validation =='
+missing="$(make_sandbox missing)"
+grep -v '^GH_TOKEN_B=' "$FIXTURE" > "$missing/.env"
+printf '%s\n' 'GH_TOKEN=global-must-not-fallback' >> "$missing/.env"
+if bash "$missing/scripts/generate-compose.sh" >"$missing/stdout" 2>"$missing/stderr"; then
+    fail 'missing GH_TOKEN_B is rejected even when global GH_TOKEN exists'
+elif grep -q 'GH_TOKEN_B' "$missing/stderr" &&
+     ! grep -q 'fixture-token\|global-must-not-fallback' "$missing/stdout" "$missing/stderr"; then
+    pass 'missing GH_TOKEN_B is named without exposing any token value'
+else
+    fail 'missing mapping diagnostic is scoped and secret-free'
+fi
+
+echo '== suffix range =='
+range="$(make_sandbox range)"
+{
+    printf '%s\n' 'NUM_ACCOUNTS=702' 'HOME=/tmp/claude-test' \
+        'PROJECT_DIR=/tmp/claude-test/project' 'GH_AUTH_MODE=per-account'
+    # shellcheck source=../scripts/lib/index.sh
+    . "$PROJECT_ROOT/scripts/lib/index.sh"
+    for i in $(seq 1 702); do
+        upper="$(index_to_upper "$i")"
+        printf 'GH_USER_%s=fixture-user-%s\n' "$upper" "$upper"
+        printf 'GH_TOKEN_%s=fixture-token-%s\n' "$upper" "$upper"
+    done
+} > "$range/.env"
+bash "$range/scripts/generate-compose.sh" >/dev/null
+if grep -Fq '  claude-zz:' "$range/docker-compose.yml" &&
+   grep -Fq '      - GH_TOKEN=${GH_TOKEN_ZZ}' "$range/docker-compose.yml"; then
+    pass 'per-account mapping reaches the supported ZZ suffix'
+else
+    fail 'per-account mapping reaches the supported ZZ suffix'
+fi
+
+echo
+printf '== Summary: PASS=%d FAIL=%d ==\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/test_installer_github_equivalence.sh
+++ b/tests/test_installer_github_equivalence.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Compare the GitHub portion of Bash and PowerShell installer-generated .env
+# files in per-account mode. Uses placeholder values only.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { printf '  PASS  %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  FAIL  %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+if ! command -v pwsh >/dev/null 2>&1; then
+    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+        echo 'FAIL: pwsh unavailable in CI' >&2
+        exit 1
+    fi
+    echo '== Summary: SKIPPED (pwsh unavailable) =='
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+make_sandbox() {
+    local name="$1"
+    local dir="$WORK/$name"
+    mkdir -p "$dir/tui/internal/config"
+    cp -r "$PROJECT_ROOT/scripts" "$dir/scripts"
+    cp "$PROJECT_ROOT/tui/internal/config/runtimes.json" "$dir/tui/internal/config/"
+    cp "$PROJECT_ROOT/VERSION" "$dir/"
+    printf '%s' "$dir"
+}
+
+bash_dir="$(make_sandbox bash)"
+pwsh_dir="$(make_sandbox pwsh)"
+
+# The sourced installer consumes these dynamically scoped values.
+# shellcheck disable=SC2034
+(
+    export CLAUDE_DOCKER_INSTALL_LIBRARY_ONLY=1
+    export HOME="$WORK/bash-home"
+    # shellcheck source=../scripts/install.sh
+    . "$bash_dir/scripts/install.sh"
+    PLATFORM=linux
+    AUTH_PATH=A
+    TIER=A
+    SOURCE_DIR="$WORK/project"
+    CLAUDE_VERSION=""
+    RUNTIME=claude
+    NUM_ACCOUNTS=2
+    GH_AUTH_MODE=per-account
+    GH_USERS=(fixture-user-a fixture-user-b)
+    GH_TOKENS=(fixture-token-a fixture-token-b)
+    generate_env
+) >"$bash_dir/install.log" 2>&1
+
+PWSH_COMMAND='& {
+    $PSVersionTable.OS = "Microsoft Windows"
+    $env:CLAUDE_DOCKER_INSTALL_LIBRARY_ONLY = "1"
+    . $env:CLAUDE_DOCKER_INSTALL_ENTRYPOINT
+    $Script:AuthPath = "A"
+    $Script:Tier = "A"
+    $Script:SourceDir = $env:CLAUDE_DOCKER_TEST_PROJECT
+    $Script:ClaudeVersion = ""
+    $Script:Runtime = "claude"
+    $Script:NumAccounts = 2
+    $Script:GhAuthMode = "per-account"
+    $Script:GhUsers = @("fixture-user-a", "fixture-user-b")
+    $Script:GhTokens = @("fixture-token-a", "fixture-token-b")
+    New-EnvFile
+}'
+CLAUDE_DOCKER_INSTALL_ENTRYPOINT="$pwsh_dir/scripts/install.ps1" \
+CLAUDE_DOCKER_TEST_PROJECT="$WORK/project" \
+USERPROFILE="$WORK/pwsh-home" APPDATA="$WORK/pwsh-appdata" \
+pwsh -NoProfile -Command "$PWSH_COMMAND" >"$pwsh_dir/install.log" 2>&1
+
+# shellcheck source=../scripts/lib/parse_env.sh
+. "$PROJECT_ROOT/scripts/lib/parse_env.sh"
+
+keys=(GH_AUTH_MODE GH_USER_A GH_TOKEN_A GH_USER_B GH_TOKEN_B)
+for key in "${keys[@]}"; do
+    bash_value="$(parse_env_value "$bash_dir/.env" "$key")"
+    pwsh_value="$(parse_env_value "$pwsh_dir/.env" "$key")"
+    if [[ -n "$bash_value" && "$bash_value" == "$pwsh_value" ]]; then
+        pass "$key is equivalent"
+    else
+        fail "$key is equivalent"
+    fi
+done
+
+if [[ -z "$(parse_env_value "$bash_dir/.env" GH_TOKEN)" &&
+      -z "$(parse_env_value "$pwsh_dir/.env" GH_TOKEN)" &&
+      -z "$(parse_env_value "$bash_dir/.env" GH_CONFIG_DIR)" &&
+      -z "$(parse_env_value "$pwsh_dir/.env" GH_CONFIG_DIR)" ]]; then
+    pass 'both installers omit shared GitHub credentials in per-account mode'
+else
+    fail 'both installers omit shared GitHub credentials in per-account mode'
+fi
+
+if grep -q 'fixture-token-a\|fixture-token-b' "$bash_dir/install.log" "$pwsh_dir/install.log"; then
+    fail 'installer output never includes token values'
+else
+    pass 'installer output never includes token values'
+fi
+
+echo
+printf '== Summary: PASS=%d FAIL=%d ==\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tui/internal/account/account.go
+++ b/tui/internal/account/account.go
@@ -74,6 +74,9 @@ type Account struct {
 	ContainerStatus ContainerStatus
 	ContainerID     string
 	GHAuthOK        bool
+	GHLogin         string
+	GHExpectedLogin string
+	GHLoginMismatch bool
 
 	// Claude-only fields. These stay zero/nil for runtimes that do not
 	// expose a Claude-style OAuth usage endpoint; the dashboard then

--- a/tui/internal/account/manager_helpers.go
+++ b/tui/internal/account/manager_helpers.go
@@ -132,7 +132,8 @@ func (m *Manager) enrichAccounts(accounts []Account) map[string]apiResult {
 }
 
 // enrichGHAuth runs `gh api user` inside the account's running container
-// and sets GHAuthOK on success. No-op when the container is not running.
+// and stores the actual login plus any configured mismatch state. No-op when
+// the container is not running.
 //
 // `gh api user` is used instead of `gh auth status` because the latter
 // evaluates every configured account — including the unusable `default`
@@ -144,19 +145,27 @@ func (m *Manager) enrichGHAuth(a *Account, wg *sync.WaitGroup) {
 		return
 	}
 	wg.Add(1)
+	a.GHExpectedLogin = m.env.GHUser(a.Letter)
 	go func() {
 		defer wg.Done()
 		cmd := exec.Command("docker", "exec", a.ContainerID, "gh", "api", "user", "--jq", ".login")
-		err := cmd.Run()
-		a.GHAuthOK = ghAuthVerdict(err)
+		out, err := cmd.Output()
+		a.GHLogin, a.GHAuthOK, a.GHLoginMismatch = ghAuthResult(out, err, a.GHExpectedLogin)
 	}()
 }
 
-// ghAuthVerdict maps the exit status of the in-container `gh api user`
-// command to a GitHub auth verdict: a nil error (exit code 0) means the
-// credential gh uses for API calls is valid.
-func ghAuthVerdict(runErr error) bool {
-	return runErr == nil
+// ghAuthResult maps an in-container `gh api user` result to display state.
+// GitHub logins are case-insensitive, while the API may return canonical case.
+func ghAuthResult(output []byte, runErr error, expected string) (string, bool, bool) {
+	if runErr != nil {
+		return "", false, false
+	}
+	actual := strings.TrimSpace(string(output))
+	if actual == "" {
+		return "", false, false
+	}
+	mismatch := expected != "" && !strings.EqualFold(actual, expected)
+	return actual, !mismatch, mismatch
 }
 
 // enrichAPIUsage fetches usage from the limitline API for OAuth accounts

--- a/tui/internal/account/manager_helpers_test.go
+++ b/tui/internal/account/manager_helpers_test.go
@@ -3,7 +3,6 @@ package account
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -180,29 +179,30 @@ func TestEnrichGHAuth_NotRunning(t *testing.T) {
 	}
 }
 
-// TestGHAuthVerdict covers the auth verdict logic used by enrichGHAuth. The
-// container check switched from `gh auth status` to `gh api user` because
-// `gh auth status` exits non-zero when the mounted host gh config exposes an
-// unusable `default` account alongside a working GH_TOKEN. The verdict must
-// follow the command exit code: `gh api user` succeeding (exit 0) means the
-// credential is valid even in that mixed-config case where `gh auth status`
-// would fail.
-func TestGHAuthVerdict(t *testing.T) {
-	// A real exit-0 command stands in for `gh api user` succeeding.
-	if err := exec.Command("true").Run(); err != nil {
-		t.Fatalf("setup: `true` should exit 0: %v", err)
-	} else if !ghAuthVerdict(err) {
-		t.Error("ghAuthVerdict(nil) = false, want true (gh api user succeeded)")
+func TestGHAuthResult(t *testing.T) {
+	cases := []struct {
+		name         string
+		output       string
+		err          error
+		expected     string
+		wantLogin    string
+		wantOK       bool
+		wantMismatch bool
+	}{
+		{"shared success", "Fixture-User\n", nil, "", "Fixture-User", true, false},
+		{"case-insensitive expected", "Fixture-User\n", nil, "fixture-user", "Fixture-User", true, false},
+		{"mismatch", "actual-user\n", nil, "expected-user", "actual-user", false, true},
+		{"command failure", "", fmt.Errorf("exit 1"), "expected-user", "", false, false},
+		{"empty login", "\n", nil, "", "", false, false},
 	}
-
-	// A real non-zero exit stands in for `gh auth status` style failure:
-	// the verdict must be false so a failed check is not reported as OK.
-	failErr := exec.Command("false").Run()
-	if failErr == nil {
-		t.Fatal("setup: `false` should exit non-zero")
-	}
-	if ghAuthVerdict(failErr) {
-		t.Error("ghAuthVerdict(exit-error) = true, want false (command exited non-zero)")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			login, ok, mismatch := ghAuthResult([]byte(tc.output), tc.err, tc.expected)
+			if login != tc.wantLogin || ok != tc.wantOK || mismatch != tc.wantMismatch {
+				t.Errorf("ghAuthResult = (%q, %v, %v), want (%q, %v, %v)",
+					login, ok, mismatch, tc.wantLogin, tc.wantOK, tc.wantMismatch)
+			}
+		})
 	}
 }
 

--- a/tui/internal/auth/auth_test.go
+++ b/tui/internal/auth/auth_test.go
@@ -26,6 +26,27 @@ func TestRateLimitErrorError(t *testing.T) {
 	}
 }
 
+func TestGHTokenArgsSelectsNamedAccount(t *testing.T) {
+	cases := []struct {
+		user string
+		want []string
+	}{
+		{"", []string{"auth", "token"}},
+		{"fixture-user-b", []string{"auth", "token", "--hostname", "github.com", "--user", "fixture-user-b"}},
+	}
+	for _, tc := range cases {
+		got := ghTokenArgs(tc.user)
+		if len(got) != len(tc.want) {
+			t.Fatalf("ghTokenArgs(%q) = %v, want %v", tc.user, got, tc.want)
+		}
+		for i := range tc.want {
+			if got[i] != tc.want[i] {
+				t.Errorf("ghTokenArgs(%q)[%d] = %q, want %q", tc.user, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
 // TestReadOAuthTokenSuccess writes a valid .credentials.json into a temp
 // dir and verifies ReadOAuthToken returns the embedded access token.
 func TestReadOAuthTokenSuccess(t *testing.T) {

--- a/tui/internal/auth/gh_token.go
+++ b/tui/internal/auth/gh_token.go
@@ -7,26 +7,29 @@ import (
 	"strings"
 )
 
-// HostGHToken returns the GitHub token from the host's gh CLI.
-// Two-step verification (status → token) gives clearer error messages
-// than relying on `gh auth token` exit codes alone.
-func HostGHToken() (string, error) {
+// HostGHToken returns the GitHub token from the host's gh CLI. A non-empty
+// user selects that stored github.com account explicitly without changing the
+// active host account. An empty user preserves the legacy active-account flow.
+func HostGHToken(user string) (string, error) {
 	if _, err := exec.LookPath("gh"); err != nil {
 		return "", fmt.Errorf("gh CLI not found on host (install via https://cli.github.com)")
 	}
 
-	var stderr bytes.Buffer
-	check := exec.Command("gh", "auth", "status")
-	check.Stderr = &stderr
-	if err := check.Run(); err != nil {
-		msg := strings.TrimSpace(stderr.String())
-		if msg == "" {
-			msg = err.Error()
+	if user == "" {
+		var stderr bytes.Buffer
+		check := exec.Command("gh", "auth", "status")
+		check.Stderr = &stderr
+		if err := check.Run(); err != nil {
+			msg := strings.TrimSpace(stderr.String())
+			if msg == "" {
+				msg = err.Error()
+			}
+			return "", fmt.Errorf("gh not authenticated: %s", msg)
 		}
-		return "", fmt.Errorf("gh not authenticated: %s", msg)
 	}
 
-	out, err := exec.Command("gh", "auth", "token").Output()
+	args := ghTokenArgs(user)
+	out, err := exec.Command("gh", args...).Output()
 	if err != nil {
 		return "", fmt.Errorf("gh auth token: %w", err)
 	}
@@ -35,4 +38,12 @@ func HostGHToken() (string, error) {
 		return "", fmt.Errorf("gh returned empty token")
 	}
 	return token, nil
+}
+
+func ghTokenArgs(user string) []string {
+	args := []string{"auth", "token"}
+	if user != "" {
+		args = append(args, "--hostname", "github.com", "--user", user)
+	}
+	return args
 }

--- a/tui/internal/config/env.go
+++ b/tui/internal/config/env.go
@@ -5,7 +5,9 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 )
@@ -16,6 +18,8 @@ const (
 	RuntimeClaude      = "claude"
 	RuntimeCodex       = "codex"
 	RuntimeGemini      = "gemini"
+	GHAuthShared       = "shared"
+	GHAuthPerAccount   = "per-account"
 )
 
 // Env holds parsed .env configuration with order-preserving entries.
@@ -134,6 +138,29 @@ func (e *Env) Save() error {
 	if err := os.Rename(tmpName, e.path); err != nil {
 		return fmt.Errorf("rename: %w", err)
 	}
+	if err := hardenSecretFile(e.path); err != nil {
+		return err
+	}
+	return nil
+}
+
+// hardenSecretFile preserves the Unix 0600 contract and applies the Windows
+// ACL equivalent after the atomic rename. Command arguments are passed as an
+// argv slice so user/path values are never shell-evaluated.
+func hardenSecretFile(path string) error {
+	if err := os.Chmod(path, 0600); err != nil {
+		return fmt.Errorf("chmod env file: %w", err)
+	}
+	if runtime.GOOS != "windows" {
+		return nil
+	}
+	user := os.Getenv("USERNAME")
+	if user == "" {
+		return fmt.Errorf("restrict env ACL: USERNAME is not set")
+	}
+	if err := exec.Command("icacls", path, "/inheritance:r", "/grant:r", user+":(M)").Run(); err != nil {
+		return fmt.Errorf("restrict env ACL: %w", err)
+	}
 	return nil
 }
 
@@ -214,6 +241,43 @@ func (e *Env) APIKey(letter string) string {
 		return ""
 	}
 	return e.Get(e.RuntimeSpec().APIKeyVarPrefix + strings.ToUpper(letter))
+}
+
+// GitHubAuthMode returns the normalized configured mode. An omitted mode uses
+// the backward-compatible shared default; invalid explicit values are retained
+// so mutating callers can reject them instead of falling back silently.
+func (e *Env) GitHubAuthMode() string {
+	if e == nil {
+		return GHAuthShared
+	}
+	mode := strings.ToLower(strings.TrimSpace(e.Get("GH_AUTH_MODE")))
+	if mode == "" {
+		return GHAuthShared
+	}
+	return mode
+}
+
+// GHUser returns the expected GitHub login for an account in per-account mode.
+func (e *Env) GHUser(letter string) string {
+	if e == nil || e.GitHubAuthMode() != GHAuthPerAccount {
+		return ""
+	}
+	return e.Get("GH_USER_" + strings.ToUpper(letter))
+}
+
+// GHTokenKey returns the host .env key updated by the TUI for an account.
+func (e *Env) GHTokenKey(letter string) string {
+	if e == nil {
+		return "GH_TOKEN"
+	}
+	switch e.GitHubAuthMode() {
+	case GHAuthPerAccount:
+		return "GH_TOKEN_" + strings.ToUpper(letter)
+	case GHAuthShared:
+		return "GH_TOKEN"
+	default:
+		return ""
+	}
 }
 
 // HasWorktrees returns true if PROJECT_DIR_A is set (worktree mode).

--- a/tui/internal/config/env_test.go
+++ b/tui/internal/config/env_test.go
@@ -226,6 +226,50 @@ func TestAPIKey_CaseInsensitiveLetter(t *testing.T) {
 	}
 }
 
+func TestGitHubPerAccountConfiguration(t *testing.T) {
+	path := writeTempEnv(t,
+		"GH_AUTH_MODE=per-account\n"+
+			"GH_USER_A=fixture-user-a\n"+
+			"GH_TOKEN_A=fixture-token-a\n"+
+			"GH_USER_AA=fixture-user-aa\n")
+	e, err := LoadEnv(path)
+	if err != nil {
+		t.Fatalf("LoadEnv: %v", err)
+	}
+	if got := e.GitHubAuthMode(); got != GHAuthPerAccount {
+		t.Errorf("GitHubAuthMode = %q, want %q", got, GHAuthPerAccount)
+	}
+	if got := e.GHUser("a"); got != "fixture-user-a" {
+		t.Errorf("GHUser(a) = %q", got)
+	}
+	if got := e.GHUser("aa"); got != "fixture-user-aa" {
+		t.Errorf("GHUser(aa) = %q", got)
+	}
+	if got := e.GHTokenKey("aa"); got != "GH_TOKEN_AA" {
+		t.Errorf("GHTokenKey(aa) = %q", got)
+	}
+
+	shared := NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+	if got := shared.GitHubAuthMode(); got != GHAuthShared {
+		t.Errorf("default GitHubAuthMode = %q, want %q", got, GHAuthShared)
+	}
+	if got := shared.GHTokenKey("a"); got != "GH_TOKEN" {
+		t.Errorf("shared GHTokenKey(a) = %q", got)
+	}
+
+	invalidPath := writeTempEnv(t, "GH_AUTH_MODE=unexpected\n")
+	invalid, err := LoadEnv(invalidPath)
+	if err != nil {
+		t.Fatalf("LoadEnv invalid mode: %v", err)
+	}
+	if got := invalid.GitHubAuthMode(); got != "unexpected" {
+		t.Errorf("invalid GitHubAuthMode = %q, want unexpected", got)
+	}
+	if got := invalid.GHTokenKey("a"); got != "" {
+		t.Errorf("invalid-mode GHTokenKey(a) = %q, want empty", got)
+	}
+}
+
 func TestAgentRuntime_DefaultAndCodex(t *testing.T) {
 	cases := []struct {
 		content string

--- a/tui/internal/docker/client.go
+++ b/tui/internal/docker/client.go
@@ -106,8 +106,9 @@ func (c *Client) BuildArgs(noCache bool) (string, []string) {
 
 // UpRecreateArgs returns (bin, args) for `docker compose up -d --force-recreate`.
 // Used after image rebuild or .env change so containers pick up new config.
-func (c *Client) UpRecreateArgs() (string, []string) {
+func (c *Client) UpRecreateArgs(services ...string) (string, []string) {
 	args := append(BuildComposeArgs(c.projectRoot, c.env), "up", "-d", "--force-recreate")
+	args = append(args, services...)
 	return "docker", args
 }
 

--- a/tui/internal/docker/docker_test.go
+++ b/tui/internal/docker/docker_test.go
@@ -247,6 +247,14 @@ func TestUpRecreateArgs(t *testing.T) {
 	}
 }
 
+func TestUpRecreateArgsSelectedService(t *testing.T) {
+	c := NewClient("/tmp/proj", nil)
+	_, args := c.UpRecreateArgs("claude-b")
+	if got := args[len(args)-1]; got != "claude-b" {
+		t.Errorf("last arg = %q, want claude-b (args=%v)", got, args)
+	}
+}
+
 // execTail returns the argv tokens after "exec" — the service name followed by
 // the command. The compose plumbing before "exec" varies with the host (linux
 // overlay) and .env (worktree overlay), so attach assertions must not depend on

--- a/tui/internal/ui/dashboard/helpers.go
+++ b/tui/internal/ui/dashboard/helpers.go
@@ -2,34 +2,68 @@ package dashboard
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/kcenon/claude-docker/tui/internal/auth"
+	"github.com/kcenon/claude-docker/tui/internal/config"
 )
 
-// startGHAuth reads the host gh token, writes it to .env, and — if any
-// container is running — queues a recreate handoff so containers pick up
-// the new GH_TOKEN. Synchronous .env write is fine (no blocking I/O beyond
-// a single file); the slow container restart is done via tea.ExecProcess.
+var hostGHToken = auth.HostGHToken
+
+// startGHAuth reads the selected host gh token, writes only its matching .env
+// key, and queues the narrowest recreate needed for running containers.
 func (m Model) startGHAuth() (Model, tea.Cmd) {
 	if m.env == nil {
 		m = m.toast("gh-auth: .env not loaded", statusErr)
 		return m, m.toastExpireCmd()
 	}
+	mode := m.env.GitHubAuthMode()
+	if mode != config.GHAuthShared && mode != config.GHAuthPerAccount {
+		m = m.toast("gh-auth: GH_AUTH_MODE must be shared or per-account", statusErr)
+		return m, m.toastExpireCmd()
+	}
 	m.busy = true
 	client := m.client
 	env := m.env
+	user := ""
+	key := "GH_TOKEN"
+	label := "shared"
+	var services []string
+	if mode == config.GHAuthPerAccount {
+		if m.cursor >= len(m.accounts) {
+			m.busy = false
+			m = m.toast("gh-auth: no account selected", statusErr)
+			return m, m.toastExpireCmd()
+		}
+		acct := m.accounts[m.cursor]
+		user = env.GHUser(acct.Letter)
+		if user == "" {
+			m.busy = false
+			m = m.toast("gh-auth: GH_USER_"+strings.ToUpper(acct.Letter)+" is not configured", statusErr)
+			return m, m.toastExpireCmd()
+		}
+		key = env.GHTokenKey(acct.Letter)
+		label = acct.ServiceName + " (" + user + ")"
+		if acct.IsRunning() {
+			services = []string{acct.ServiceName}
+		}
+	}
 	return m, func() tea.Msg {
-		token, err := auth.HostGHToken()
+		token, err := hostGHToken(user)
 		if err != nil {
 			return ghAuthAppliedMsg{err: err}
 		}
-		env.Set("GH_TOKEN", token)
+		env.Set(key, token)
 		if err := env.Save(); err != nil {
 			return ghAuthAppliedMsg{err: fmt.Errorf("write .env: %w", err)}
 		}
-		return ghAuthAppliedMsg{recreateNeeded: client.HasRunningContainers()}
+		recreate := len(services) > 0
+		if mode == config.GHAuthShared {
+			recreate = client.HasRunningContainers()
+		}
+		return ghAuthAppliedMsg{recreateNeeded: recreate, services: services, label: label}
 	}
 }
 

--- a/tui/internal/ui/dashboard/messages.go
+++ b/tui/internal/ui/dashboard/messages.go
@@ -26,6 +26,8 @@ type dockerOpDoneMsg struct {
 type ghAuthAppliedMsg struct {
 	err            error
 	recreateNeeded bool
+	services       []string
+	label          string
 }
 
 // statusExpiredMsg clears any stale toast once its TTL has passed.

--- a/tui/internal/ui/dashboard/model_test.go
+++ b/tui/internal/ui/dashboard/model_test.go
@@ -1,10 +1,139 @@
 package dashboard
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/kcenon/claude-docker/tui/internal/account"
+	"github.com/kcenon/claude-docker/tui/internal/config"
+	"github.com/kcenon/claude-docker/tui/internal/docker"
 )
+
+func TestStartGHAuthPerAccountWritesSelectedAccount(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	content := "GH_AUTH_MODE=per-account\n" +
+		"GH_USER_A=fixture-user-a\nGH_TOKEN_A=unchanged-a\n" +
+		"GH_USER_B=fixture-user-b\nGH_TOKEN_B=old-b\n" +
+		"GH_TOKEN=unchanged-shared\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write env: %v", err)
+	}
+	env, err := config.LoadEnv(path)
+	if err != nil {
+		t.Fatalf("LoadEnv: %v", err)
+	}
+	client := docker.NewClient(t.TempDir(), env)
+	m := New(nil, client, env, false)
+	m.accounts = []account.Account{
+		{Letter: "a", ServiceName: "claude-a"},
+		{Letter: "b", ServiceName: "claude-b"},
+	}
+	m.cursor = 1
+
+	original := hostGHToken
+	t.Cleanup(func() { hostGHToken = original })
+	var selected string
+	hostGHToken = func(user string) (string, error) {
+		selected = user
+		return "new-b", nil
+	}
+
+	updated, cmd := m.startGHAuth()
+	if !updated.busy || cmd == nil {
+		t.Fatal("startGHAuth should enter busy state and return a command")
+	}
+	raw := cmd()
+	msg, ok := raw.(ghAuthAppliedMsg)
+	if !ok {
+		t.Fatalf("message type = %T, want ghAuthAppliedMsg", raw)
+	}
+	if msg.err != nil || msg.recreateNeeded {
+		t.Fatalf("message = %+v, want successful write without recreate", msg)
+	}
+	if selected != "fixture-user-b" {
+		t.Errorf("selected host login = %q, want fixture-user-b", selected)
+	}
+
+	reloaded, err := config.LoadEnv(path)
+	if err != nil {
+		t.Fatalf("reload env: %v", err)
+	}
+	if got := reloaded.Get("GH_TOKEN_B"); got != "new-b" {
+		t.Errorf("GH_TOKEN_B = %q, want new-b", got)
+	}
+	if runtime.GOOS != "windows" {
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			t.Fatalf("stat env: %v", statErr)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Errorf(".env permissions = %04o, want 0600", got)
+		}
+	}
+	for key, want := range map[string]string{
+		"GH_TOKEN_A": "unchanged-a",
+		"GH_TOKEN":   "unchanged-shared",
+	} {
+		if got := reloaded.Get(key); got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestStartGHAuthRejectsInvalidMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte("GH_AUTH_MODE=unexpected\nGH_TOKEN=unchanged\n"), 0o600); err != nil {
+		t.Fatalf("write env: %v", err)
+	}
+	env, err := config.LoadEnv(path)
+	if err != nil {
+		t.Fatalf("LoadEnv: %v", err)
+	}
+	m := New(nil, docker.NewClient(t.TempDir(), env), env, false)
+
+	original := hostGHToken
+	t.Cleanup(func() { hostGHToken = original })
+	called := false
+	hostGHToken = func(string) (string, error) {
+		called = true
+		return "must-not-be-written", nil
+	}
+
+	updated, cmd := m.startGHAuth()
+	if updated.busy || cmd == nil {
+		t.Fatalf("invalid mode result: busy=%v cmd=nil=%v", updated.busy, cmd == nil)
+	}
+	if called {
+		t.Fatal("invalid mode must not read or write a GitHub token")
+	}
+	if !strings.Contains(updated.statusText, "GH_AUTH_MODE must be shared or per-account") {
+		t.Errorf("status = %q", updated.statusText)
+	}
+	reloaded, err := config.LoadEnv(path)
+	if err != nil {
+		t.Fatalf("reload env: %v", err)
+	}
+	if got := reloaded.Get("GH_TOKEN"); got != "unchanged" {
+		t.Errorf("GH_TOKEN = %q, want unchanged", got)
+	}
+}
+
+func TestRenderGitHubLoginAndMismatch(t *testing.T) {
+	accounts := []account.Account{
+		{ServiceName: "claude-a", ContainerStatus: account.ContainerRunning, GHAuthOK: true, GHLogin: "actual-a"},
+		{ServiceName: "claude-b", ContainerStatus: account.ContainerRunning, GHLogin: "actual-b", GHExpectedLogin: "expected-b", GHLoginMismatch: true},
+	}
+	view := renderAccountTable(accounts, 0, 140)
+	for _, want := range []string{"GITHUB LOGIN", "actual-a", "actual-b != expected-b"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("rendered table missing %q: %s", want, view)
+		}
+	}
+}
 
 func TestPadPlainAscii(t *testing.T) {
 	got := padPlain("hello", 10)

--- a/tui/internal/ui/dashboard/render.go
+++ b/tui/internal/ui/dashboard/render.go
@@ -15,7 +15,7 @@ func renderAccountTable(accounts []account.Account, cursor int, width int) strin
 		colService  = 12
 		colStatus   = 10
 		colAuth     = 8
-		colGH       = 10
+		colGH       = 24
 		colFiveHour = 22
 		colSevenDay = 22
 	)
@@ -24,7 +24,7 @@ func renderAccountTable(accounts []account.Account, cursor int, width int) strin
 		padPlain("SERVICE", colService) +
 		padPlain("STATUS", colStatus) +
 		padPlain("AUTH", colAuth) +
-		padPlain("GH AUTH", colGH) +
+		padPlain("GITHUB LOGIN", colGH) +
 		padPlain("5h USED / LEFT", colFiveHour) +
 		padPlain("7d USED / LEFT", colSevenDay)
 	b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#9CA3AF")).
@@ -63,8 +63,10 @@ func renderAccountTable(accounts []account.Account, cursor int, width int) strin
 		var ghCell string
 		if !acct.IsRunning() {
 			ghCell = padStyled("--", colGH, styleMuted)
+		} else if acct.GHLoginMismatch {
+			ghCell = padStyled(acct.GHLogin+" != "+acct.GHExpectedLogin, colGH, styleYellow)
 		} else if acct.GHAuthOK {
-			ghCell = padStyled("OK", colGH, styleGreen)
+			ghCell = padStyled(acct.GHLogin, colGH, styleGreen)
 		} else {
 			ghCell = padStyled("FAIL", colGH, styleRed)
 		}

--- a/tui/internal/ui/dashboard/update.go
+++ b/tui/internal/ui/dashboard/update.go
@@ -106,11 +106,11 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		}
 		if !msg.recreateNeeded {
 			m.busy = false
-			m = m.toast("GitHub token written to .env (no running containers)", statusOK)
+			m = m.toast("GitHub token written for "+msg.label+" (container not running)", statusOK)
 			return m, tea.Batch(m.Refresh(), m.toastExpireCmd())
 		}
 		// Containers are running — recreate them so the new GH_TOKEN takes effect.
-		bin, args := m.client.UpRecreateArgs()
+		bin, args := m.client.UpRecreateArgs(msg.services...)
 		cmd := exec.Command(bin, args...)
 		return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
 			return dockerOpDoneMsg{kind: opGHAuthRecreate, err: err}

--- a/tui/internal/ui/dashboard/view.go
+++ b/tui/internal/ui/dashboard/view.go
@@ -109,6 +109,10 @@ func renderHelp(env *config.Env) string {
 	runtime := env.RuntimeBinary()
 	skipFlag := env.SkipPermissionsFlag()
 
+	ghDescription := "Inject the active host gh token into .env (+ recreate)"
+	if env.GitHubAuthMode() == config.GHAuthPerAccount {
+		ghDescription = "Refresh selected account's configured host gh login"
+	}
 	rows := [][2]string{
 		{"j / k", "Move cursor down / up"},
 		{"Enter / c", "Attach to selected account's " + runtime + " session"},
@@ -119,7 +123,7 @@ func renderHelp(env *config.Env) string {
 		{"B", "docker compose build --no-cache"},
 		{"U", "Full update: rebuild --no-cache + force-recreate"},
 		{"R", "Restart the selected container"},
-		{"g", "Inject host gh token into .env (+ recreate)"},
+		{"g", ghDescription},
 		{"?", "Toggle this help"},
 		{"q / Ctrl+C", "Quit"},
 	}


### PR DESCRIPTION
## Summary

- add opt-in `GH_AUTH_MODE=per-account` Compose generation with account-scoped GitHub credentials and Git identities through suffix `ZZ`
- extend Bash and PowerShell installers, `gh-auth`, `update`, startup verification, and the TUI to select and verify explicit GitHub logins
- omit the shared GitHub config mount in per-account mode, preserve shared mode by default, and retain Unix/Windows secret-file protections
- add non-secret fixtures, cross-shell parity coverage, resolved Compose isolation assertions, entrypoint tests, TUI tests, and migration/rotation documentation

## Why

All generated services currently share the same GitHub token, host GitHub config mount, and commit identity. That can perform GitHub or HTTPS Git operations as the wrong account and prevents strict credential isolation between account containers.

Per-account mode maps only the selected host account token into each service, records the expected login, and reports mismatches explicitly without changing the host's active `gh` account.

## Verification

- `go test ./...` in `tui`
- `gofmt -l .` in `tui`
- Bash syntax checks and warning-level ShellCheck
- PowerShell parser checks
- `bash tests/test_github_per_account_compose.sh`
- `bash tests/test_github_account_selection.sh`
- `bash tests/test_entrypoint_github_auth.sh`
- native `pwsh -NoProfile -File tests/test_github_account_selection.ps1`
- existing Bash and PowerShell regression tests
- native Docker resolved-Compose validation for account isolation and Git identity fallback
- Bash/PowerShell generated Compose parity and tracked Compose freshness

Local WSL lacks PowerShell, Docker, and jq integration on the same path, so the Ubuntu cross-shell installer/generator parity and full Compose matrix remain covered by CI.

## Security

- per-account generation fails before writing output when any configured login or token is missing
- named host tokens are retrieved with explicit argv and never with `gh auth switch`
- token values are never emitted in command output or diagnostics
- TUI and CLI writes reapply `0600` or protected Windows ACLs
- invalid auth modes fail closed on every mutating path
- the documented boundary remains HTTPS Git/`gh` isolation between containers, not protection from host administrators or Docker daemon users

Closes #331