### PR TITLE
feat(isolation): scope isolated credential and network access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,9 +36,10 @@ PROJECT_DIR=/absolute/path/to/your/project
 #             shared host configuration. The container is hardened as well:
 #             read-only root filesystem, every capability dropped,
 #             no-new-privileges, an init process and a bounded PID limit.
-#             Credentials and networks are NOT yet scoped: an isolated account
-#             cannot reach another account's source, but still sees the same
-#             GH_TOKEN. Read docs/ISOLATION.md before relying on it.
+#             It receives no shared GH_TOKEN and sits on its own network, so
+#             set GH_AUTH_MODE=per-account if the account has to push. Egress
+#             is NOT filtered and a container escape is still out of scope.
+#             Read docs/ISOLATION.md before relying on it.
 #
 # Regenerate compose files (scripts/generate-compose.sh or .ps1) after changing
 # this. An unrecognized value is rejected, and so is a mode whose per-account
@@ -150,3 +151,20 @@ PROJECT_DIR=/absolute/path/to/your/project
 # runners; it is not a measured figure, and a value set too low fails the
 # workload rather than the boundary.
 # ISOLATED_PIDS_LIMIT=1024
+#
+# Optional network policy for isolated services. Read only when
+# ISOLATION_MODE=isolated.
+#
+#   bridge  (default) Each account gets its own bridge network, so outbound
+#           access to the model API and git remotes keeps working while
+#           siblings cannot resolve or connect to each other. This does NOT
+#           filter egress -- that is a proxy or firewall concern.
+#   none    Each account is detached from every network, for workloads that
+#           need no external access at all. The agent cannot reach its API.
+#
+# Regenerate compose after changing this: bridge and none are different YAML
+# keys, not two values of one key, so the policy is fixed when the file is
+# written rather than interpolated at start time. An unrecognized value is
+# rejected rather than defaulting to bridge -- an offline profile that quietly
+# came up networked has no other visible symptom.
+# ISOLATED_NETWORK_MODE=bridge

--- a/README.md
+++ b/README.md
@@ -683,7 +683,7 @@ against are in [`docs/ISOLATION.md`](docs/ISOLATION.md).
 |---|---|---|
 | `shared` (default) | Tier A | One read-write project mount shared by every account. |
 | `worktree` | Tier B | Each account mounts only its own worktree. Git metadata stays shared. |
-| `isolated` | Tier C | Each account mounts its own independent clone, with its own git metadata and no shared host configuration, under a hardened container profile. Credentials and networks are not yet scoped. |
+| `isolated` | Tier C | Each account mounts its own independent clone, with its own git metadata and no shared host configuration, under a hardened container profile. No shared GitHub credential, and one bridge network per account. |
 
 An unrecognized value is refused, and so is a mode whose per-account workspace
 paths are missing. The active mode and its boundary are printed by
@@ -741,8 +741,7 @@ that key, so an undeclared mode is a mistake worth reporting rather than a
 legacy layout worth honoring.
 
 Isolated accounts receive no shared host configuration, which means no shared
-hooks, skills, commands, statusline or `CLAUDE.md`. GitHub authentication still
-works through `GH_TOKEN`.
+hooks, skills, commands, statusline or `CLAUDE.md`.
 
 The container profile is hardened: a read-only root filesystem, every capability
 dropped, `no-new-privileges`, an init process, and a bounded PID limit
@@ -751,11 +750,18 @@ have to write — `/tmp`, the npm and tool caches, the XDG config directory — 
 bounded tmpfs mounts, and the global git config is redirected into the account's
 own state mount so `git push` keeps working.
 
-> **What this tier does not yet do.** Credentials and networks are not scoped:
-> an isolated account cannot reach another account's source, but still sees the
-> same `GH_TOKEN` and can reach sibling containers. Those are the remainder of
-> stage 4 of [#335](https://github.com/kcenon/claude-docker/issues/335);
-> [`docs/ISOLATION.md`](docs/ISOLATION.md) has the per-concern table.
+Credentials and networks are scoped too. An isolated account receives **no
+shared `GH_TOKEN`**, and each account sits on its own bridge network so siblings
+cannot resolve or connect to each other. Set `GH_AUTH_MODE=per-account` to give
+an account credentials of its own — it then receives only its own `GH_TOKEN_<X>`
+— and `ISOLATED_NETWORK_MODE=none` for a fully offline profile.
+
+> **What this tier does not do.** Egress is not filtered: separate bridges stop
+> account A from reaching account B, not from reaching the internet. A container
+> escape is also out of scope — the hardened profile raises the cost of one, but
+> a kernel or runtime vulnerability defeats it, so this is not a substitute for a
+> VM boundary. [`docs/ISOLATION.md`](docs/ISOLATION.md) has the per-concern
+> table.
 
 ## Scaling Accounts
 

--- a/docker-compose.isolated.yml
+++ b/docker-compose.isolated.yml
@@ -22,8 +22,15 @@
 # mounts is a bounded tmpfs; $HOME itself stays read-only, so the global
 # git config is redirected into the per-account state mount.
 #
-# Credential environment variables and per-account networks are NOT yet
-# scoped. See docs/ISOLATION.md.
+# The environment lists carry !override for the same reason the volume
+# lists do. An untagged block merges by key, so the base stack's shared
+# GH_TOKEN would survive into every isolated service; Compose cannot
+# remove a single inherited key, so the list is re-emitted in full and
+# whatever is absent below is absent from the resolved service.
+#
+# Each account is on its own bridge network, so outbound access keeps
+# working while siblings cannot resolve or connect to each other.
+# Egress allowlisting is a separate proxy/firewall concern.
 
 services:
   claude-a:
@@ -44,7 +51,19 @@ services:
       - /home/node/.cache:uid=${UID:-1000},gid=${GID:-1000},mode=0700
       - /home/node/.npm:uid=${UID:-1000},gid=${GID:-1000},mode=0700
       - /home/node/.agents:uid=${UID:-1000},gid=${GID:-1000},mode=0700
-    environment:
+    networks:
+      - isolated_net_a
+    environment: !override
+      - TERM=xterm-256color
+      - TZ=${TZ:-UTC}
+      - HOME=/home/node
+      - AGENT_RUNTIME=claude
+      - CLAUDE_CONFIG_DIR=/home/node/.claude
+      - CLAUDE_CONFIG_SOURCE=${CLAUDE_CONFIG_SOURCE:-}
+      - CLAUDE_NORMALIZE_CRLF=${CLAUDE_NORMALIZE_CRLF:-}
+      - NODE_OPTIONS=--max-old-space-size=4096
+      - GIT_USER_NAME=${GIT_USER_NAME:-}
+      - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}
       - GIT_CONFIG_GLOBAL=/home/node/.claude/gitconfig
     volumes: !override
       - ${ISOLATED_WORKSPACE_A}:${CONTAINER_ISOLATED_DIR_A:-/workspace-a}
@@ -69,9 +88,27 @@ services:
       - /home/node/.cache:uid=${UID:-1000},gid=${GID:-1000},mode=0700
       - /home/node/.npm:uid=${UID:-1000},gid=${GID:-1000},mode=0700
       - /home/node/.agents:uid=${UID:-1000},gid=${GID:-1000},mode=0700
-    environment:
+    networks:
+      - isolated_net_b
+    environment: !override
+      - TERM=xterm-256color
+      - TZ=${TZ:-UTC}
+      - HOME=/home/node
+      - AGENT_RUNTIME=claude
+      - CLAUDE_CONFIG_DIR=/home/node/.claude
+      - CLAUDE_CONFIG_SOURCE=${CLAUDE_CONFIG_SOURCE:-}
+      - CLAUDE_NORMALIZE_CRLF=${CLAUDE_NORMALIZE_CRLF:-}
+      - NODE_OPTIONS=--max-old-space-size=4096
+      - GIT_USER_NAME=${GIT_USER_NAME:-}
+      - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}
       - GIT_CONFIG_GLOBAL=/home/node/.claude/gitconfig
     volumes: !override
       - ${ISOLATED_WORKSPACE_B}:${CONTAINER_ISOLATED_DIR_B:-/workspace-b}
       - ${HOME}/.claude-state/account-b:/home/node/.claude
       - node_modules_b:${CONTAINER_ISOLATED_DIR_B:-/workspace-b}/node_modules
+
+networks:
+  isolated_net_a:
+    driver: bridge
+  isolated_net_b:
+    driver: bridge

--- a/docs/ISOLATION.md
+++ b/docs/ISOLATION.md
@@ -5,14 +5,16 @@ under. This document states what each mode does and does not protect against,
 so a boundary is chosen deliberately rather than inferred from which compose
 file happened to be passed.
 
-Status: stages 1 to 3 of issue #335 are implemented, plus the container
-hardening half of stage 4. `isolated` isolates the **workspace** — independent
-clones, independent git metadata, no shared host configuration — and runs under
-a hardened container profile: read-only root filesystem, every capability
-dropped, no-new-privileges, an init process and a bounded PID limit. It does
-**not** yet scope credentials or the network; that is the rest of stage 4. Read
+Status: stages 1 to 4 of issue #335 are implemented. `isolated` isolates the
+**workspace** (independent clones, independent git metadata, no shared host
+configuration), runs under a hardened container profile (read-only root
+filesystem, every capability dropped, no-new-privileges, an init process and a
+bounded PID limit), receives no shared GitHub credential, and sits on its own
+network. What remains is capacity and performance work — see
+[Delivery order](#delivery-order). Read
 [What each mode protects against](#what-each-mode-protects-against) before
-relying on it, and see [Delivery order](#delivery-order) for what remains.
+relying on it: several concerns are still outside the model, container escape
+among them.
 
 ## Modes
 
@@ -41,6 +43,12 @@ every clone.
 
 Regenerate compose afterwards; `ISOLATION_MODE=isolated` without
 `ISOLATED_WORKSPACE_<X>` for every account is refused, not guessed.
+
+Two optional keys tune the profile, both read only under `isolated`:
+`ISOLATED_NETWORK_MODE` (`bridge` by default, or `none` for an offline
+profile — see [Network policy](#network-policy)) and `ISOLATED_PIDS_LIMIT`.
+Changing either means regenerating: they select what the generator writes, not
+what Compose interpolates at start time.
 
 ### Resolution
 
@@ -77,26 +85,29 @@ The adversary model for `isolated` is an agent running an unsafe or malicious
 command **inside a normal container** — a wrong `rm -rf`, a prompt-injected
 tool call, a compromised dependency's postinstall script.
 
-| Concern | `shared` | `worktree` | `isolated` (as shipped) | `isolated` (once credentials/networks land) |
-|---|---|---|---|---|
-| Account A edits account B's working tree | No | Yes | Yes | Yes |
-| Account A reads account B's working tree | No | Yes | Yes | Yes |
-| Account A rewrites shared git history (`.git`) | No | **No** | Yes | Yes |
-| Account A reads the shared host configuration | No | No | Yes | Yes |
-| Container root filesystem is read-only | No | No | Yes | Yes |
-| Capabilities dropped and privilege escalation blocked | No | No | Yes | Yes |
-| Account A reads account B's credentials | No | No | **No** | Yes |
-| Account A reaches account B over the network | No | No | **No** | Yes |
-| Container escape to the host | No | No | No | No |
+| Concern | `shared` | `worktree` | `isolated` |
+|---|---|---|---|
+| Account A edits account B's working tree | No | Yes | Yes |
+| Account A reads account B's working tree | No | Yes | Yes |
+| Account A rewrites shared git history (`.git`) | No | **No** | Yes |
+| Account A reads the shared host configuration | No | No | Yes |
+| Container root filesystem is read-only | No | No | Yes |
+| Capabilities dropped and privilege escalation blocked | No | No | Yes |
+| Account A holds account B's GitHub credential | No | No | Yes |
+| Account A connects to account B over the network | No | No | Yes |
+| Account A reaches the internet | No | No | **No**, unless `ISOLATED_NETWORK_MODE=none` |
+| Container escape to the host | No | No | **No** |
 
 "No" means the mode does not defend against it.
 
-The two `isolated` columns matter. What is shipped is the workspace boundary
-(stage 3) and the container profile (the hardening half of stage 4); credential
-scoping and per-account networks are the remainder. Until they land `isolated`
-is the right choice for "these agents must not touch each other's source" and
-"this agent should not be able to write outside its workspace", and the wrong
-choice for "these agents must not learn each other's secrets".
+Two rows are worth reading twice. **Egress is not restricted** by default: each
+account is on its own bridge, which stops A from reaching B, not from reaching
+anything outside. Restricting what a container may talk to is a proxy or
+firewall concern, and `ISOLATED_NETWORK_MODE=none` is the only lever this
+document offers — it removes all network access rather than filtering it. And
+**container escape is still out of the model**: the hardened profile raises the
+cost of one, but a kernel or runtime vulnerability defeats it, so `isolated` is
+not a substitute for a VM boundary when the workload is genuinely untrusted.
 
 ### Why `worktree` is a concurrency tier, not a sandbox
 
@@ -159,7 +170,7 @@ Compose overlays are applied in this order, and the combination matters:
 | `docker-compose.yml` | always | Base services, shared `/project` mount. |
 | `docker-compose.linux.yml` | Linux hosts, file present | Overrides the effective user with `${UID}:${GID}`. |
 | `docker-compose.worktree.yml` | resolved mode is `worktree` | Replaces each service's volume list with the worktree set. |
-| `docker-compose.isolated.yml` | resolved mode is `isolated` | Replaces each service's volume list with the clone-only set. |
+| `docker-compose.isolated.yml` | resolved mode is `isolated` | Replaces each service's volume list with the clone-only set, replaces its environment list, and attaches it to a per-account network. |
 
 All four files are generated in every mode. The mode decides which ones a
 caller composes together, not which ones exist, so drift checks keep comparing
@@ -250,6 +261,85 @@ redirect the container starts normally, prints its "authenticated as ..."
 banner, and only fails later at `git push` — with no credential helper and no
 diagnostic explaining why.
 
+## Credential scoping
+
+An isolated service receives **no shared GitHub credential**. Under the default
+`GH_AUTH_MODE`, the base stack hands every service the same `GH_TOKEN`; that
+token names one GitHub account, so passing it to each isolated service would
+have left the boundary decorative on the one surface carrying write access to
+remote repositories.
+
+Two configurations are therefore supported, and nothing in between:
+
+| `GH_AUTH_MODE` | What an isolated service receives |
+|---|---|
+| `per-account` (from #331) | Its own `GH_TOKEN_<X>` and `GH_USER_<X>`. Each account authenticates as itself. |
+| anything else | No GitHub credential. `gh` reports unauthenticated; `git push` to a remote needing auth fails. |
+
+The second row is a deliberate cost. An isolated account that needs to push
+should be configured with per-account authentication rather than handed the
+shared token — that is what #331 exists for, and this mode reuses its contract
+unchanged rather than growing a second mechanism.
+
+Provider API keys were already per-account (`ANTHROPIC_API_KEY_<X>` and the
+equivalents for other runtimes) and are unaffected. `GIT_USER_NAME` and
+`GIT_USER_EMAIL` are still passed through: they are committer identity, they
+name the human rather than an account, and an isolated account still has to be
+able to commit.
+
+### Why the environment list is replaced wholesale
+
+`docker-compose.isolated.yml` tags each service's environment block
+`!override`, exactly as it does the volume list, and therefore re-states every
+variable the service needs.
+
+That looks like duplication, and it is — deliberately. Compose merges an
+untagged `environment` block **by key**, so the base stack's `GH_TOKEN` entry
+survives into the merged service; and Compose offers no way to remove a single
+inherited key. `!reset` on an individual environment entry is ignored outright,
+which is worse than unsupported: the overlay reads as though it removes the
+variable and the resolved model still carries it. Replacing the whole list is
+the only mechanism that works.
+
+The property this buys is worth the duplication: anything not listed in the
+isolated branch never reaches an isolated service, so a credential added to the
+base stack later cannot leak into this profile by being forgotten. Both lists
+are emitted by one function in each generator (`emit_account_environment` /
+`Get-AccountEnvironmentLines`), so the two cannot silently diverge, and
+`tests/test_isolation_modes.sh` asserts on the resolved model in both
+directions — that `GH_TOKEN` is gone, and that `HOME`, `AGENT_RUNTIME` and the
+rest survived.
+
+## Network policy
+
+`ISOLATED_NETWORK_MODE` selects what an isolated account can reach. It is read
+only when `ISOLATION_MODE=isolated`.
+
+| Value | Effect |
+|---|---|
+| `bridge` (default) | Each account is attached to its own bridge network, `isolated_net_<x>`. |
+| `none` | Each account is detached from every network. |
+
+The base stack declares no networks at all, so without this every service lands
+on the project-wide implicit `default` bridge and account A can reach account B
+by service name. Declaring an explicit network in the overlay **replaces** that
+attachment rather than adding to it, which is what makes the separation real.
+
+The bridges are ordinary, not `internal: true`: outbound access to the model
+API and to git remotes has to keep working. What per-account bridges buy is
+that A and B sit on different ones, so neither appears in the other's DNS and
+neither can open a direct connection to it. **Egress allowlisting is not
+attempted here** and belongs to a proxy or firewall.
+
+`none` is the offline policy, for workloads that need no external access at
+all. It is a different YAML key (`network_mode`) rather than a different value
+of `networks`, and Compose rejects a service carrying both, so the policy is
+decided when the file is generated rather than interpolated at compose time —
+the same shape `NUM_ACCOUNTS` and `GH_AUTH_MODE` already have. **Changing it
+means regenerating**, and an unrecognized value is refused rather than
+defaulting to `bridge`, because an offline profile that quietly came up
+networked produces no other visible symptom.
+
 ## Interaction with the shared runtime configuration mount
 
 Every service mounts the host's `~/.claude/` read-only at
@@ -266,19 +356,25 @@ returns early when its config source is missing, so the runtime degrades rather
 than failing.
 
 What an isolated account gives up, concretely: shared hooks, skills, commands,
-statusline and `CLAUDE.md`. GitHub authentication still works, because it
-travels through the `GH_TOKEN` environment variable rather than the mounted
-`gh` config.
+statusline and `CLAUDE.md`.
 
-**Still open for stage 4.** Whether to restore any of that through an explicit
-allowlisted import — issue #335 offers "copy an explicit allowlist into a
-per-account staging directory and reject files classified as credentials" — is
-a cross-repository decision, because the consuming side of the contract lives
-in `kcenon/claude-config`. The mechanism already exists and is wired:
-`CLAUDE_CONFIG_SOURCE` overrides the config source path
-(`scripts/lib/bootstrap-claude.sh`), both generators emit it, and the
-installers write it as a commented key. What is undecided is the policy — which
-files are safe to copy — not the plumbing.
+GitHub authentication does **not** survive by default. It travels through the
+`GH_TOKEN` environment variable rather than the mounted `gh` config, so the
+absent mount alone would not have removed it — the environment override does.
+Configure per-account authentication to give an isolated account credentials of
+its own; see [Credential scoping](#credential-scoping).
+
+**Still open.** Whether to restore any of the shared configuration through an
+explicit allowlisted import — issue #335 offers "copy an explicit allowlist
+into a per-account staging directory and reject files classified as
+credentials" — is a cross-repository decision, because the consuming side of
+the contract lives in `kcenon/claude-config`. It gates that optional import
+alone; the requirement it belongs to ("an absent-by-default **or**
+account-scoped source") is already met by the absent-by-default half. The
+mechanism exists and is wired: `CLAUDE_CONFIG_SOURCE` overrides the config
+source path (`scripts/lib/bootstrap-claude.sh`), both generators emit it, and
+the installers write it as a commented key. What is undecided is the policy —
+which files are safe to copy — not the plumbing.
 
 The read-only mount is unchanged in `shared` and `worktree`.
 
@@ -289,9 +385,7 @@ Issue #335 is delivered in six stages. Each is a separate PR.
 1. **Configuration contract, threat model, resolved-compose test helpers.** ✅
 2. **Worktree mount correction and regression tests.** ✅
 3. **Independent workspace setup and isolated mount generation.** ✅
-4. Runtime, configuration, credential and network hardening. **Partial** — the
-   container profile is delivered; credential scoping and per-account networks
-   remain.
+4. **Runtime, configuration, credential and network hardening.** ✅
 5. Resource validation, transactional scaling, TUI cache correction, benchmarks.
 6. Cross-platform rollout, migration documentation, final benchmark report.
 
@@ -299,15 +393,23 @@ Issue #335 is delivered in six stages. Each is a separate PR.
 a name — the contract had accepted the value since stage 1 precisely so that
 stages could turn it on without changing what users configure.
 
-Stage 4 is split because its four axes are independent: the container profile
-constrains what an account can do to its own container, while credential and
-network scoping constrain what it can reach. Landing them separately keeps a
-read-only-root regression and a network regression from arriving in one CI run.
+Stage 4 landed as two PRs because its axes are independent: the container
+profile constrains what an account can do to its own container, while
+credential and network scoping constrain what it can reach. Landing them
+separately kept a read-only-root regression and a network regression from
+arriving in one CI run.
+
+One item from stage 4's issue text is **not** implemented: the allowlisted
+configuration import described in
+[Interaction with the shared runtime configuration mount](#interaction-with-the-shared-runtime-configuration-mount).
+It is optional in the issue's own wording ("**If** configuration import is
+supported"), and the requirement it belongs to is satisfied by the
+absent-by-default source.
 
 ## Verifying the active mode
 
 ```bash
-scripts/claude-docker config     # prints the mode, its trust boundary, then the resolved compose model
+scripts/claude-docker config     # prints the mode and its trust boundary, the network policy when the mode is isolated, then the resolved compose model
 scripts/claude-docker up         # prints the same banner before starting containers
 scripts/claude-docker tui        # dashboard shows the mode above the account table
 ```

--- a/scripts/ClaudeDocker.psm1
+++ b/scripts/ClaudeDocker.psm1
@@ -653,6 +653,67 @@ function Get-IsolationMode {
     return $mode
 }
 
+function Test-IsolatedNetworkModeKnown {
+    <#
+    .SYNOPSIS
+    Return $true when Mode is one of bridge, none.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$Mode)
+
+    # -cin for the same reason Test-IsolationModeKnown uses it: the bash `case`
+    # is case-sensitive, so accepting 'Bridge' here would let a Windows user
+    # configure a value a Linux user's generator rejects.
+    return $Mode -cin @('bridge', 'none')
+}
+
+function Get-IsolatedNetworkModeSummary {
+    <#
+    .SYNOPSIS
+    One-line description of the reachability a network policy provides.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Mode)
+
+    switch ($Mode) {
+        'bridge' {
+            return 'each account is on its own bridge network; outbound access works, sibling discovery and direct connections do not'
+        }
+        'none' {
+            return 'each account is detached from every network; no outbound agent, API or git access'
+        }
+        default {
+            throw "Unknown isolated network mode: $Mode"
+        }
+    }
+}
+
+function Get-IsolatedNetworkMode {
+    <#
+    .SYNOPSIS
+    Resolve the network policy the isolated mode applies.
+    .DESCRIPTION
+    Mirrors resolve_isolated_network_mode in lib/isolation.sh: environment,
+    then .env, then bridge. No inference leg -- nothing predates this key, so
+    an unset value means "never configured" rather than "configured the old
+    way". An unrecognized value throws rather than falling back to bridge,
+    because a typo that silently attaches every account to a network produces
+    no other visible symptom.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$ProjectRoot)
+
+    $mode = Get-IsolationValue -ProjectRoot $ProjectRoot -Key 'ISOLATED_NETWORK_MODE'
+
+    if ([string]::IsNullOrWhiteSpace($mode)) { $mode = 'bridge' }
+    $mode = $mode.ToLowerInvariant()
+
+    if (-not (Test-IsolatedNetworkModeKnown -Mode $mode)) {
+        throw "ISOLATED_NETWORK_MODE must be bridge or none (got: $mode)"
+    }
+    return $mode
+}
+
 function Get-SupportedIsolationMode {
     <#
     .SYNOPSIS
@@ -847,6 +908,8 @@ Export-ModuleMember -Function @(
     'Test-IsolationModeKnown', 'Get-IsolationModeSummary', 'Get-IsolationMode',
     'Get-IsolationAccountVariable', 'Get-IsolationSetupHint',
     'Get-SupportedIsolationMode', 'Write-UnusedWorkspacePathWarning',
+    'Test-IsolatedNetworkModeKnown', 'Get-IsolatedNetworkModeSummary',
+    'Get-IsolatedNetworkMode',
     # .env
     'Read-EnvFile', 'Get-EnvValue', 'Write-EnvContent', 'Set-EnvValue',
     # Docker Compose

--- a/scripts/claude-docker
+++ b/scripts/claude-docker
@@ -178,6 +178,14 @@ show_isolation_mode() {
     mode=$(resolve_isolation_mode) || return 1
     echo -e "${BOLD}Isolation mode:${NC} $mode"
     echo -e "${DIM}  $(isolation_mode_summary "$mode")${NC}"
+    # Only under isolated: no other mode reads the network policy, and printing
+    # it elsewhere would suggest it applies when it does not.
+    if [[ "$mode" == "isolated" ]]; then
+        local net
+        net=$(resolve_isolated_network_mode) || return 1
+        echo -e "${BOLD}Network policy:${NC} $net"
+        echo -e "${DIM}  $(isolated_network_mode_summary "$net")${NC}"
+    fi
     warn_unused_workspace_paths "$mode"
 }
 

--- a/scripts/claude-docker.ps1
+++ b/scripts/claude-docker.ps1
@@ -126,6 +126,13 @@ function Show-IsolationMode {
     $mode = Get-IsolationMode -ProjectRoot $ProjectRoot
     Write-Host "Isolation mode: $mode"
     Write-Host "  $(Get-IsolationModeSummary -Mode $mode)" -ForegroundColor DarkGray
+    # Only under isolated: no other mode reads the network policy, and printing
+    # it elsewhere would suggest it applies when it does not.
+    if ($mode -eq 'isolated') {
+        $net = Get-IsolatedNetworkMode -ProjectRoot $ProjectRoot
+        Write-Host "Network policy: $net"
+        Write-Host "  $(Get-IsolatedNetworkModeSummary -Mode $net)" -ForegroundColor DarkGray
+    }
     Write-UnusedWorkspacePathWarning -ProjectRoot $ProjectRoot -Mode $mode
 }
 

--- a/scripts/generate-compose.ps1
+++ b/scripts/generate-compose.ps1
@@ -181,6 +181,19 @@ catch {
 
 Write-UnusedWorkspacePathWarning -ProjectRoot $ProjectRoot -Mode $IsolationMode
 
+# The network policy is resolved unconditionally, even under shared or worktree,
+# because docker-compose.isolated.yml is written in every mode. Resolving it
+# only when the mode is isolated would leave an invalid value undetected until
+# somebody switched modes, which is the point at which a wrong network policy is
+# hardest to notice.
+try {
+    $IsolatedNetworkMode = Get-IsolatedNetworkMode -ProjectRoot $ProjectRoot
+}
+catch {
+    Write-Error $_.Exception.Message
+    exit 1
+}
+
 # Thin wrappers around the shared helpers in lib/index.ps1 so legacy call
 # sites below keep working without rewriting each loop. Both helpers accept
 # indices 1..702 and throw out-of-range otherwise.
@@ -234,7 +247,8 @@ function Get-AccountVolumeLines {
     # bootstrap-claude.sh returns early when the config source is missing -- so
     # the container still starts, with no shared hooks, skills, commands,
     # statusline or CLAUDE.md. Restoring that through an allowlisted
-    # per-account import is stage 4; see docs/ISOLATION.md.
+    # per-account import is still open -- it is optional in the issue's own
+    # wording and depends on a cross-repository decision; see docs/ISOLATION.md.
     if ($Mode -ne 'isolated') {
         $lines += "      - `${HOME}/${RtHostConfigBasename}:${RtHostConfigMount}:ro"
         # The agents/skills volume is bound only for runtimes whose registry
@@ -249,6 +263,177 @@ function Get-AccountVolumeLines {
 
     $lines += "      - node_modules_${Letter}:${ProjectTarget}/node_modules"
     return $lines
+}
+
+function Get-AccountEnvironmentLines {
+    <#
+    .SYNOPSIS
+    Return the environment list for one account service, without its key.
+    .DESCRIPTION
+    Mirrors emit_account_environment in generate-compose.sh.
+
+    Both the base config and the isolated overlay come through here, and the
+    isolated overlay tags its block !override. That tag is not decoration: an
+    untagged block MERGES by key, so the base's shared-token entry would survive
+    into an isolated service. Compose offers no way to remove a single inherited
+    key -- !reset on an individual environment entry is ignored outright, and
+    !override replaces the whole list -- so the isolated environment has to be
+    re-emitted in full. Emitting both from one function is what keeps that
+    duplication honest: a variable added below reaches every mode, and a
+    credential withheld below is withheld everywhere it should be.
+
+    The withholding is deliberately fail-closed. Anything not listed here never
+    reaches an isolated service, so a credential added to the base later cannot
+    leak into the isolated profile by being forgotten -- only by being written
+    into the isolated branch on purpose.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Mode,
+        [Parameter(Mandatory)][string]$Upper
+    )
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+
+    $lines.Add('      - TERM=xterm-256color')
+    $lines.Add('      - TZ=${TZ:-UTC}')
+    # When the container runs as the host UID instead of node(1000),
+    # the passwd entry for that UID is missing, so $HOME defaults to
+    # /. Pinning HOME keeps runtime state, ~/.config, etc. resolvable.
+    $lines.Add('      - HOME=/home/node')
+    # AGENT_RUNTIME is now always emitted (previously codex-only).
+    # The entrypoint defaults to claude when unset, so emitting it
+    # for claude too is functionally inert and keeps the env block
+    # uniform across runtimes.
+    $lines.Add("      - AGENT_RUNTIME=${AgentRuntime}")
+    $lines.Add("      - ${RtConfigDirEnv}=${RtConfigDirEnvValue}")
+    $lines.Add("      - ${RtConfigSourceEnv}=`${${RtConfigSourceEnv}:-}")
+    # CLAUDE_NORMALIZE_CRLF is a claude-only env var (read directly by
+    # the entrypoint, no codex equivalent). The registry has no field
+    # for it, so this one line stays gated on the runtime id.
+    if ($AgentRuntime -eq 'claude') {
+        $lines.Add('      - CLAUDE_NORMALIZE_CRLF=${CLAUDE_NORMALIZE_CRLF:-}')
+    }
+    $lines.Add('      - NODE_OPTIONS=--max-old-space-size=4096')
+    # Only emit provider API keys when a per-account key is set at
+    # generate time. Emitting an empty key makes SDKs prefer the blank env
+    # var over persisted credentials in the mounted state dir. The variable
+    # read is already per-account, so this needs no isolated-mode branch.
+    $keyVarName = "${RtApiKeyPrefix}${Upper}"
+    $keyValue = [Environment]::GetEnvironmentVariable($keyVarName)
+    if ([string]::IsNullOrEmpty($keyValue) -and $envData.ContainsKey($keyVarName)) {
+        $keyValue = $envData[$keyVarName]
+    }
+    if (-not [string]::IsNullOrEmpty($keyValue)) {
+        $lines.Add("      - ${RtSdkApiKeyVar}=`${${keyVarName}}")
+    }
+
+    # GIT_USER_NAME/EMAIL are committer identity, not credentials: they name the
+    # human rather than an account, and an isolated account still has to commit.
+    # They are emitted in all three cases below.
+    if ($GhAuthMode -eq 'per-account') {
+        # Already scoped: every account reads its own token variable, which is
+        # exactly the contract issue #331 established. Isolated services reuse
+        # it unchanged rather than growing a second mechanism.
+        $ghUserVar = "GH_USER_${Upper}"
+        $ghTokenVar = "GH_TOKEN_${Upper}"
+        $gitNameVar = "GIT_USER_NAME_${Upper}"
+        $gitEmailVar = "GIT_USER_EMAIL_${Upper}"
+        $lines.Add('      - GH_AUTH_MODE=per-account')
+        $lines.Add("      - GH_USER=`${${ghUserVar}}")
+        $lines.Add("      - GH_TOKEN=`${${ghTokenVar}}")
+        $lines.Add("      - GIT_USER_NAME=`${${gitNameVar}:-`${GIT_USER_NAME:-}}")
+        $lines.Add("      - GIT_USER_EMAIL=`${${gitEmailVar}:-`${GIT_USER_EMAIL:-}}")
+    }
+    elseif ($Mode -eq 'isolated') {
+        # No GitHub credential at all. The shared GH_TOKEN identifies one
+        # account to GitHub, so handing the same value to every isolated
+        # service would make the boundary decorative on the one surface that
+        # carries write access to remote repositories (issue #335, stage 4).
+        # The entrypoint already treats an unset GH_TOKEN as "no token": it
+        # falls through to hosts.yml, which an isolated account does not have
+        # either, and reports unauthenticated rather than failing to start.
+        $lines.Add('      - GIT_USER_NAME=${GIT_USER_NAME:-}')
+        $lines.Add('      - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}')
+    }
+    else {
+        $lines.Add('      - GH_TOKEN=${GH_TOKEN:-}')
+        $lines.Add('      - GIT_USER_NAME=${GIT_USER_NAME:-}')
+        $lines.Add('      - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}')
+    }
+
+    if ($Mode -eq 'isolated') {
+        # $HOME is on the read-only root filesystem, so "git config --global"
+        # and "gh auth setup-git" cannot write ~/.gitconfig. Redirect the global
+        # config into the per-account state mount, which is writable and already
+        # account-private. Without this the entrypoint's credential-helper setup
+        # fails silently and git push breaks with no diagnostic. Requires git
+        # 2.32+ (image ships 2.39 on bookworm).
+        $lines.Add("      - GIT_CONFIG_GLOBAL=${RtContainerConfigMount}/gitconfig")
+    }
+
+    return $lines.ToArray()
+}
+
+function Get-IsolatedServiceNetworkLines {
+    <#
+    .SYNOPSIS
+    Return the network attachment lines for one isolated service.
+    .DESCRIPTION
+    Mirrors emit_isolated_service_network in generate-compose.sh.
+
+    The base stack declares no networks at all, so every service lands on the
+    project-wide implicit `default` bridge and siblings can reach each other by
+    service name. Declaring an explicit network here REPLACES that attachment
+    rather than adding to it, which is what makes the separation real.
+
+    `networks` and `network_mode` are mutually exclusive keys -- a service
+    carrying both is rejected -- so the policy has to pick one at generate time
+    and cannot be expressed as an interpolated ${VAR}.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Letter)
+
+    if ($IsolatedNetworkMode -eq 'none') {
+        return @('    network_mode: none')
+    }
+
+    return @(
+        '    networks:'
+        "      - isolated_net_$Letter"
+    )
+}
+
+function Get-IsolatedNetworksBlockLines {
+    <#
+    .SYNOPSIS
+    Return the top-level networks block declaring one bridge per account.
+    .DESCRIPTION
+    Mirrors emit_isolated_networks in generate-compose.sh.
+
+    Ordinary bridges, not internal: outbound access to the model API and to git
+    remotes has to keep working. What this buys is that A and B sit on different
+    bridges, so neither appears in the other's DNS and neither can open a direct
+    connection to it. Blocking egress is a proxy/firewall concern and is
+    deliberately not attempted here.
+    #>
+    [CmdletBinding()]
+    param()
+
+    if ($IsolatedNetworkMode -eq 'none') {
+        return @()
+    }
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $lines.Add('')
+    $lines.Add('networks:')
+    for ($i = 1; $i -le $NumAccounts; $i++) {
+        $letter = ConvertTo-Letter $i
+        $lines.Add("  isolated_net_${letter}:")
+        $lines.Add('    driver: bridge')
+    }
+
+    return $lines.ToArray()
 }
 
 function Get-IsolatedTmpfsLines {
@@ -345,52 +530,8 @@ function New-BaseCompose {
             [void]$sb.AppendLine($volumeLine)
         }
         [void]$sb.AppendLine('    environment:')
-        [void]$sb.AppendLine('      - TERM=xterm-256color')
-        [void]$sb.AppendLine('      - TZ=${TZ:-UTC}')
-        # When the container runs as the host UID instead of node(1000),
-        # the passwd entry for that UID is missing, so $HOME defaults to
-        # /. Pinning HOME keeps runtime state, ~/.config, etc. resolvable.
-        [void]$sb.AppendLine('      - HOME=/home/node')
-        # AGENT_RUNTIME is now always emitted (previously codex-only).
-        # The entrypoint defaults to claude when unset, so emitting it
-        # for claude too is functionally inert and keeps the env block
-        # uniform across runtimes.
-        [void]$sb.AppendLine("      - AGENT_RUNTIME=${AgentRuntime}")
-        [void]$sb.AppendLine("      - ${RtConfigDirEnv}=${RtConfigDirEnvValue}")
-        [void]$sb.AppendLine("      - ${RtConfigSourceEnv}=`${${RtConfigSourceEnv}:-}")
-        # CLAUDE_NORMALIZE_CRLF is a claude-only env var (read directly by
-        # the entrypoint, no codex equivalent). The registry has no field
-        # for it, so this one line stays gated on the runtime id.
-        if ($AgentRuntime -eq 'claude') {
-            [void]$sb.AppendLine('      - CLAUDE_NORMALIZE_CRLF=${CLAUDE_NORMALIZE_CRLF:-}')
-        }
-        [void]$sb.AppendLine('      - NODE_OPTIONS=--max-old-space-size=4096')
-        # Only emit provider API keys when a per-account key is set at
-        # generate time. Emitting an empty key makes SDKs prefer the blank env
-        # var over persisted credentials in the mounted state dir.
-        $keyVarName = "${RtApiKeyPrefix}${upper}"
-        $keyValue = [Environment]::GetEnvironmentVariable($keyVarName)
-        if ([string]::IsNullOrEmpty($keyValue) -and $envData.ContainsKey($keyVarName)) {
-            $keyValue = $envData[$keyVarName]
-        }
-        if (-not [string]::IsNullOrEmpty($keyValue)) {
-            [void]$sb.AppendLine("      - ${RtSdkApiKeyVar}=`${${keyVarName}}")
-        }
-        if ($GhAuthMode -eq 'per-account') {
-            $ghUserVar = "GH_USER_${upper}"
-            $ghTokenVar = "GH_TOKEN_${upper}"
-            $gitNameVar = "GIT_USER_NAME_${upper}"
-            $gitEmailVar = "GIT_USER_EMAIL_${upper}"
-            [void]$sb.AppendLine('      - GH_AUTH_MODE=per-account')
-            [void]$sb.AppendLine("      - GH_USER=`${${ghUserVar}}")
-            [void]$sb.AppendLine("      - GH_TOKEN=`${${ghTokenVar}}")
-            [void]$sb.AppendLine("      - GIT_USER_NAME=`${${gitNameVar}:-`${GIT_USER_NAME:-}}")
-            [void]$sb.AppendLine("      - GIT_USER_EMAIL=`${${gitEmailVar}:-`${GIT_USER_EMAIL:-}}")
-        }
-        else {
-            [void]$sb.AppendLine('      - GH_TOKEN=${GH_TOKEN:-}')
-            [void]$sb.AppendLine('      - GIT_USER_NAME=${GIT_USER_NAME:-}')
-            [void]$sb.AppendLine('      - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}')
+        foreach ($envLine in (Get-AccountEnvironmentLines -Mode 'shared' -Upper $upper)) {
+            [void]$sb.AppendLine($envLine)
         }
         [void]$sb.AppendLine('    deploy:')
         [void]$sb.AppendLine('      resources:')
@@ -493,8 +634,22 @@ function New-IsolatedCompose {
     [void]$sb.AppendLine('# mounts is a bounded tmpfs; $HOME itself stays read-only, so the global')
     [void]$sb.AppendLine('# git config is redirected into the per-account state mount.')
     [void]$sb.AppendLine('#')
-    [void]$sb.AppendLine('# Credential environment variables and per-account networks are NOT yet')
-    [void]$sb.AppendLine('# scoped. See docs/ISOLATION.md.')
+    [void]$sb.AppendLine('# The environment lists carry !override for the same reason the volume')
+    [void]$sb.AppendLine('# lists do. An untagged block merges by key, so the base stack''s shared')
+    [void]$sb.AppendLine('# GH_TOKEN would survive into every isolated service; Compose cannot')
+    [void]$sb.AppendLine('# remove a single inherited key, so the list is re-emitted in full and')
+    [void]$sb.AppendLine('# whatever is absent below is absent from the resolved service.')
+    [void]$sb.AppendLine('#')
+    if ($IsolatedNetworkMode -eq 'none') {
+        [void]$sb.AppendLine('# ISOLATED_NETWORK_MODE=none: every account is detached from all')
+        [void]$sb.AppendLine('# networks. Outbound agent, API and git access do not work. Regenerate')
+        [void]$sb.AppendLine('# with ISOLATED_NETWORK_MODE=bridge to restore them.')
+    }
+    else {
+        [void]$sb.AppendLine('# Each account is on its own bridge network, so outbound access keeps')
+        [void]$sb.AppendLine('# working while siblings cannot resolve or connect to each other.')
+        [void]$sb.AppendLine('# Egress allowlisting is a separate proxy/firewall concern.')
+    }
     [void]$sb.AppendLine('')
     [void]$sb.AppendLine('services:')
 
@@ -523,14 +678,13 @@ function New-IsolatedCompose {
         foreach ($tmpfsLine in (Get-IsolatedTmpfsLines)) {
             [void]$sb.AppendLine($tmpfsLine)
         }
-        [void]$sb.AppendLine('    environment:')
-        # $HOME is on the read-only root filesystem, so "git config --global"
-        # and "gh auth setup-git" cannot write ~/.gitconfig. Redirect the global
-        # config into the per-account state mount, which is writable and already
-        # account-private. Without this the entrypoint's credential-helper setup
-        # fails silently and git push breaks with no diagnostic. Requires git
-        # 2.32+ (image ships 2.39 on bookworm).
-        [void]$sb.AppendLine("      - GIT_CONFIG_GLOBAL=${RtContainerConfigMount}/gitconfig")
+        foreach ($networkLine in (Get-IsolatedServiceNetworkLines -Letter $letter)) {
+            [void]$sb.AppendLine($networkLine)
+        }
+        [void]$sb.AppendLine('    environment: !override')
+        foreach ($envLine in (Get-AccountEnvironmentLines -Mode 'isolated' -Upper $upper)) {
+            [void]$sb.AppendLine($envLine)
+        }
         [void]$sb.AppendLine('    volumes: !override')
         foreach ($volumeLine in (Get-AccountVolumeLines -Mode 'isolated' -Letter $letter `
                     -ProjectSource "`${ISOLATED_WORKSPACE_${upper}}" `
@@ -541,6 +695,10 @@ function New-IsolatedCompose {
         if ($i -lt $NumAccounts) {
             [void]$sb.AppendLine('')
         }
+    }
+
+    foreach ($networkLine in (Get-IsolatedNetworksBlockLines)) {
+        [void]$sb.AppendLine($networkLine)
     }
 
     Write-EnvContent -Path $outFile -Content $sb.ToString()

--- a/scripts/generate-compose.sh
+++ b/scripts/generate-compose.sh
@@ -146,6 +146,13 @@ ISOLATION_MODE_RESOLVED="$(require_supported_isolation_mode "$NUM_ACCOUNTS")" ||
 
 warn_unused_workspace_paths "$ISOLATION_MODE_RESOLVED"
 
+# The network policy is resolved unconditionally, even under shared or worktree,
+# because docker-compose.isolated.yml is written in every mode. Resolving it
+# only when the mode is isolated would leave an invalid value undetected until
+# somebody switched modes, which is the point at which a wrong network policy is
+# hardest to notice.
+ISOLATED_NETWORK_MODE_RESOLVED="$(resolve_isolated_network_mode)" || exit 1
+
 # index_to_letter and index_to_upper provided by scripts/lib/index.sh.
 
 # --- Shared emitters ----------------------------------------------------------
@@ -181,7 +188,8 @@ emit_account_volumes() {
     # bootstrap-claude.sh returns early when the config source is missing -- so
     # the container still starts, with no shared hooks, skills, commands,
     # statusline or CLAUDE.md. Restoring that through an allowlisted
-    # per-account import is stage 4; see docs/ISOLATION.md.
+    # per-account import is still open -- it is optional in the issue's own
+    # wording and depends on a cross-repository decision; see docs/ISOLATION.md.
     if [[ "$mode" != "isolated" ]]; then
         echo "      - \${HOME}/${RT_HOST_CONFIG_BASENAME}:${RT_HOST_CONFIG_MOUNT}:ro"
         # The agents/skills volume is bound only for runtimes whose registry
@@ -195,6 +203,97 @@ emit_account_volumes() {
     fi
 
     echo "      - node_modules_${letter}:${project_target}/node_modules"
+}
+
+# emit_account_environment MODE UPPER
+# Print the complete environment list for one account service, indented for an
+# `environment:` block.
+#
+# Both the base config and the isolated overlay come through here, and the
+# isolated overlay tags its block `!override`. That tag is not decoration: an
+# untagged block MERGES by key, so the base's shared-token entry would survive
+# into an isolated service. Compose offers no way to remove a single inherited
+# key -- `!reset` on an individual environment entry is ignored outright, and
+# `!override` replaces the whole list -- so the isolated environment has to be
+# re-emitted in full. Emitting both from one function is what keeps that
+# duplication honest: a variable added below reaches every mode, and a
+# credential withheld below is withheld everywhere it should be.
+#
+# The withholding is deliberately fail-closed. Anything not listed here never
+# reaches an isolated service, so a credential added to the base later cannot
+# leak into the isolated profile by being forgotten -- only by being written
+# into the isolated branch on purpose.
+emit_account_environment() {
+    local mode="$1" upper="$2"
+
+    echo "      - TERM=xterm-256color"
+    echo "      - TZ=\${TZ:-UTC}"
+    # When the container runs as the host UID instead of node(1000),
+    # the passwd entry for that UID is missing, so \$HOME defaults
+    # to /. Pinning HOME keeps runtime state, ~/.config, etc.
+    # resolvable.
+    echo "      - HOME=/home/node"
+    # AGENT_RUNTIME is now always emitted (previously codex-only).
+    # The entrypoint defaults to claude when unset, so emitting it
+    # for claude too is functionally inert and keeps the env block
+    # uniform across runtimes.
+    echo "      - AGENT_RUNTIME=${AGENT_RUNTIME}"
+    echo "      - ${RT_CONFIG_DIR_ENV}=${RT_CONFIG_DIR_ENV_VALUE}"
+    echo "      - ${RT_CONFIG_SOURCE_ENV}=\${${RT_CONFIG_SOURCE_ENV}:-}"
+    # CLAUDE_NORMALIZE_CRLF is a claude-only env var (read directly by
+    # the entrypoint, no codex equivalent). The registry has no field
+    # for it, so this one line stays gated on the runtime id.
+    if [[ "$AGENT_RUNTIME" == "claude" ]]; then
+        echo "      - CLAUDE_NORMALIZE_CRLF=\${CLAUDE_NORMALIZE_CRLF:-}"
+    fi
+    echo "      - NODE_OPTIONS=--max-old-space-size=4096"
+
+    # Only emit provider API keys when a per-account key is set at
+    # generate time. Emitting an empty key makes SDKs prefer the
+    # blank env var over persisted credentials. The variable read is
+    # already per-account, so this needs no isolated-mode branch.
+    local key_var="${RT_API_KEY_PREFIX}${upper}"
+    if [[ -n "${!key_var:-}" ]]; then
+        echo "      - ${RT_SDK_API_KEY_VAR}=\${${key_var}}"
+    fi
+
+    # GIT_USER_NAME/EMAIL are committer identity, not credentials: they name the
+    # human rather than an account, and an isolated account still has to commit.
+    # They are emitted in all three cases below.
+    if [[ "$GH_AUTH_MODE" == "per-account" ]]; then
+        # Already scoped: every account reads its own token variable, which is
+        # exactly the contract issue #331 established. Isolated services reuse
+        # it unchanged rather than growing a second mechanism.
+        echo "      - GH_AUTH_MODE=per-account"
+        echo "      - GH_USER=\${GH_USER_${upper}}"
+        echo "      - GH_TOKEN=\${GH_TOKEN_${upper}}"
+        echo "      - GIT_USER_NAME=\${GIT_USER_NAME_${upper}:-\${GIT_USER_NAME:-}}"
+        echo "      - GIT_USER_EMAIL=\${GIT_USER_EMAIL_${upper}:-\${GIT_USER_EMAIL:-}}"
+    elif [[ "$mode" == "isolated" ]]; then
+        # No GitHub credential at all. The shared GH_TOKEN identifies one
+        # account to GitHub, so handing the same value to every isolated
+        # service would make the boundary decorative on the one surface that
+        # carries write access to remote repositories (issue #335, stage 4).
+        # The entrypoint already treats an unset GH_TOKEN as "no token": it
+        # falls through to hosts.yml, which an isolated account does not have
+        # either, and reports unauthenticated rather than failing to start.
+        echo "      - GIT_USER_NAME=\${GIT_USER_NAME:-}"
+        echo "      - GIT_USER_EMAIL=\${GIT_USER_EMAIL:-}"
+    else
+        echo "      - GH_TOKEN=\${GH_TOKEN:-}"
+        echo "      - GIT_USER_NAME=\${GIT_USER_NAME:-}"
+        echo "      - GIT_USER_EMAIL=\${GIT_USER_EMAIL:-}"
+    fi
+
+    if [[ "$mode" == "isolated" ]]; then
+        # $HOME is on the read-only root filesystem, so `git config --global`
+        # and `gh auth setup-git` cannot write ~/.gitconfig. Redirect the
+        # global config into the per-account state mount, which is writable
+        # and already account-private. Without this the entrypoint's
+        # credential-helper setup fails silently and `git push` breaks with
+        # no diagnostic. Requires git 2.32+ (image ships 2.39 on bookworm).
+        echo "      - GIT_CONFIG_GLOBAL=${RT_CONTAINER_CONFIG_MOUNT}/gitconfig"
+    fi
 }
 
 # emit_isolated_tmpfs
@@ -229,6 +328,54 @@ emit_isolated_tmpfs() {
     echo "      - /home/node/.cache:${owner}"
     echo "      - /home/node/.npm:${owner}"
     echo "      - /home/node/.agents:${owner}"
+}
+
+# emit_isolated_service_network LETTER
+# Print the network attachment for one isolated account service.
+#
+# The base stack declares no networks at all, so every service lands on the
+# project-wide implicit `default` bridge and siblings can reach each other by
+# service name. Declaring an explicit network here REPLACES that attachment
+# rather than adding to it, which is what makes the separation real.
+#
+# `networks` and `network_mode` are mutually exclusive keys -- a service
+# carrying both is rejected -- so the policy has to pick one at generate time
+# and cannot be expressed as an interpolated ${VAR}. That is the same shape
+# NUM_ACCOUNTS and GH_AUTH_MODE already have: the generated file is correct for
+# the configuration it was generated from, and changing the key means
+# regenerating.
+emit_isolated_service_network() {
+    local letter="$1"
+
+    if [[ "$ISOLATED_NETWORK_MODE_RESOLVED" == "none" ]]; then
+        echo "    network_mode: none"
+    else
+        echo "    networks:"
+        echo "      - isolated_net_${letter}"
+    fi
+}
+
+# emit_isolated_networks
+# Print the top-level `networks:` block declaring one bridge per account.
+#
+# Ordinary bridges, not `internal: true`: outbound access to the model API and
+# to git remotes has to keep working. What this buys is that A and B sit on
+# different bridges, so neither appears in the other's DNS and neither can open
+# a direct connection to it. Blocking egress is a proxy/firewall concern and is
+# deliberately not attempted here.
+emit_isolated_networks() {
+    if [[ "$ISOLATED_NETWORK_MODE_RESOLVED" == "none" ]]; then
+        return 0
+    fi
+
+    echo ""
+    echo "networks:"
+    local i letter
+    for i in $(seq 1 "$NUM_ACCOUNTS"); do
+        letter=$(index_to_letter "$i")
+        echo "  isolated_net_${letter}:"
+        echo "    driver: bridge"
+    done
 }
 
 # --- Generate docker-compose.yml ---------------------------------------------
@@ -279,49 +426,7 @@ generate_base() {
             echo "    volumes:"
             emit_account_volumes shared "$letter" '${PROJECT_DIR}' '${CONTAINER_PROJECT_DIR:-/project}'
             echo "    environment:"
-            echo "      - TERM=xterm-256color"
-            echo "      - TZ=\${TZ:-UTC}"
-            # When the container runs as the host UID instead of node(1000),
-            # the passwd entry for that UID is missing, so \$HOME defaults
-            # to /. Pinning HOME keeps runtime state, ~/.config, etc.
-            # resolvable.
-            echo "      - HOME=/home/node"
-            # AGENT_RUNTIME is now always emitted (previously codex-only).
-            # The entrypoint defaults to claude when unset, so emitting it
-            # for claude too is functionally inert and keeps the env block
-            # uniform across runtimes.
-            echo "      - AGENT_RUNTIME=${AGENT_RUNTIME}"
-            echo "      - ${RT_CONFIG_DIR_ENV}=${RT_CONFIG_DIR_ENV_VALUE}"
-            echo "      - ${RT_CONFIG_SOURCE_ENV}=\${${RT_CONFIG_SOURCE_ENV}:-}"
-            # CLAUDE_NORMALIZE_CRLF is a claude-only env var (read directly by
-            # the entrypoint, no codex equivalent). The registry has no field
-            # for it, so this one line stays gated on the runtime id.
-            if [[ "$AGENT_RUNTIME" == "claude" ]]; then
-                echo "      - CLAUDE_NORMALIZE_CRLF=\${CLAUDE_NORMALIZE_CRLF:-}"
-            fi
-            echo "      - NODE_OPTIONS=--max-old-space-size=4096"
-            # Only emit provider API keys when a per-account key is set at
-            # generate time. Emitting an empty key makes SDKs prefer the
-            # blank env var over persisted credentials.
-            local key_var="${RT_API_KEY_PREFIX}${upper}"
-            if [[ -n "${!key_var:-}" ]]; then
-                echo "      - ${RT_SDK_API_KEY_VAR}=\${${key_var}}"
-            fi
-            if [[ "$GH_AUTH_MODE" == "per-account" ]]; then
-                local gh_user_var="GH_USER_${upper}"
-                local gh_token_var="GH_TOKEN_${upper}"
-                local git_name_var="GIT_USER_NAME_${upper}"
-                local git_email_var="GIT_USER_EMAIL_${upper}"
-                echo "      - GH_AUTH_MODE=per-account"
-                echo "      - GH_USER=\${${gh_user_var}}"
-                echo "      - GH_TOKEN=\${${gh_token_var}}"
-                echo "      - GIT_USER_NAME=\${${git_name_var}:-\${GIT_USER_NAME:-}}"
-                echo "      - GIT_USER_EMAIL=\${${git_email_var}:-\${GIT_USER_EMAIL:-}}"
-            else
-                echo "      - GH_TOKEN=\${GH_TOKEN:-}"
-                echo "      - GIT_USER_NAME=\${GIT_USER_NAME:-}"
-                echo "      - GIT_USER_EMAIL=\${GIT_USER_EMAIL:-}"
-            fi
+            emit_account_environment shared "$upper"
             echo "    deploy:"
             echo "      resources:"
             echo "        limits:"
@@ -423,8 +528,21 @@ generate_isolated() {
         echo "# mounts is a bounded tmpfs; \$HOME itself stays read-only, so the global"
         echo "# git config is redirected into the per-account state mount."
         echo "#"
-        echo "# Credential environment variables and per-account networks are NOT yet"
-        echo "# scoped. See docs/ISOLATION.md."
+        echo "# The environment lists carry !override for the same reason the volume"
+        echo "# lists do. An untagged block merges by key, so the base stack's shared"
+        echo "# GH_TOKEN would survive into every isolated service; Compose cannot"
+        echo "# remove a single inherited key, so the list is re-emitted in full and"
+        echo "# whatever is absent below is absent from the resolved service."
+        echo "#"
+        if [[ "$ISOLATED_NETWORK_MODE_RESOLVED" == "none" ]]; then
+            echo "# ISOLATED_NETWORK_MODE=none: every account is detached from all"
+            echo "# networks. Outbound agent, API and git access do not work. Regenerate"
+            echo "# with ISOLATED_NETWORK_MODE=bridge to restore them."
+        else
+            echo "# Each account is on its own bridge network, so outbound access keeps"
+            echo "# working while siblings cannot resolve or connect to each other."
+            echo "# Egress allowlisting is a separate proxy/firewall concern."
+        fi
         echo ""
         echo "services:"
 
@@ -453,14 +571,9 @@ generate_isolated() {
             echo "        limits:"
             echo "          pids: \${ISOLATED_PIDS_LIMIT:-1024}"
             emit_isolated_tmpfs
-            echo "    environment:"
-            # $HOME is on the read-only root filesystem, so `git config --global`
-            # and `gh auth setup-git` cannot write ~/.gitconfig. Redirect the
-            # global config into the per-account state mount, which is writable
-            # and already account-private. Without this the entrypoint's
-            # credential-helper setup fails silently and `git push` breaks with
-            # no diagnostic. Requires git 2.32+ (image ships 2.39 on bookworm).
-            echo "      - GIT_CONFIG_GLOBAL=${RT_CONTAINER_CONFIG_MOUNT}/gitconfig"
+            emit_isolated_service_network "$letter"
+            echo "    environment: !override"
+            emit_account_environment isolated "$upper"
             echo "    volumes: !override"
             emit_account_volumes isolated "$letter" \
                 "\${ISOLATED_WORKSPACE_${upper}}" \
@@ -470,6 +583,8 @@ generate_isolated() {
                 echo ""
             fi
         done
+
+        emit_isolated_networks
     } > "$outfile"
 
     echo "Generated: $outfile ($NUM_ACCOUNTS services)"

--- a/scripts/lib/isolation.sh
+++ b/scripts/lib/isolation.sh
@@ -21,6 +21,17 @@
 #             shared host configuration. Clones come from
 #             scripts/setup-isolated.sh; see docs/ISOLATION.md.
 #
+# ISOLATED_NETWORK_MODE names the network policy the isolated mode applies. It
+# is a separate axis from ISOLATION_MODE because it constrains reachability
+# rather than the workspace, and only the isolated mode reads it.
+#
+#   bridge    Each account is attached to its own ordinary bridge network.
+#             Outbound agent/API/git access keeps working; sibling service
+#             discovery and direct lateral connections do not.
+#   none      Each account is detached from every network, for workloads that
+#             need no external access. Egress allowlisting is a separate
+#             proxy/firewall concern and is not what this provides.
+#
 # Public functions:
 #   isolation_mode_is_known MODE       # 0 when MODE is one of the three names
 #   isolation_mode_summary MODE        # one-line trust-boundary description
@@ -28,6 +39,9 @@
 #   resolve_isolation_mode             # environment -> .env -> inference -> shared
 #   require_supported_isolation_mode   # resolve, then check per-account inputs
 #   warn_unused_workspace_paths MODE   # flag per-account paths MODE ignores
+#   isolated_network_mode_is_known M   # 0 when M is bridge or none
+#   isolated_network_mode_summary M    # one-line reachability description
+#   resolve_isolated_network_mode      # environment -> .env -> bridge
 #
 # Requires: scripts/lib/parse_env.sh and scripts/lib/index.sh sourced before
 # this file.
@@ -40,6 +54,11 @@ _CLAUDE_DOCKER_ISOLATION_SH_SOURCED=1
 
 # Backward-compatible default for installations that never set the key.
 ISOLATION_MODE_DEFAULT="shared"
+
+# bridge, not none: an isolated agent still has to reach the model API and its
+# git remote, so detaching by default would break every ordinary workload while
+# looking like a stricter setting.
+ISOLATED_NETWORK_MODE_DEFAULT="bridge"
 
 # isolation_mode_is_known MODE
 # Return 0 when MODE is one of the three contract names.
@@ -149,6 +168,58 @@ resolve_isolation_mode() {
 
     if ! isolation_mode_is_known "$mode"; then
         echo "Error: ISOLATION_MODE must be shared, worktree or isolated (got: $mode)" >&2
+        return 1
+    fi
+
+    printf '%s' "$mode"
+}
+
+# isolated_network_mode_is_known MODE
+# Return 0 when MODE is one of the two network policy names.
+isolated_network_mode_is_known() {
+    case "${1:-}" in
+        bridge|none) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# isolated_network_mode_summary MODE
+# Print a one-line description of the reachability MODE provides, for the same
+# reason isolation_mode_summary exists: the policy should be stated rather than
+# read out of a generated compose file.
+isolated_network_mode_summary() {
+    case "${1:-}" in
+        bridge)
+            printf '%s' "each account is on its own bridge network; outbound access works, sibling discovery and direct connections do not"
+            ;;
+        none)
+            printf '%s' "each account is detached from every network; no outbound agent, API or git access"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# resolve_isolated_network_mode
+# Print the configured network policy: environment, then .env, then the default.
+#
+# There is no inference leg and no per-account variant. Unlike ISOLATION_MODE
+# this key predates nothing, so an unset value means "never configured" rather
+# than "configured the old way".
+#
+# An unrecognized value fails rather than falling back to the default, matching
+# resolve_isolation_mode: ISOLATED_NETWORK_MODE=non silently attaching every
+# account to a network is the failure this contract exists to prevent, and it
+# is worse here than a typo elsewhere because nothing downstream looks wrong.
+resolve_isolated_network_mode() {
+    local mode
+    mode="$(_isolation_lookup ISOLATED_NETWORK_MODE)"
+    mode="$(printf '%s' "$mode" | tr '[:upper:]' '[:lower:]')"
+    mode="${mode:-$ISOLATED_NETWORK_MODE_DEFAULT}"
+
+    if ! isolated_network_mode_is_known "$mode"; then
+        echo "Error: ISOLATED_NETWORK_MODE must be bridge or none (got: $mode)" >&2
         return 1
     fi
 

--- a/tests/lib/compose_assert.sh
+++ b/tests/lib/compose_assert.sh
@@ -142,6 +142,85 @@ resolved_service_tmpfs() {
         | jq -r --arg svc "$service" '.services[$svc].tmpfs // [] | .[]'
 }
 
+# resolved_service_env_keys DIR SERVICE FILE...
+# Print the environment variable NAMES of one resolved service, one per line,
+# sorted.
+#
+# Names only, never values. This helper resolves whatever .env the sandbox
+# holds, and in CI the same code path runs against fixtures that put a
+# placeholder token in exactly the slot a real one would occupy; a helper that
+# printed values would put them in the job log the first time an assertion
+# failed. Every question this file needs to answer about credentials -- is
+# GH_TOKEN present, is it absent -- is answerable from the names alone.
+resolved_service_env_keys() {
+    local dir="$1" service="$2"
+    shift 2
+
+    local file_args=() f
+    for f in "$@"; do
+        file_args+=(-f "$f")
+    done
+
+    (cd "$dir" && docker compose "${file_args[@]}" config --format json) \
+        | jq -r --arg svc "$service" '.services[$svc].environment // {} | keys[]'
+}
+
+# resolved_env_distinct DIR KEY SERVICE_A SERVICE_B FILE...
+# Compare one environment variable across two resolved services and print
+# `distinct`, `identical`, or `missing` -- never the values themselves.
+#
+# Presence of a key says only that a service has *a* credential; it cannot
+# distinguish a correctly scoped setup from one where both accounts were handed
+# the same token, which is the failure per-account auth exists to prevent. The
+# comparison happens inside jq so the values stay out of the output and out of
+# any CI log, which is why this is a helper rather than two greps in a caller.
+resolved_env_distinct() {
+    local dir="$1" key="$2" svc_a="$3" svc_b="$4"
+    shift 4
+
+    local file_args=() f
+    for f in "$@"; do
+        file_args+=(-f "$f")
+    done
+
+    (cd "$dir" && docker compose "${file_args[@]}" config --format json) \
+        | jq -r --arg k "$key" --arg a "$svc_a" --arg b "$svc_b" '
+            (.services[$a].environment[$k] // null) as $va
+            | (.services[$b].environment[$k] // null) as $vb
+            | if $va == null or $vb == null then "missing"
+              elif $va == $vb then "identical"
+              else "distinct"
+              end
+        '
+}
+
+# resolved_service_networks DIR SERVICE FILE...
+# Print the network attachment of one resolved service: either one
+# `network=NAME` line per attached network, or a single `network_mode=NAME`
+# line when the service declares an explicit mode instead.
+#
+# Both spellings are reported by one helper because they are alternative
+# answers to the same question, and a caller that grepped only for `network=`
+# would read a detached service as "no assertion applies" rather than as the
+# offline policy it is.
+resolved_service_networks() {
+    local dir="$1" service="$2"
+    shift 2
+
+    local file_args=() f
+    for f in "$@"; do
+        file_args+=(-f "$f")
+    done
+
+    (cd "$dir" && docker compose "${file_args[@]}" config --format json) \
+        | jq -r --arg svc "$service" '
+            .services[$svc] as $s
+            | if $s.network_mode then "network_mode=\($s.network_mode)"
+              else (($s.networks // {}) | keys[] | "network=\(.)")
+              end
+        '
+}
+
 # resolved_mount_manifest DIR FILE...
 # Print one "SERVICE|TYPE|SOURCE|TARGET|ACCESS" line per mount across every
 # service in the resolved model, sorted so the output is stable to diff.

--- a/tests/test_isolation_modes.ps1
+++ b/tests/test_isolation_modes.ps1
@@ -1,5 +1,5 @@
 # test_isolation_modes.ps1 — ISOLATION_MODE contract parity for the PowerShell
-# layer (issue #335, stages 1 to 3).
+# layer (issue #335, stages 1 to 4).
 #
 # Run:  pwsh -NoProfile -File tests/test_isolation_modes.ps1
 # Exits non-zero on any failure.
@@ -87,9 +87,11 @@ function New-Sandbox {
 $savedMode = [Environment]::GetEnvironmentVariable('ISOLATION_MODE')
 $savedProjectDirA = [Environment]::GetEnvironmentVariable('PROJECT_DIR_A')
 $savedIsolatedA = [Environment]::GetEnvironmentVariable('ISOLATED_WORKSPACE_A')
+$savedNetworkMode = [Environment]::GetEnvironmentVariable('ISOLATED_NETWORK_MODE')
 $env:ISOLATION_MODE = ''
 $env:PROJECT_DIR_A = ''
 $env:ISOLATED_WORKSPACE_A = ''
+$env:ISOLATED_NETWORK_MODE = ''
 
 try {
     Write-Host '== Test-IsolationModeKnown =='
@@ -149,7 +151,51 @@ try {
     Assert-Eq 'environment outranks .env' 'worktree' (Get-IsolationMode -ProjectRoot $sharedRoot)
     $env:ISOLATION_MODE = ''
 
+    Write-Host '== Test-IsolatedNetworkModeKnown =='
+    foreach ($netMode in @('bridge', 'none')) {
+        Assert-Eq "network known: $netMode" $true (Test-IsolatedNetworkModeKnown -Mode $netMode)
+    }
+    # 'Bridge' is rejected on purpose: the bash `case` is case-sensitive, so
+    # accepting it here would let a Windows user configure a value the Linux
+    # generator refuses -- the asymmetry this contract exists to prevent.
+    foreach ($netMode in @('', 'bogus', 'Bridge', 'internal')) {
+        Assert-Eq "network not known: '$netMode'" $false (Test-IsolatedNetworkModeKnown -Mode $netMode)
+    }
+
+    Write-Host '== Get-IsolatedNetworkModeSummary =='
+    # bridge is the one whose limits are easy to overstate: it separates the
+    # accounts from each other, it does not restrict what they can reach
+    # outside. The summary has to say the first part without implying the
+    # second.
+    Assert-Eq 'bridge summary says outbound access still works' $true `
+        ((Get-IsolatedNetworkModeSummary -Mode 'bridge') -like '*outbound access works*')
+    Assert-Eq 'none summary says there is no outbound access' $true `
+        ((Get-IsolatedNetworkModeSummary -Mode 'none') -like '*no outbound*')
+
+    Write-Host '== Get-IsolatedNetworkMode: resolution order =='
+    Assert-Eq 'no .env at all defaults to bridge' 'bridge' `
+        (Get-IsolatedNetworkMode -ProjectRoot (New-Sandbox @()))
+    Assert-Eq 'plain .env defaults to bridge' 'bridge' `
+        (Get-IsolatedNetworkMode -ProjectRoot (New-Sandbox @('ISOLATION_MODE=isolated')))
+    Assert-Eq 'explicit none' 'none' `
+        (Get-IsolatedNetworkMode -ProjectRoot (New-Sandbox @('ISOLATED_NETWORK_MODE=none')))
+    Assert-Eq 'case-insensitive input is normalized' 'bridge' `
+        (Get-IsolatedNetworkMode -ProjectRoot (New-Sandbox @('ISOLATED_NETWORK_MODE=BRIDGE')))
+
+    $bridgeRoot = New-Sandbox @('ISOLATED_NETWORK_MODE=bridge')
+    $env:ISOLATED_NETWORK_MODE = 'none'
+    Assert-Eq 'environment outranks .env' 'none' `
+        (Get-IsolatedNetworkMode -ProjectRoot $bridgeRoot)
+    $env:ISOLATED_NETWORK_MODE = ''
+
     Write-Host '== rejected configurations =='
+    # An unknown network policy must not degrade to bridge. A rejected value
+    # that quietly became bridge would attach every account to a network while
+    # the user believed they had asked for an offline profile.
+    Assert-Throws 'unknown network mode throws and names the accepted values' `
+        { Get-IsolatedNetworkMode -ProjectRoot (New-Sandbox @('ISOLATED_NETWORK_MODE=bogus')) } `
+        '*must be bridge or none*'
+
     # An unknown mode must not degrade to shared.
     Assert-Throws 'unknown mode throws and names the accepted values' `
         { Get-IsolationMode -ProjectRoot (New-Sandbox @('ISOLATION_MODE=bogus')) } `
@@ -239,6 +285,7 @@ finally {
     $env:ISOLATION_MODE = $savedMode
     $env:PROJECT_DIR_A = $savedProjectDirA
     $env:ISOLATED_WORKSPACE_A = $savedIsolatedA
+    $env:ISOLATED_NETWORK_MODE = $savedNetworkMode
     foreach ($dir in $script:Sandboxes) {
         Remove-Item -Recurse -Force $dir -ErrorAction SilentlyContinue
     }

--- a/tests/test_isolation_modes.sh
+++ b/tests/test_isolation_modes.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # test_isolation_modes.sh -- ISOLATION_MODE contract, worktree mount
-# regression, and isolated stack coverage (issue #335, stages 1 to 3).
+# regression, and isolated stack coverage (issue #335, stages 1 to 4).
 #
 # Three things are under test and they fail in different ways:
 #
@@ -134,7 +134,8 @@ run_generator() {
     shift
     local rc=0
     # shellcheck disable=SC2086  # deliberate word-split of the assignment list
-    env -u ISOLATION_MODE -u NUM_ACCOUNTS -u PROJECT_DIR_A -u ISOLATED_WORKSPACE_A "$@" \
+    env -u ISOLATION_MODE -u NUM_ACCOUNTS -u PROJECT_DIR_A -u ISOLATED_WORKSPACE_A \
+        -u ISOLATED_NETWORK_MODE "$@" \
         bash "$dir/scripts/generate-compose.sh" >"$dir/.gen.log" 2>&1 || rc=$?
     return "$rc"
 }
@@ -146,7 +147,7 @@ run_generator() {
 # The sourcing list mirrors what scripts/claude-docker sources, in its order.
 # index.sh is not decoration: isolation.sh derives per-account variable names
 # through index_to_upper, so omitting it makes every mode that needs a
-# per-account path fail as if the overlay were missing. Section 5 asserts the
+# per-account path fail as if the overlay were missing. Section 6 asserts the
 # real entry points keep this set complete.
 compose_files() {
     local dir="$1"
@@ -304,6 +305,22 @@ if [[ -f "$dir/docker-compose.yml" ]]; then
     fail "isolated without paths: partial output was written"
 else
     pass "isolated without paths: no compose file was written"
+fi
+
+# An unknown network policy must not degrade to bridge. This one matters more
+# than a typo usually does: a rejected value that quietly became `bridge` would
+# attach every account to a network while the user believed they had asked for
+# an offline profile, and nothing downstream would look wrong.
+dir="$(make_sandbox reject-unknown-network)"
+write_env "$dir" "HOME=$PLACEHOLDER_HOME" "PROJECT_DIR=$PLACEHOLDER_PROJECT" \
+    "ISOLATED_NETWORK_MODE=bogus"
+if run_generator "$dir"; then
+    fail "unknown network mode: generator succeeded"
+elif grep -q 'ISOLATED_NETWORK_MODE must be bridge or none' "$dir/.gen.log"; then
+    pass "unknown network mode: generator refused with a naming diagnostic"
+else
+    fail "unknown network mode: generator failed without naming the accepted values"
+    sed 's/^/        /' "$dir/.gen.log"
 fi
 
 # A configured isolated mode whose overlay has not been generated must refuse
@@ -612,7 +629,154 @@ else
     echo "  SKIP  resolved-compose assertions (docker or jq unavailable)"
 fi
 
-# --- 5. Entry-point library wiring --------------------------------------------
+# --- 5. Resolved isolated credentials and networks ----------------------------
+
+echo "== resolved isolated credentials and networks =="
+
+if compose_assert_requires; then
+    dir="$(make_sandbox resolved-scoping)"
+    write_env "$dir" "HOME=$PLACEHOLDER_HOME" "PROJECT_DIR=$PLACEHOLDER_PROJECT" \
+        "ISOLATION_MODE=isolated" \
+        "ISOLATED_WORKSPACE_A=$PLACEHOLDER_ISO_A" "ISOLATED_WORKSPACE_B=$PLACEHOLDER_ISO_B"
+    if ! run_generator "$dir"; then
+        fail "scoping: generator failed for a valid isolated configuration"
+        sed 's/^/        /' "$dir/.gen.log"
+    else
+        iso_files=(docker-compose.yml docker-compose.isolated.yml)
+        env_keys="$(resolved_service_env_keys "$dir" claude-a "${iso_files[@]}")"
+
+        # The shared GH_TOKEN names one GitHub account. Handing the same value
+        # to every isolated service would leave the boundary decorative on the
+        # one surface carrying write access to remote repositories. This is
+        # asserted on the resolved model because the overlay cannot be read for
+        # it: the base stack declares the variable, and only the merged project
+        # shows whether the override actually removed it.
+        if grep -qx 'GH_TOKEN' <<<"$env_keys"; then
+            fail "isolated: the shared GH_TOKEN survived into the isolated service"
+            printf '%s\n' "$env_keys" | sed 's/^/        key: /'
+        else
+            pass "isolated: no shared GitHub token"
+        fi
+
+        # The override replaces the whole environment list, so it can fail in
+        # the other direction too: a variable left out here is simply gone, and
+        # a container missing HOME or CLAUDE_CONFIG_DIR starts and then behaves
+        # strangely rather than failing outright.
+        for required in TERM HOME AGENT_RUNTIME CLAUDE_CONFIG_DIR NODE_OPTIONS \
+                        GIT_USER_NAME GIT_USER_EMAIL GIT_CONFIG_GLOBAL; do
+            if grep -qx "$required" <<<"$env_keys"; then
+                pass "isolated: $required survived the environment override"
+            else
+                fail "isolated: $required was dropped by the environment override"
+            fi
+        done
+
+        # Control. Without it, a generator that emitted an empty environment
+        # list for every mode would satisfy the assertion above.
+        cred_control="$(make_sandbox cred-control-shared)"
+        write_env "$cred_control" "HOME=$PLACEHOLDER_HOME" "PROJECT_DIR=$PLACEHOLDER_PROJECT"
+        if run_generator "$cred_control"; then
+            if resolved_service_env_keys "$cred_control" claude-a docker-compose.yml \
+                | grep -qx 'GH_TOKEN'; then
+                pass "control: shared mode does receive the shared GitHub token"
+            else
+                fail "control: shared mode lost GH_TOKEN, so the isolated check proves nothing"
+            fi
+        else
+            fail "control: generator failed for a plain shared configuration"
+            sed 's/^/        /' "$cred_control/.gen.log"
+        fi
+
+        # Per-account auth is the other half of the contract: an isolated
+        # service may hold its OWN credential. Presence alone would not
+        # distinguish that from both accounts being handed the same token, so
+        # the values are compared -- inside the helper, which reports only
+        # whether they differ and never prints either one.
+        pa_dir="$(make_sandbox scoping-per-account)"
+        write_env "$pa_dir" "HOME=$PLACEHOLDER_HOME" "PROJECT_DIR=$PLACEHOLDER_PROJECT" \
+            "ISOLATION_MODE=isolated" \
+            "ISOLATED_WORKSPACE_A=$PLACEHOLDER_ISO_A" "ISOLATED_WORKSPACE_B=$PLACEHOLDER_ISO_B" \
+            "GH_AUTH_MODE=per-account" \
+            "GH_USER_A=placeholder-user-a" "GH_TOKEN_A=placeholder-token-a" \
+            "GH_USER_B=placeholder-user-b" "GH_TOKEN_B=placeholder-token-b"
+        if run_generator "$pa_dir"; then
+            if resolved_service_env_keys "$pa_dir" claude-a "${iso_files[@]}" \
+                | grep -qx 'GH_TOKEN'; then
+                pass "isolated + per-account: the account keeps its own token"
+            else
+                fail "isolated + per-account: the account's own token was dropped"
+            fi
+
+            case "$(resolved_env_distinct "$pa_dir" GH_TOKEN claude-a claude-b "${iso_files[@]}")" in
+                distinct)  pass "isolated + per-account: the two accounts hold different tokens" ;;
+                identical) fail "isolated + per-account: both accounts hold the same token" ;;
+                *)         fail "isolated + per-account: GH_TOKEN is missing from a service" ;;
+            esac
+        else
+            fail "isolated + per-account: generator failed"
+            sed 's/^/        /' "$pa_dir/.gen.log"
+        fi
+
+        # --- Networks --------------------------------------------------------
+        # The base stack declares no networks, so every service lands on the
+        # project-wide implicit bridge and siblings reach each other by service
+        # name. That is the lateral path this replaces.
+        net_a="$(resolved_service_networks "$dir" claude-a "${iso_files[@]}")"
+        net_b="$(resolved_service_networks "$dir" claude-b "${iso_files[@]}")"
+
+        if [[ -z "$(comm -12 <(sort <<<"$net_a") <(sort <<<"$net_b"))" ]]; then
+            pass "isolated: the two accounts share no network"
+        else
+            fail "isolated: the two accounts share a network"
+            printf '%s\n' "$net_a" | sed 's/^/        a: /'
+            printf '%s\n' "$net_b" | sed 's/^/        b: /'
+        fi
+
+        # Attached, not detached. A bridge per account is what keeps outbound
+        # model-API and git access working; a profile that dropped the
+        # attachment entirely would also pass the disjointness check above
+        # while breaking every ordinary workload.
+        if grep -q '^network=' <<<"$net_a"; then
+            pass "isolated: the account is attached to a network under the default policy"
+        else
+            fail "isolated: the account has no network; outbound API and git access would fail"
+        fi
+
+        # Control. Shared mode puts every service on the implicit default
+        # bridge, so it MUST be reported as sharing -- without this, a helper
+        # that returned nothing for any input would pass the check above.
+        if [[ -n "$(comm -12 \
+            <(resolved_service_networks "$cred_control" claude-a docker-compose.yml | sort) \
+            <(resolved_service_networks "$cred_control" claude-b docker-compose.yml | sort))" ]]; then
+            pass "control: shared mode's accounts do share a network"
+        else
+            fail "control: shared mode reported no shared network, so the isolated check proves nothing"
+        fi
+
+        # The offline policy is a different YAML key, not a different value of
+        # the same one, so it is generated rather than interpolated and needs
+        # its own resolved-model case.
+        off_dir="$(make_sandbox scoping-offline)"
+        write_env "$off_dir" "HOME=$PLACEHOLDER_HOME" "PROJECT_DIR=$PLACEHOLDER_PROJECT" \
+            "ISOLATION_MODE=isolated" "ISOLATED_NETWORK_MODE=none" \
+            "ISOLATED_WORKSPACE_A=$PLACEHOLDER_ISO_A" "ISOLATED_WORKSPACE_B=$PLACEHOLDER_ISO_B"
+        if run_generator "$off_dir"; then
+            if resolved_service_networks "$off_dir" claude-a "${iso_files[@]}" \
+                | grep -qx 'network_mode=none'; then
+                pass "isolated + none: the account is detached from every network"
+            else
+                fail "isolated + none: the offline policy did not reach the resolved model"
+            fi
+        else
+            fail "isolated + none: generator failed"
+            sed 's/^/        /' "$off_dir/.gen.log"
+        fi
+    fi
+else
+    echo "  SKIP  resolved-compose assertions (docker or jq unavailable)"
+fi
+
+# --- 6. Entry-point library wiring --------------------------------------------
 
 echo "== entry-point library wiring =="
 
@@ -652,7 +816,7 @@ for entry in "${wiring_entries[@]}"; do
     fi
 done
 
-# --- 6. Committed files untouched ---------------------------------------------
+# --- 7. Committed files untouched ---------------------------------------------
 
 echo "== committed compose files =="
 if [[ "$(compose_digest)" == "$DIGEST_BEFORE" ]]; then


### PR DESCRIPTION
## Summary

Completes stage 4 of #335. An isolated service no longer receives the shared
GitHub token, and each account sits on its own bridge network. Together with
#338 (the container profile) this closes the runtime-hardening stage.

`docker-compose.yml`, `docker-compose.worktree.yml` and
`docker-compose.linux.yml` are byte-identical after the refactor — the shared
emitter changed no base output.

## Credentials

The base stack hands every service the same `GH_TOKEN`. That token names one
GitHub account, so passing it to each isolated service left the boundary
decorative on the one surface that carries write access to remote
repositories.

| `GH_AUTH_MODE` | What an isolated service receives |
|---|---|
| `per-account` (from #331) | Its own `GH_TOKEN_<X>` and `GH_USER_<X>`. |
| anything else | No GitHub credential. `gh` reports unauthenticated. |

The second row is a deliberate cost: an isolated account that needs to push
should be configured with per-account auth rather than handed the shared
token. This reuses #331's contract unchanged rather than growing a second
mechanism. Provider API keys were already per-account and are unaffected;
`GIT_USER_NAME`/`GIT_USER_EMAIL` still pass through as committer identity.

## The `!reset` finding

Removing an inherited environment key needs `environment: !override`, which
replaces the whole list. That was not the first design — the obvious tool is
`!reset` on the single key, and it does not work:

```
base:    environment: [- GH_TOKEN=LITERAL-BASE-VALUE]
overlay: environment: {GH_TOKEN: !reset null}
resolved: GH_TOKEN=LITERAL-BASE-VALUE
```

`!reset` on an individual environment entry is **ignored outright**. That is
worse than unsupported: the overlay reads as though it removes the variable
and the resolved model still carries it.

A first probe could not tell this apart from "`!reset` nulls the key and
Compose passes the host environment through", because the base interpolated
`${GH_TOKEN:-}` from the same host environment being observed. Pinning the
base to a literal is what separated the two, and the distinction mattered:
the pass-through reading would have meant an overlay that *leaks* the host
credential.

Consequence: the isolated environment list is re-emitted in full. Both lists
come from one function per language (`emit_account_environment` /
`Get-AccountEnvironmentLines`) so they cannot diverge, and the isolated
branch is fail-closed — a credential added to the base later cannot reach
this profile by being forgotten, only by being written into that branch on
purpose.

## Networks

The base stack declares no networks at all, so every service landed on the
project-wide implicit `default` bridge and account A could reach account B by
service name.

`ISOLATED_NETWORK_MODE` (read only under `ISOLATION_MODE=isolated`):

| Value | Effect |
|---|---|
| `bridge` (default) | One ordinary bridge per account, `isolated_net_<x>`. |
| `none` | Detached from every network. |

The bridges are ordinary, not `internal: true` — outbound access to the model
API and git remotes has to keep working. **Egress is not filtered**; that
belongs to a proxy or firewall, and the threat table now says so rather than
implying it away.

`networks` and `network_mode` are mutually exclusive keys, so the policy is a
generate-time switch rather than an interpolated `${VAR}` — the same shape
`NUM_ACCOUNTS` and `GH_AUTH_MODE` already have. An unrecognized value is
refused rather than defaulting to `bridge`, because an offline profile that
quietly came up networked produces no other visible symptom.

## Documentation corrections

Two sentences became false with this change and were fixed rather than left:

- `README.md` said "GitHub authentication still works through `GH_TOKEN`" for
  isolated accounts. It no longer does by default.
- The threat table listed container escape without qualification; it now says
  explicitly that the hardened profile raises the cost of an escape but does
  not prevent one, so `isolated` is not a substitute for a VM boundary.

## Verification

Correctness is asserted against `docker compose config` output, never source
YAML. New assertions (17) cover: `GH_TOKEN` absent under isolated; every
required variable surviving the override; per-account tokens present **and
distinct** between services; disjoint networks; `network_mode=none` under the
offline policy — each with a shared-mode control, because a helper that
returned nothing for any input would otherwise pass.

No test prints a credential value. `resolved_service_env_keys` emits names
only, and `resolved_env_distinct` compares the two services' values inside
`jq`, reporting `distinct`/`identical`/`missing`.

Run locally:

- WSL — `test_isolation_modes.sh` 19/19, generator syntax, regeneration drift.
- Windows — `test_isolation_modes.ps1` 48/48, `shellcheck -S warning` clean,
  `gofmt -l` clean.
- Generator parity — both generators run against the same tree produce
  identical output for all four files.
- Resolved-model assertions — WSL has no `jq`, so those sections SKIP there.
  They were executed for real in Git Bash against the actual helpers from
  `tests/lib/compose_assert.sh` (17/17), so CI is not running them for the
  first time.
- `ISOLATED_NETWORK_MODE=none` was validated as an accepted compose project,
  confirming no leftover `networks` key conflicts with `network_mode`.
- `claude-docker config` smoke-tested under bridge, none, and shared.

Not covered: no adversarial container smoke test has run — the assertions are
against the resolved model, not a live container.

Relates to #335
