### PR TITLE
feat(isolation): harden the isolated container profile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,10 +33,12 @@ PROJECT_DIR=/absolute/path/to/your/project
 #             concurrency tier and NOT an adversarial sandbox.
 #   isolated  Each account mounts its own independent clone (see
 #             ISOLATED_WORKSPACE_A below), with its own git metadata and no
-#             shared host configuration. Credentials and networks are NOT yet
-#             scoped: an isolated account cannot reach another account's
-#             source, but still sees the same GH_TOKEN. Read docs/ISOLATION.md
-#             before relying on it.
+#             shared host configuration. The container is hardened as well:
+#             read-only root filesystem, every capability dropped,
+#             no-new-privileges, an init process and a bounded PID limit.
+#             Credentials and networks are NOT yet scoped: an isolated account
+#             cannot reach another account's source, but still sees the same
+#             GH_TOKEN. Read docs/ISOLATION.md before relying on it.
 #
 # Regenerate compose files (scripts/generate-compose.sh or .ps1) after changing
 # this. An unrecognized value is rejected, and so is a mode whose per-account
@@ -140,3 +142,11 @@ PROJECT_DIR=/absolute/path/to/your/project
 # /workspace-b, ... and each account's mounts follow whichever value is set.
 # CONTAINER_ISOLATED_DIR_A=/workspace-a
 # CONTAINER_ISOLATED_DIR_B=/workspace-b
+#
+# Optional PID ceiling for isolated services. The profile always sets one --
+# an unbounded container can exhaust the host process table through a fork
+# loop -- so this only changes the value, never whether there is a limit. The
+# 1024 default is chosen to leave headroom for parallel compilers and test
+# runners; it is not a measured figure, and a value set too low fails the
+# workload rather than the boundary.
+# ISOLATED_PIDS_LIMIT=1024

--- a/README.md
+++ b/README.md
@@ -683,7 +683,7 @@ against are in [`docs/ISOLATION.md`](docs/ISOLATION.md).
 |---|---|---|
 | `shared` (default) | Tier A | One read-write project mount shared by every account. |
 | `worktree` | Tier B | Each account mounts only its own worktree. Git metadata stays shared. |
-| `isolated` | Tier C | Each account mounts its own independent clone, with its own git metadata and no shared host configuration. Credentials and networks are not yet scoped. |
+| `isolated` | Tier C | Each account mounts its own independent clone, with its own git metadata and no shared host configuration, under a hardened container profile. Credentials and networks are not yet scoped. |
 
 An unrecognized value is refused, and so is a mode whose per-account workspace
 paths are missing. The active mode and its boundary are printed by
@@ -744,11 +744,17 @@ Isolated accounts receive no shared host configuration, which means no shared
 hooks, skills, commands, statusline or `CLAUDE.md`. GitHub authentication still
 works through `GH_TOKEN`.
 
+The container profile is hardened: a read-only root filesystem, every capability
+dropped, `no-new-privileges`, an init process, and a bounded PID limit
+(`ISOLATED_PIDS_LIMIT`, default 1024). The paths the entrypoint and toolchain
+have to write — `/tmp`, the npm and tool caches, the XDG config directory — are
+bounded tmpfs mounts, and the global git config is redirected into the account's
+own state mount so `git push` keeps working.
+
 > **What this tier does not yet do.** Credentials and networks are not scoped:
 > an isolated account cannot reach another account's source, but still sees the
-> same `GH_TOKEN` and can reach sibling containers. The container also still
-> runs with a writable root filesystem and full default capabilities. Those are
-> the next stage of [#335](https://github.com/kcenon/claude-docker/issues/335);
+> same `GH_TOKEN` and can reach sibling containers. Those are the remainder of
+> stage 4 of [#335](https://github.com/kcenon/claude-docker/issues/335);
 > [`docs/ISOLATION.md`](docs/ISOLATION.md) has the per-concern table.
 
 ## Scaling Accounts

--- a/docker-compose.isolated.yml
+++ b/docker-compose.isolated.yml
@@ -15,12 +15,37 @@
 # Shared host-home mounts are absent by design: no read-only host config
 # tree, no agents/skills tree, no shared gh config. An isolated account
 # therefore has no shared hooks, skills, commands, statusline or CLAUDE.md.
+#
+# The container profile is hardened: read-only root filesystem, all
+# capabilities dropped, no-new-privileges, an init process and a bounded
+# PID limit. Every path the entrypoint writes to outside the account's own
+# mounts is a bounded tmpfs; $HOME itself stays read-only, so the global
+# git config is redirected into the per-account state mount.
+#
 # Credential environment variables and per-account networks are NOT yet
-# scoped — that is stage 4. See docs/ISOLATION.md.
+# scoped. See docs/ISOLATION.md.
 
 services:
   claude-a:
     working_dir: ${CONTAINER_ISOLATED_DIR_A:-/workspace-a}
+    read_only: true
+    init: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          pids: ${ISOLATED_PIDS_LIMIT:-1024}
+    tmpfs:
+      - /tmp:mode=1777
+      - /home/node/.config:uid=${UID:-1000},gid=${GID:-1000},mode=0700
+      - /home/node/.cache:uid=${UID:-1000},gid=${GID:-1000},mode=0700
+      - /home/node/.npm:uid=${UID:-1000},gid=${GID:-1000},mode=0700
+      - /home/node/.agents:uid=${UID:-1000},gid=${GID:-1000},mode=0700
+    environment:
+      - GIT_CONFIG_GLOBAL=/home/node/.claude/gitconfig
     volumes: !override
       - ${ISOLATED_WORKSPACE_A}:${CONTAINER_ISOLATED_DIR_A:-/workspace-a}
       - ${HOME}/.claude-state/account-a:/home/node/.claude
@@ -28,6 +53,24 @@ services:
 
   claude-b:
     working_dir: ${CONTAINER_ISOLATED_DIR_B:-/workspace-b}
+    read_only: true
+    init: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          pids: ${ISOLATED_PIDS_LIMIT:-1024}
+    tmpfs:
+      - /tmp:mode=1777
+      - /home/node/.config:uid=${UID:-1000},gid=${GID:-1000},mode=0700
+      - /home/node/.cache:uid=${UID:-1000},gid=${GID:-1000},mode=0700
+      - /home/node/.npm:uid=${UID:-1000},gid=${GID:-1000},mode=0700
+      - /home/node/.agents:uid=${UID:-1000},gid=${GID:-1000},mode=0700
+    environment:
+      - GIT_CONFIG_GLOBAL=/home/node/.claude/gitconfig
     volumes: !override
       - ${ISOLATED_WORKSPACE_B}:${CONTAINER_ISOLATED_DIR_B:-/workspace-b}
       - ${HOME}/.claude-state/account-b:/home/node/.claude

--- a/docs/ISOLATION.md
+++ b/docs/ISOLATION.md
@@ -5,10 +5,12 @@ under. This document states what each mode does and does not protect against,
 so a boundary is chosen deliberately rather than inferred from which compose
 file happened to be passed.
 
-Status: stages 1 to 3 of issue #335 are implemented. `isolated` runs, and it
-isolates the **workspace**: independent clones, independent git metadata, and
-no shared host configuration. It does **not** yet scope credentials or the
-network — that is stage 4. Read
+Status: stages 1 to 3 of issue #335 are implemented, plus the container
+hardening half of stage 4. `isolated` isolates the **workspace** — independent
+clones, independent git metadata, no shared host configuration — and runs under
+a hardened container profile: read-only root filesystem, every capability
+dropped, no-new-privileges, an init process and a bounded PID limit. It does
+**not** yet scope credentials or the network; that is the rest of stage 4. Read
 [What each mode protects against](#what-each-mode-protects-against) before
 relying on it, and see [Delivery order](#delivery-order) for what remains.
 
@@ -75,24 +77,26 @@ The adversary model for `isolated` is an agent running an unsafe or malicious
 command **inside a normal container** — a wrong `rm -rf`, a prompt-injected
 tool call, a compromised dependency's postinstall script.
 
-| Concern | `shared` | `worktree` | `isolated` (as shipped) | `isolated` (stage 4+) |
+| Concern | `shared` | `worktree` | `isolated` (as shipped) | `isolated` (once credentials/networks land) |
 |---|---|---|---|---|
 | Account A edits account B's working tree | No | Yes | Yes | Yes |
 | Account A reads account B's working tree | No | Yes | Yes | Yes |
 | Account A rewrites shared git history (`.git`) | No | **No** | Yes | Yes |
 | Account A reads the shared host configuration | No | No | Yes | Yes |
+| Container root filesystem is read-only | No | No | Yes | Yes |
+| Capabilities dropped and privilege escalation blocked | No | No | Yes | Yes |
 | Account A reads account B's credentials | No | No | **No** | Yes |
 | Account A reaches account B over the network | No | No | **No** | Yes |
-| Container root filesystem is read-only | No | No | **No** | Yes |
 | Container escape to the host | No | No | No | No |
 
 "No" means the mode does not defend against it.
 
-The two `isolated` columns matter. Stage 3 delivered the workspace boundary;
-credential scoping, per-account networks and container hardening are stage 4.
-Until then `isolated` is the right choice for "these agents must not touch each
-other's source", and the wrong choice for "these agents must not learn each
-other's secrets".
+The two `isolated` columns matter. What is shipped is the workspace boundary
+(stage 3) and the container profile (the hardening half of stage 4); credential
+scoping and per-account networks are the remainder. Until they land `isolated`
+is the right choice for "these agents must not touch each other's source" and
+"this agent should not be able to write outside its workspace", and the wrong
+choice for "these agents must not learn each other's secrets".
 
 ### Why `worktree` is a concurrency tier, not a sandbox
 
@@ -165,21 +169,86 @@ Exactly one mode overlay is ever composed. Composing two would let the later
 one replace the volume list again, which is how a boundary could be undone by
 an ordering accident rather than a code change.
 
-**Note for stage 4 — the Linux overlay `user` conflict has a mechanical
-answer.** `docker-compose.linux.yml` sets `user: "${UID}:${GID}"`, which looked
-like it would block the stage 4 requirement to run isolated services as the
-non-root `node` user, because on a Linux host that overlay is applied
-unconditionally. It does not: the mode overlay is appended **after** the Linux
-overlay and Compose lets a later `-f` win, so an isolated stack declaring
-`user: node` overrides it without the Linux overlay being touched or scoped to
-non-isolated modes.
+**The overlay order settles the `user` question.** Both the base stack and
+`docker-compose.linux.yml` declare `user: "${UID:-1000}:${GID:-1000}"`, and the
+mode overlay is appended **after** both, so an isolated stack could override the
+field outright — Compose lets a later `-f` win. It deliberately does not; see
+[Why the host user, not `node`](#why-the-host-user-not-node).
 
-Stage 3 declares no `user`, so nothing changes yet. One consequence is worth
-carrying forward: running as `node` (uid 1000) when the host user has a
-different uid makes the bind-mounted per-account state directory unwritable,
-which is the reason the Linux overlay exists. Stage 4 has to solve that —
-`chown` at setup, a named volume for state, or an entrypoint fixup — not just
-set the field.
+## The hardened container profile
+
+`isolated` services run under a restricted profile. Every field below is
+asserted against the resolved model in `tests/test_isolation_modes.sh` rather
+than against the overlay, because the base stack contributes fields of its own
+and only the merged project shows which value wins.
+
+| Field | Value | What it bounds |
+|---|---|---|
+| `read_only` | `true` | Writes anywhere outside the declared mounts, including the image's own tooling. |
+| `cap_drop` | `[ALL]` | Every Linux capability, including the ones an agent workload never uses. |
+| `security_opt` | `no-new-privileges:true` | A setuid binary raising privileges after start. |
+| `init` | `true` | Orphaned processes accumulating as zombies under PID 1. |
+| `deploy.resources.limits.pids` | `${ISOLATED_PIDS_LIMIT:-1024}` | A fork loop exhausting the host process table. |
+
+The PID cap lives under `deploy.resources.limits`, not the legacy top-level
+`pids_limit` key. The base stack already declares `deploy.resources.limits`
+(cpus, memory); Compose treats the two spellings as one setting and rejects the
+merged project outright when both appear. The default is chosen to leave
+headroom for parallel compilers and test runners, not from measurement —
+measured budgets are stage 5.
+
+### Why the host user, not `node`
+
+Issue #335 asks isolated services to run as "the existing non-root `node`
+user". The profile keeps the host user's uid/gid instead, and the tests assert
+the property the acceptance criterion actually names: the effective user is not
+uid 0.
+
+Pinning uid 1000 would break the reason the base stack declares `user` at all.
+The per-account state directory is a host bind mount; on a Linux host whose user
+is not uid 1000 it would become unwritable, and that directory is also what the
+TUI reads. The alternatives cost more than they buy — `chown`ing the host
+directories at setup mutates paths the user and the dashboard share, and moving
+state into a named volume blinds account discovery.
+
+### Writable paths under a read-only root
+
+`read_only: true` makes the image layers unwritable, so every path the
+entrypoint or the toolchain writes to needs a mount of its own. The account's
+workspace, runtime state and `node_modules` already are mounts. The rest are
+bounded tmpfs:
+
+| Path | Written by |
+|---|---|
+| `/tmp` | general tool scratch |
+| `/home/node/.config` | `bootstrap-claude.sh`, creating the ccstatusline XDG link |
+| `/home/node/.cache` | generic tool caches |
+| `/home/node/.npm` | npm |
+| `/home/node/.agents` | `bootstrap-codex.sh` / `bootstrap-gemini.sh` |
+
+`/home/node/.local` is deliberately **absent**: the agent CLI is installed there
+and is on `PATH`, so a tmpfs would hide the binary. A test asserts its absence,
+because "add one more tmpfs" is the obvious wrong fix for a future write error
+in that tree.
+
+Each tmpfs is mounted `uid=${UID:-1000},gid=${GID:-1000},mode=0700` to match the
+service's own identity. Without those options Docker mounts a tmpfs root-owned
+with mode 1777 — writable, but world-writable, which is not what this profile
+should be shipping. `/tmp` keeps the conventional 1777 and its sticky bit,
+because tools expect a shared scratch there.
+
+### The global git config
+
+`$HOME` stays on the read-only root, so `git config --global` and
+`gh auth setup-git` cannot write `~/.gitconfig`. The profile therefore sets
+`GIT_CONFIG_GLOBAL=/home/node/.claude/gitconfig`, inside the per-account state
+mount, which is writable and already account-private.
+
+This is worth stating explicitly because the failure it prevents is silent. The
+entrypoint wraps `gh auth setup-git` in `2>/dev/null || true`, so without the
+redirect the container starts normally, prints its "authenticated as ..."
+banner, and only fails later at `git push` — with no credential helper and no
+diagnostic explaining why.
 
 ## Interaction with the shared runtime configuration mount
 
@@ -220,13 +289,20 @@ Issue #335 is delivered in six stages. Each is a separate PR.
 1. **Configuration contract, threat model, resolved-compose test helpers.** ✅
 2. **Worktree mount correction and regression tests.** ✅
 3. **Independent workspace setup and isolated mount generation.** ✅
-4. Runtime, configuration, credential and network hardening.
+4. Runtime, configuration, credential and network hardening. **Partial** — the
+   container profile is delivered; credential scoping and per-account networks
+   remain.
 5. Resource validation, transactional scaling, TUI cache correction, benchmarks.
 6. Cross-platform rollout, migration documentation, final benchmark report.
 
 `isolated` became usable at stage 3, which removed a refusal rather than adding
 a name — the contract had accepted the value since stage 1 precisely so that
 stages could turn it on without changing what users configure.
+
+Stage 4 is split because its four axes are independent: the container profile
+constrains what an account can do to its own container, while credential and
+network scoping constrain what it can reach. Landing them separately keeps a
+read-only-root regression and a network regression from arriving in one CI run.
 
 ## Verifying the active mode
 

--- a/scripts/generate-compose.ps1
+++ b/scripts/generate-compose.ps1
@@ -251,6 +251,49 @@ function Get-AccountVolumeLines {
     return $lines
 }
 
+function Get-IsolatedTmpfsLines {
+    <#
+    .SYNOPSIS
+    Return the tmpfs block for one isolated service, including its `tmpfs:` key.
+    .DESCRIPTION
+    Mirrors emit_isolated_tmpfs in generate-compose.sh.
+
+    Every path below is an image layer rather than a mount, so with
+    read_only: true the first write to it fails. The inventory is what the
+    entrypoint and toolchain actually write outside the account's own mounts:
+
+      /tmp                 general tool scratch
+      /home/node/.config   bootstrap-claude.sh creates the ccstatusline XDG link
+      /home/node/.cache    generic tool caches
+      /home/node/.npm      npm cache
+      /home/node/.agents   bootstrap-codex/gemini create skills/ under it
+
+    /home/node/.local is deliberately absent: the agent CLI is installed there
+    (Dockerfile) and is on PATH, so covering it with a tmpfs would hide the
+    binary. $HOME itself is likewise left read-only; the one thing that needed
+    to write there, the global git config, is redirected via GIT_CONFIG_GLOBAL.
+
+    uid/gid repeat the host-user defaults the base stack uses for `user:`.
+    Without them a tmpfs mounts root-owned with mode 1777 — writable by the
+    service, but world-writable, which contradicts the point of this profile.
+    /tmp keeps the conventional 1777 with its sticky bit instead, because tools
+    expect a shared scratch there.
+    #>
+    [CmdletBinding()]
+    param()
+
+    $owner = 'uid=${UID:-1000},gid=${GID:-1000},mode=0700'
+
+    return @(
+        '    tmpfs:'
+        '      - /tmp:mode=1777'
+        "      - /home/node/.config:$owner"
+        "      - /home/node/.cache:$owner"
+        "      - /home/node/.npm:$owner"
+        "      - /home/node/.agents:$owner"
+    )
+}
+
 # --- Generate docker-compose.yml ---------------------------------------------
 
 function New-BaseCompose {
@@ -443,8 +486,15 @@ function New-IsolatedCompose {
     [void]$sb.AppendLine('# Shared host-home mounts are absent by design: no read-only host config')
     [void]$sb.AppendLine('# tree, no agents/skills tree, no shared gh config. An isolated account')
     [void]$sb.AppendLine('# therefore has no shared hooks, skills, commands, statusline or CLAUDE.md.')
+    [void]$sb.AppendLine('#')
+    [void]$sb.AppendLine('# The container profile is hardened: read-only root filesystem, all')
+    [void]$sb.AppendLine('# capabilities dropped, no-new-privileges, an init process and a bounded')
+    [void]$sb.AppendLine('# PID limit. Every path the entrypoint writes to outside the account''s own')
+    [void]$sb.AppendLine('# mounts is a bounded tmpfs; $HOME itself stays read-only, so the global')
+    [void]$sb.AppendLine('# git config is redirected into the per-account state mount.')
+    [void]$sb.AppendLine('#')
     [void]$sb.AppendLine('# Credential environment variables and per-account networks are NOT yet')
-    [void]$sb.AppendLine('# scoped — that is stage 4. See docs/ISOLATION.md.')
+    [void]$sb.AppendLine('# scoped. See docs/ISOLATION.md.')
     [void]$sb.AppendLine('')
     [void]$sb.AppendLine('services:')
 
@@ -455,6 +505,32 @@ function New-IsolatedCompose {
 
         [void]$sb.AppendLine("  ${svc}:")
         [void]$sb.AppendLine("    working_dir: `${CONTAINER_ISOLATED_DIR_${upper}:-/workspace-$letter}")
+        [void]$sb.AppendLine('    read_only: true')
+        [void]$sb.AppendLine('    init: true')
+        [void]$sb.AppendLine('    cap_drop:')
+        [void]$sb.AppendLine('      - ALL')
+        [void]$sb.AppendLine('    security_opt:')
+        [void]$sb.AppendLine('      - no-new-privileges:true')
+        # The PID cap goes under deploy.resources.limits, not the legacy
+        # top-level pids_limit key. The base stack already declares
+        # deploy.resources.limits (cpus, memory); Compose treats the legacy key
+        # and the deploy field as the same setting and rejects the merged
+        # project outright when both appear.
+        [void]$sb.AppendLine('    deploy:')
+        [void]$sb.AppendLine('      resources:')
+        [void]$sb.AppendLine('        limits:')
+        [void]$sb.AppendLine('          pids: ${ISOLATED_PIDS_LIMIT:-1024}')
+        foreach ($tmpfsLine in (Get-IsolatedTmpfsLines)) {
+            [void]$sb.AppendLine($tmpfsLine)
+        }
+        [void]$sb.AppendLine('    environment:')
+        # $HOME is on the read-only root filesystem, so "git config --global"
+        # and "gh auth setup-git" cannot write ~/.gitconfig. Redirect the global
+        # config into the per-account state mount, which is writable and already
+        # account-private. Without this the entrypoint's credential-helper setup
+        # fails silently and git push breaks with no diagnostic. Requires git
+        # 2.32+ (image ships 2.39 on bookworm).
+        [void]$sb.AppendLine("      - GIT_CONFIG_GLOBAL=${RtContainerConfigMount}/gitconfig")
         [void]$sb.AppendLine('    volumes: !override')
         foreach ($volumeLine in (Get-AccountVolumeLines -Mode 'isolated' -Letter $letter `
                     -ProjectSource "`${ISOLATED_WORKSPACE_${upper}}" `

--- a/scripts/generate-compose.sh
+++ b/scripts/generate-compose.sh
@@ -197,6 +197,40 @@ emit_account_volumes() {
     echo "      - node_modules_${letter}:${project_target}/node_modules"
 }
 
+# emit_isolated_tmpfs
+# Bounded writable scratch for the isolated profile's read-only root filesystem.
+#
+# Every path below is an image layer rather than a mount, so with
+# read_only: true the first write to it fails. The inventory is what the
+# entrypoint and toolchain actually write outside the account's own mounts:
+#
+#   /tmp                 general tool scratch
+#   /home/node/.config   bootstrap-claude.sh creates the ccstatusline XDG link
+#   /home/node/.cache    generic tool caches
+#   /home/node/.npm      npm cache
+#   /home/node/.agents   bootstrap-codex/gemini create skills/ under it
+#
+# /home/node/.local is deliberately absent: the agent CLI is installed there
+# (Dockerfile) and is on PATH, so covering it with a tmpfs would hide the
+# binary. $HOME itself is likewise left read-only; the one thing that needed to
+# write there, the global git config, is redirected via GIT_CONFIG_GLOBAL.
+#
+# uid/gid repeat the host-user defaults the base stack uses for `user:`.
+# Without them a tmpfs mounts root-owned with mode 1777 — writable by the
+# service, but world-writable, which contradicts the point of this profile.
+# /tmp keeps the conventional 1777 with its sticky bit instead, because tools
+# expect a shared scratch there.
+emit_isolated_tmpfs() {
+    local owner="uid=\${UID:-1000},gid=\${GID:-1000},mode=0700"
+
+    echo "    tmpfs:"
+    echo "      - /tmp:mode=1777"
+    echo "      - /home/node/.config:${owner}"
+    echo "      - /home/node/.cache:${owner}"
+    echo "      - /home/node/.npm:${owner}"
+    echo "      - /home/node/.agents:${owner}"
+}
+
 # --- Generate docker-compose.yml ---------------------------------------------
 
 generate_base() {
@@ -382,8 +416,15 @@ generate_isolated() {
         echo "# Shared host-home mounts are absent by design: no read-only host config"
         echo "# tree, no agents/skills tree, no shared gh config. An isolated account"
         echo "# therefore has no shared hooks, skills, commands, statusline or CLAUDE.md."
+        echo "#"
+        echo "# The container profile is hardened: read-only root filesystem, all"
+        echo "# capabilities dropped, no-new-privileges, an init process and a bounded"
+        echo "# PID limit. Every path the entrypoint writes to outside the account's own"
+        echo "# mounts is a bounded tmpfs; \$HOME itself stays read-only, so the global"
+        echo "# git config is redirected into the per-account state mount."
+        echo "#"
         echo "# Credential environment variables and per-account networks are NOT yet"
-        echo "# scoped — that is stage 4. See docs/ISOLATION.md."
+        echo "# scoped. See docs/ISOLATION.md."
         echo ""
         echo "services:"
 
@@ -396,6 +437,30 @@ generate_isolated() {
 
             echo "  ${svc}:"
             echo "    working_dir: \${CONTAINER_ISOLATED_DIR_${upper}:-/workspace-${letter}}"
+            echo "    read_only: true"
+            echo "    init: true"
+            echo "    cap_drop:"
+            echo "      - ALL"
+            echo "    security_opt:"
+            echo "      - no-new-privileges:true"
+            # The PID cap goes under deploy.resources.limits, not the legacy
+            # top-level pids_limit key. The base stack already declares
+            # deploy.resources.limits (cpus, memory); Compose treats the legacy
+            # key and the deploy field as the same setting and rejects the
+            # merged project outright when both appear.
+            echo "    deploy:"
+            echo "      resources:"
+            echo "        limits:"
+            echo "          pids: \${ISOLATED_PIDS_LIMIT:-1024}"
+            emit_isolated_tmpfs
+            echo "    environment:"
+            # $HOME is on the read-only root filesystem, so `git config --global`
+            # and `gh auth setup-git` cannot write ~/.gitconfig. Redirect the
+            # global config into the per-account state mount, which is writable
+            # and already account-private. Without this the entrypoint's
+            # credential-helper setup fails silently and `git push` breaks with
+            # no diagnostic. Requires git 2.32+ (image ships 2.39 on bookworm).
+            echo "      - GIT_CONFIG_GLOBAL=${RT_CONTAINER_CONFIG_MOUNT}/gitconfig"
             echo "    volumes: !override"
             emit_account_volumes isolated "$letter" \
                 "\${ISOLATED_WORKSPACE_${upper}}" \

--- a/tests/lib/compose_assert.sh
+++ b/tests/lib/compose_assert.sh
@@ -94,6 +94,54 @@ resolved_mount_sources() {
     resolved_service_mounts "$@" | cut -d'|' -f2
 }
 
+# resolved_service_hardening DIR SERVICE FILE...
+# Print the container-hardening fields of one resolved service as KEY=VALUE
+# lines. List-valued fields are rendered as sorted compact JSON so a caller can
+# match the whole list exactly instead of grepping for a substring -- the
+# difference between asserting "all capabilities are dropped" and accepting a
+# list that merely mentions ALL among others.
+resolved_service_hardening() {
+    local dir="$1" service="$2"
+    shift 2
+
+    local file_args=() f
+    for f in "$@"; do
+        file_args+=(-f "$f")
+    done
+
+    (cd "$dir" && docker compose "${file_args[@]}" config --format json) \
+        | jq -r --arg svc "$service" '
+            .services[$svc] as $s
+            | [
+                "user=\($s.user // "")",
+                "read_only=\($s.read_only // false)",
+                "init=\($s.init // false)",
+                "pids=\($s.deploy.resources.limits.pids // "")",
+                "cap_drop=\(($s.cap_drop // []) | sort | tostring)",
+                "security_opt=\(($s.security_opt // []) | sort | tostring)",
+                "git_config_global=\($s.environment.GIT_CONFIG_GLOBAL // "")"
+              ]
+            | .[]
+        '
+}
+
+# resolved_service_tmpfs DIR SERVICE FILE...
+# Print one tmpfs entry per line, as it appears in the resolved model
+# (`TARGET` or `TARGET:OPTIONS`). Callers that only care about the mount point
+# should `cut -d: -f1`.
+resolved_service_tmpfs() {
+    local dir="$1" service="$2"
+    shift 2
+
+    local file_args=() f
+    for f in "$@"; do
+        file_args+=(-f "$f")
+    done
+
+    (cd "$dir" && docker compose "${file_args[@]}" config --format json) \
+        | jq -r --arg svc "$service" '.services[$svc].tmpfs // [] | .[]'
+}
+
 # resolved_mount_manifest DIR FILE...
 # Print one "SERVICE|TYPE|SOURCE|TARGET|ACCESS" line per mount across every
 # service in the resolved model, sorted so the output is stable to diff.

--- a/tests/test_isolation_modes.sh
+++ b/tests/test_isolation_modes.sh
@@ -447,9 +447,9 @@ else
     echo "  SKIP  resolved-compose assertions (docker or jq unavailable)"
 fi
 
-# --- 4. Resolved isolated mounts ----------------------------------------------
+# --- 4. Resolved isolated mounts and container hardening ----------------------
 
-echo "== resolved isolated mounts =="
+echo "== resolved isolated mounts and hardening =="
 
 if compose_assert_requires; then
     dir="$(make_sandbox resolved-isolated)"
@@ -532,6 +532,80 @@ if compose_assert_requires; then
         else
             fail "control: generator failed for a plain shared configuration"
             sed 's/^/        /' "$dup_control/.gen.log"
+        fi
+
+        # --- Container hardening --------------------------------------------
+        # Asserted on the resolved model rather than the overlay, for the same
+        # reason the mounts are: the base stack contributes fields of its own,
+        # and only the merged project shows which value actually wins.
+        hardening="$(resolved_service_hardening "$dir" claude-a "${iso_files[@]}")"
+
+        for expected in 'read_only=true' 'init=true' 'cap_drop=["ALL"]' \
+                        'security_opt=["no-new-privileges:true"]'; do
+            if grep -qxF "$expected" <<<"$hardening"; then
+                pass "isolated: $expected"
+            else
+                fail "isolated: expected $expected"
+                printf '%s\n' "$hardening" | sed 's/^/        /'
+            fi
+        done
+
+        # The profile must not run as root. It pins the host user's uid/gid
+        # rather than the image's `node` account, because the per-account state
+        # directory is a host bind mount and a fixed uid 1000 would make it
+        # unwritable wherever the host user is not uid 1000. Either identity
+        # satisfies the requirement this asserts, which is that uid 0 is not it.
+        user_field="$(grep -m1 '^user=' <<<"$hardening" | cut -d= -f2-)"
+        case "$user_field" in
+            '') fail "isolated: no effective user is declared" ;;
+            0|0:*|root|root:*) fail "isolated: service runs as root ($user_field)" ;;
+            *) pass "isolated: effective user is non-root ($user_field)" ;;
+        esac
+
+        pids_field="$(grep -m1 '^pids=' <<<"$hardening" | cut -d= -f2-)"
+        if [[ "$pids_field" =~ ^[0-9]+$ ]] && [[ "$pids_field" -gt 0 ]]; then
+            pass "isolated: PID limit is bounded ($pids_field)"
+        else
+            fail "isolated: PID limit is not a positive integer ($pids_field)"
+        fi
+
+        # $HOME sits on the read-only root filesystem, so the global git config
+        # has to be redirected into something writable. Without it the
+        # entrypoint's `gh auth setup-git` fails silently -- the container still
+        # starts and still prints an authenticated banner, but git push has no
+        # credential helper. Requiring the path to be inside a declared mount is
+        # what makes this a real check rather than a spelling test.
+        git_cfg="$(grep -m1 '^git_config_global=' <<<"$hardening" | cut -d= -f2-)"
+        if [[ -z "$git_cfg" ]]; then
+            fail "isolated: GIT_CONFIG_GLOBAL is unset; \$HOME/.gitconfig is read-only"
+        elif grep -qxF "${git_cfg%/*}" <<<"$targets"; then
+            pass "isolated: GIT_CONFIG_GLOBAL is inside a writable mount ($git_cfg)"
+        else
+            fail "isolated: GIT_CONFIG_GLOBAL ($git_cfg) is not inside any mount"
+        fi
+
+        # Under a read-only root every image-layer path the entrypoint or the
+        # toolchain writes to needs a tmpfs. A missing one can fail silently:
+        # ccstatusline falls back to a hardcoded layout when its XDG directory
+        # is unwritable, so the container looks healthy and the user just loses
+        # their configuration.
+        tmpfs_mounts="$(resolved_service_tmpfs "$dir" claude-a "${iso_files[@]}" | cut -d: -f1)"
+        for required in /tmp /home/node/.config /home/node/.cache \
+                        /home/node/.npm /home/node/.agents; do
+            if grep -qxF "$required" <<<"$tmpfs_mounts"; then
+                pass "isolated: $required is writable under a read-only root"
+            else
+                fail "isolated: $required has no tmpfs under a read-only root"
+            fi
+        done
+
+        # The agent CLI is installed into /home/node/.local and is on PATH, so a
+        # tmpfs there would hide the binary. Its absence from the list is
+        # load-bearing, not an oversight.
+        if grep -qxF /home/node/.local <<<"$tmpfs_mounts"; then
+            fail "isolated: /home/node/.local is masked by a tmpfs; the agent CLI would disappear"
+        else
+            pass "isolated: /home/node/.local is not masked by a tmpfs"
         fi
     fi
 else


### PR DESCRIPTION
## What

Stage 4 of #335, container-hardening half. `isolated` services now run under a
restricted container profile:

| Field | Value |
|---|---|
| `read_only` | `true` |
| `cap_drop` | `[ALL]` |
| `security_opt` | `no-new-privileges:true` |
| `init` | `true` |
| `deploy.resources.limits.pids` | `${ISOLATED_PIDS_LIMIT:-1024}` |

Generated shape (per service):

```yaml
  claude-a:
    working_dir: ${CONTAINER_ISOLATED_DIR_A:-/workspace-a}
    read_only: true
    init: true
    cap_drop:
      - ALL
    security_opt:
      - no-new-privileges:true
    deploy:
      resources:
        limits:
          pids: ${ISOLATED_PIDS_LIMIT:-1024}
    tmpfs:
      - /tmp:mode=1777
      - /home/node/.config:uid=${UID:-1000},gid=${GID:-1000},mode=0700
      - /home/node/.cache:uid=${UID:-1000},gid=${GID:-1000},mode=0700
      - /home/node/.npm:uid=${UID:-1000},gid=${GID:-1000},mode=0700
      - /home/node/.agents:uid=${UID:-1000},gid=${GID:-1000},mode=0700
    environment:
      - GIT_CONFIG_GLOBAL=/home/node/.claude/gitconfig
    volumes: !override
      - ...
```

Credential scoping and per-account networks are **not** in this PR. They are the
rest of stage 4 and land separately, so a read-only-root regression and a
network regression cannot arrive in the same CI run.

## Why

Stage 3 gave `isolated` a workspace boundary. It constrained what an account can
*reach*; it did not constrain what an account can *do* inside its own container.
The acceptance criteria this PR serves:

- The isolated profile runs non-root with a read-only root filesystem, all
  capabilities dropped, no-new-privileges, an init process, and a configurable
  PID limit.
- All required runtime, git, hook, statusline, package-manager and temporary
  writes succeed only through documented writable mounts.

## How

### Writable-path inventory

`read_only: true` makes the image layers unwritable, so every path the
entrypoint or the toolchain writes to needs a mount. The account's workspace,
runtime state and `node_modules` already are mounts; the rest became tmpfs:

| Path | Written by |
|---|---|
| `/tmp` | general tool scratch |
| `/home/node/.config` | `bootstrap-claude.sh`, creating the ccstatusline XDG link |
| `/home/node/.cache` | generic tool caches |
| `/home/node/.npm` | npm |
| `/home/node/.agents` | `bootstrap-codex.sh` / `bootstrap-gemini.sh` |

`/home/node/.local` is deliberately **excluded** — the agent CLI is installed
there and is on `PATH`, so a tmpfs would hide the binary. A test asserts its
absence, because "add one more tmpfs" is the obvious wrong fix for a future
write error in that tree.

Each tmpfs carries `uid`/`gid`/`mode` explicitly. Measured on Compose 5.1.0: a
tmpfs with no options mounts root-owned with mode 1777 — writable, but
world-writable, which is not what a hardening profile should ship.

### The silent failure this avoids

`$HOME` stays on the read-only root, so `git config --global` and
`gh auth setup-git` cannot write `~/.gitconfig`. The profile redirects the
global config into the per-account state mount.

This one is worth calling out for review: the entrypoint wraps
`gh auth setup-git` in `2>/dev/null || true`. Without the redirect the container
starts normally, prints its `authenticated as ...` banner, and only fails later
at `git push` with no credential helper and no diagnostic. The test therefore
asserts the value resolves *inside a declared mount*, not merely that the
variable is set.

### Deviation: the effective user

Issue #335 §3 asks for "the existing non-root `node` user". This PR keeps the
host user's uid/gid and asserts the property the acceptance criterion names —
the effective user is not uid 0.

Pinning uid 1000 would break the reason the base stack declares `user` at all:
the per-account state directory is a host bind mount, and on a Linux host whose
user is not uid 1000 it would become unwritable. That directory is also what the
TUI scans for account discovery. The alternatives cost more than they buy —
`chown`ing host directories at setup mutates paths the user and the dashboard
share, and moving state into a named volume blinds discovery (the reason stage 3
kept it a bind mount).

### `pids_limit` vs `deploy.resources.limits.pids`

The first attempt used the top-level `pids_limit` key and Compose refused the
merged project:

```
services.claude-b: can't set distinct values on 'pids_limit' and
'deploy.resources.limits.pids': invalid compose project
```

The base stack already declares `deploy.resources.limits` (cpus, memory), and
Compose treats the two spellings as one setting. Neither source file shows a
duplicate; only the merged model does — the same reason #335 requires assertions
against `docker compose config` rather than source YAML.

## Verification

Resolved model, placeholder values only (Compose 5.1.0, Docker 29.2.1):

```
claude-a|user=1000:1000|read_only=true|init=true|pids=1024|cap_drop=["ALL"]|secopt=["no-new-privileges:true"]
claude-b|user=1000:1000|read_only=true|init=true|pids=1024|cap_drop=["ALL"]|secopt=["no-new-privileges:true"]
--- tmpfs ---
claude-a|/tmp:mode=1777
claude-a|/home/node/.config:uid=1000,gid=1000,mode=0700
claude-a|/home/node/.cache:uid=1000,gid=1000,mode=0700
claude-a|/home/node/.npm:uid=1000,gid=1000,mode=0700
claude-a|/home/node/.agents:uid=1000,gid=1000,mode=0700
--- GIT_CONFIG_GLOBAL ---
claude-a|/home/node/.claude/gitconfig
--- mounts (target only) ---
claude-a|bind|/workspace-a
claude-a|bind|/home/node/.claude
claude-a|volume|/workspace-a/node_modules
```

`/project` is still absent, so the stage 3 boundary is intact.

The field set was also proven to actually boot before it was written into the
generators. A throwaway probe with the same combination on `ubuntu:24.04`:

```
uid=1234 gid=1234 groups=1234
TMP_WRITE=ok
CFG_WRITE=ok
touch: cannot touch '/home/probe/.gitconfig': Read-only file system
HOME_WRITE=fail
touch: cannot touch '/etc/probe': Read-only file system
ROOTFS_WRITE=fail
CFG_OWNER=1234:1234 CFG_MODE=700
```

That is where the `~/.gitconfig` problem was confirmed rather than predicted,
and where the tmpfs ownership options were verified.

Other checks:

- `bash tests/test_isolation_modes.sh` — 18 pass, 0 fail
- `bash tests/test_parse_env.sh` — 21 pass, 0 fail
- `shellcheck -S warning` on all three modified shell files — clean
- Generator parity: the PowerShell generator was run into a scratch sandbox on
  Windows and all four generated files match the bash output byte-for-byte after
  line-ending normalization.

### Gap to note for review

The resolved-model assertions **skip locally** — this WSL has no `jq`, which is
exactly the code path this PR adds. They are green in CI, where both `docker` and
`jq` are present. To avoid handing CI an unexercised assertion, the two new
helpers were run directly through Git Bash (which sees the Windows `jq` and
`docker`), and their output is the block quoted above; the assertions are plain
`grep -qxF` matches against those strings.

No test writes or prints a credential; every fixture value is a placeholder.

## Where

- `scripts/generate-compose.sh`, `scripts/generate-compose.ps1` — hardening
  fields and the tmpfs inventory, emitted from one helper per language
- `docker-compose.isolated.yml` — regenerated
- `tests/lib/compose_assert.sh` — `resolved_service_hardening`,
  `resolved_service_tmpfs`
- `tests/test_isolation_modes.sh` — hardening assertions on the resolved model
- `docs/ISOLATION.md` — the hardened-profile section, the `user` decision, the
  updated protection table and delivery order
- `README.md`, `.env.example` — `ISOLATED_PIDS_LIMIT` and the corrected
  "what this tier does not yet do" note

`.github/workflows/ci.yml` needed no change: the drift file list already covers
`docker-compose.isolated.yml` from stage 3.

Relates to #335
