### PR TITLE
fix(tui): scope usage-cache pruning to each account

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,14 @@ jobs:
       - name: Run Go unit tests
         working-directory: ./tui
         run: go test ./...
+      # `go test ./...` compiles benchmark functions but never executes them,
+      # so a benchmark harness that panics at runtime stays green forever.
+      # -benchtime=1x runs each benchmark exactly once: enough to catch that,
+      # too few iterations for the timing to be a flaky gate. Results are not
+      # asserted on here; the numbers of record live in docs/PERFORMANCE.md.
+      - name: Smoke-run Go benchmarks
+        working-directory: ./tui
+        run: go test ./... -run '^$' -bench . -benchtime=1x
       # Formatting is checked here rather than in a separate job because the Go
       # toolchain is already provisioned. The job name stays "Go tests (TUI)"
       # so any branch-protection rule referencing it keeps matching; the step

--- a/README.md
+++ b/README.md
@@ -636,6 +636,12 @@ Release automation currently publishes Linux `amd64`/`arm64`, macOS
 `amd64`/`arm64`, and Windows `amd64` assets. Other targets must build from
 source.
 
+Token usage is recomputed on every refresh from each account's JSONL session
+files and memoized per file, so an unchanged history is not reparsed. The
+cache is shared across accounts and pruned per account; the measurements and
+the benchmark that produces them are in
+[`docs/PERFORMANCE.md`](docs/PERFORMANCE.md).
+
 ### Rebuilding the Image
 
 ```bash

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -51,10 +51,14 @@ one cache across both accounts, as the dashboard does.
 
 ### Measured results
 
-Windows 11, amd64, Intel Core i5-14600KF (20 logical CPUs), Go 1.24. Each
+Windows 11, amd64, Intel Core i5-14600KF (20 logical CPUs), Go 1.26.2. Each
 session file holds 40 assistant entries. Median of 5 samples; the range
 across those samples is given because the `cache=off` arm is GC-bound and
 therefore noisy.
+
+That toolchain is newer than the 1.24 `tui/go.mod` requires and CI pins, so
+these are one machine's figures rather than a cross-platform baseline. The
+relationship between the two arms is what the benchmark is for.
 
 | History per account | `cache=off` | `cache=on` | Ratio |
 |---|---|---|---|

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,100 @@
+# Performance
+
+Measured behaviour and the benchmarks that produce it.
+
+This document currently covers the TUI usage cache only. Container startup,
+memory, and disk benchmarks for the `shared`, `worktree`, and `isolated`
+modes are tracked separately in issue #335 and are **not** in this file yet;
+see [Not covered yet](#not-covered-yet).
+
+Absolute figures below are machine-specific. What the benchmark is designed
+to establish is the *relationship* between the two arms, which is stable
+across machines.
+
+## TUI usage cache
+
+### What it does
+
+The dashboard recomputes each account's token summary on every refresh by
+walking that account's `projects` directory and parsing every `.jsonl`
+session file. `usage.Cache` memoizes the parsed result per file, keyed on
+path plus size plus mtime, so a refresh that changes nothing re-reads
+nothing. One `Cache` lives on the `account.Manager` and is shared by every
+account in a refresh.
+
+### Why pruning is scoped per account
+
+A scan can only build a "seen" set for the tree it walked. Pruning the whole
+cache against that set therefore deletes every *other* account's entries as
+a side effect of scanning one account. With two accounts alternating, each
+scan evicts the other and the cache stops being a cache — every refresh
+reparses the full history of both accounts, and the cost grows with history
+rather than with what changed.
+
+`Cache.pruneScope` therefore restricts the sweep to entries under the
+scanned root, and `Cache.RetainRoots` runs once at the end of a refresh to
+release entries under roots that are no longer scanned at all (an account
+that has gone away). Scoped pruning alone cannot reclaim those, because
+nothing walks that tree any more.
+
+### Running the benchmark
+
+```bash
+cd tui
+go test ./internal/usage -run '^$' -bench BenchmarkAlternatingAccountScans -benchmem -count=5
+```
+
+`BenchmarkAlternatingAccountScans` reproduces the refresh pattern: two
+accounts, each with a synthetic history, scanned one after the other. The
+`cache=off` arm uses no cache and is the baseline; the `cache=on` arm shares
+one cache across both accounts, as the dashboard does.
+
+### Measured results
+
+Windows 11, amd64, Intel Core i5-14600KF (20 logical CPUs), Go 1.24. Each
+session file holds 40 assistant entries. Median of 5 samples; the range
+across those samples is given because the `cache=off` arm is GC-bound and
+therefore noisy.
+
+| History per account | `cache=off` | `cache=on` | Ratio |
+|---|---|---|---|
+| 20 files | 8.29 ms (8.16–11.52) | 0.216 ms (0.213–0.300) | 38x |
+| 400 files | 275 ms (245–516) | 0.880 ms (0.866–1.197) | 313x |
+
+Allocation per refresh, which varies far less than wall time:
+
+| History per account | `cache=off` | `cache=on` |
+|---|---|---|
+| 20 files | 43.3 MB, 19,858 allocs | 32.2 KB, 214 allocs |
+| 400 files | 862.7 MB, 396,070 allocs | 574 KB, 3,286 allocs |
+
+Two things to read out of this:
+
+- **The arms scale differently.** Twenty times more history costs the
+  uncached arm 33x more time, but the cached arm only 4x. What remains in
+  the cached arm is directory walking and `stat`, not parsing, so its cost
+  tracks file *count* rather than accumulated content.
+- **The gap is mostly allocation.** At 400 files the uncached arm allocates
+  roughly 863 MB per refresh. That is the number that made this defect worth
+  fixing rather than the wall time: a dashboard refreshing on a timer was
+  producing that garbage repeatedly.
+
+### What a regression looks like
+
+If per-account scoping regresses to a whole-cache sweep, the two accounts
+evict each other every round and `cache=on` collapses onto the `cache=off`
+figures. That convergence is the signal, not any absolute number.
+`TestCacheAlternatingAccountsRetainEntries` fails first and more cheaply, so
+the benchmark is corroboration rather than the gate.
+
+## Not covered yet
+
+Issue #335 stage 5 also asks for a Node heap limit validated against the
+container memory cap, per-account and aggregate resource budgets surfaced
+before startup, transactional `scale`, and a reproducible 1/2/4-account
+benchmark matrix across all three isolation modes recording startup time,
+idle and peak memory, CPU and wall time for a representative workload, and
+disk usage. None of that is measured here. Until it is, this file is not a
+capacity statement, and the syntactic account ceiling described in
+[`README.md`](../README.md) remains a parser range rather than a supported
+simultaneous capacity.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -83,6 +83,14 @@ Two things to read out of this:
   fixing rather than the wall time: a dashboard refreshing on a timer was
   producing that garbage repeatedly.
 
+The CI smoke run prints the same benchmark on a very different machine — a
+4-CPU Linux runner, one iteration rather than a timed sample — and is worth
+comparing against as a second data point. At 400 files per account it
+reported 325 ms against 3.35 ms, and 862 MB against 675 KB. The absolute
+times and the ratio both move (97x rather than 313x); the shape does not.
+That is the sense in which these figures travel and the exact numbers do
+not.
+
 ### What a regression looks like
 
 If per-account scoping regresses to a whole-cache sweep, the two accounts

--- a/tui/internal/account/manager_helpers.go
+++ b/tui/internal/account/manager_helpers.go
@@ -54,6 +54,9 @@ func (m *Manager) buildAccounts(n int, stateDirs map[string]config.StateDir, con
 	runtime := m.env.AgentRuntime()
 	servicePrefix := m.env.ServicePrefix()
 	claudeUsage := m.env.SupportsClaudeUsage()
+	// Projects trees visited by this refresh. Each scan only prunes inside
+	// its own tree, so accounts that have gone away are released here.
+	scannedRoots := make([]string, 0, n)
 	for i := 1; i <= n; i++ {
 		letter := config.IndexToLetter(i)
 		svcName := servicePrefix + "-" + letter
@@ -77,7 +80,9 @@ func (m *Manager) buildAccounts(n int, stateDirs map[string]config.StateDir, con
 			// Uses the manager-scoped cache so unchanged session files are
 			// not re-read and re-decoded on every dashboard refresh.
 			if claudeUsage {
-				if sessions, err := usage.ScanAccountSessionsWithCache(sd.ProjectsDir(), m.usageCache); err == nil && len(sessions) > 0 {
+				projectsDir := sd.ProjectsDir()
+				scannedRoots = append(scannedRoots, projectsDir)
+				if sessions, err := usage.ScanAccountSessionsWithCache(projectsDir, m.usageCache); err == nil && len(sessions) > 0 {
 					opts := usage.AllTimeOptions()
 					tokens := usage.AggregateSessions(sessions, opts)
 					count := usage.CountFilteredSessions(sessions, opts)
@@ -103,6 +108,7 @@ func (m *Manager) buildAccounts(n int, stateDirs map[string]config.StateDir, con
 
 		accounts[i-1] = acct
 	}
+	m.usageCache.RetainRoots(scannedRoots)
 	return accounts
 }
 

--- a/tui/internal/usage/cache_bench_test.go
+++ b/tui/internal/usage/cache_bench_test.go
@@ -1,0 +1,86 @@
+package usage
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildHistory writes fileCount JSONL files of linesPerFile assistant
+// entries each into dir and returns dir. Content is identical across files
+// because the cache keys on path/size/mtime, not on what was parsed.
+func buildHistory(tb testing.TB, dir string, fileCount, linesPerFile int) string {
+	tb.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		tb.Fatalf("mkdir %s: %v", dir, err)
+	}
+	body := []byte(strings.Repeat(asstLine, linesPerFile))
+	for i := 0; i < fileCount; i++ {
+		path := filepath.Join(dir, fmt.Sprintf("session-%04d.jsonl", i))
+		if err := os.WriteFile(path, body, 0o644); err != nil {
+			tb.Fatalf("write %s: %v", path, err)
+		}
+	}
+	return dir
+}
+
+// BenchmarkAlternatingAccountScans measures the dashboard refresh pattern:
+// two accounts scanned one after the other through a single shared cache,
+// which is what buildAccounts does on every refresh.
+//
+// The cache=off arm is the no-cache baseline. The cache=on arm should stay
+// roughly flat as history grows, because a refresh that changes nothing
+// re-reads nothing. If per-account prune scoping regresses to a global
+// sweep, the two accounts evict each other every round and cache=on
+// collapses onto the cache=off numbers — that convergence, not any
+// absolute figure, is the signal this benchmark exists to expose.
+//
+// Run with:
+//
+//	go test ./internal/usage -run '^$' -bench BenchmarkAlternatingAccountScans -benchmem
+func BenchmarkAlternatingAccountScans(b *testing.B) {
+	// 40 lines per file keeps each session small enough that walk and stat
+	// cost stay visible; file count is what the history axis varies.
+	const linesPerFile = 40
+
+	for _, fileCount := range []int{20, 400} {
+		root := b.TempDir()
+		rootA := buildHistory(b, filepath.Join(root, "account-a", "projects"), fileCount, linesPerFile)
+		rootB := buildHistory(b, filepath.Join(root, "account-b", "projects"), fileCount, linesPerFile)
+
+		b.Run(fmt.Sprintf("files=%d/cache=off", fileCount), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := ScanAccountSessions(rootA); err != nil {
+					b.Fatalf("scan A: %v", err)
+				}
+				if _, err := ScanAccountSessions(rootB); err != nil {
+					b.Fatalf("scan B: %v", err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("files=%d/cache=on", fileCount), func(b *testing.B) {
+			cache := NewCache()
+			// Warm both trees so the loop measures steady-state refresh
+			// rather than the one-time parse. b.Loop resets the timer on
+			// its first call, so this setup is not charged to the result.
+			for _, dir := range []string{rootA, rootB} {
+				if _, err := ScanAccountSessionsWithCache(dir, cache); err != nil {
+					b.Fatalf("warm %s: %v", dir, err)
+				}
+			}
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := ScanAccountSessionsWithCache(rootA, cache); err != nil {
+					b.Fatalf("scan A: %v", err)
+				}
+				if _, err := ScanAccountSessionsWithCache(rootB, cache); err != nil {
+					b.Fatalf("scan B: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/tui/internal/usage/cache_test.go
+++ b/tui/internal/usage/cache_test.go
@@ -230,25 +230,176 @@ func TestNilCacheParsesEveryTime(t *testing.T) {
 	}
 }
 
-// TestCacheMissingDirReturnsNil verifies that a missing projects dir
-// is not an error and pruning still empties the cache so callers that
-// switch state directories do not leak stale entries.
-func TestCacheMissingDirReturnsNil(t *testing.T) {
+// TestCacheMissingDirPrunesOnlyThatTree verifies that a missing projects
+// dir is not an error and that entries cached under it are dropped, while
+// entries belonging to another account survive.
+//
+// The earlier version of this test asserted that a missing dir empties the
+// whole cache. That assertion was the defect rather than the contract: the
+// manager shares one cache across accounts, so the account whose state dir
+// happens to be missing would take every sibling's entries with it.
+func TestCacheMissingDirPrunesOnlyThatTree(t *testing.T) {
+	root := t.TempDir()
+	live := filepath.Join(root, "account-a", "projects")
+	gone := filepath.Join(root, "account-b", "projects")
+	if err := os.MkdirAll(live, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeJSONL(t, live, "a.jsonl")
+
 	cache := NewCache()
-	// Pre-seed cache so prune has something to do.
-	cache.put("/non/existent/seed.jsonl", 1, 2, Session{Path: "/non/existent/seed.jsonl"})
-	if cache.Len() != 1 {
-		t.Fatalf("seed Len = %d, want 1", cache.Len())
+	if _, err := ScanAccountSessionsWithCache(live, cache); err != nil {
+		t.Fatalf("scan live: %v", err)
+	}
+	// Seed an entry under the tree that is about to be reported missing.
+	stale := filepath.Join(gone, "old.jsonl")
+	cache.put(stale, 1, 2, Session{Path: stale})
+	if cache.Len() != 2 {
+		t.Fatalf("cache.Len after seeding = %d, want 2", cache.Len())
 	}
 
-	got, err := ScanAccountSessionsWithCache(filepath.Join(t.TempDir(), "does-not-exist"), cache)
+	got, err := ScanAccountSessionsWithCache(gone, cache)
 	if err != nil {
 		t.Fatalf("scan missing dir: err = %v, want nil", err)
 	}
 	if got != nil {
 		t.Errorf("scan missing dir sessions = %v, want nil", got)
 	}
+	if cache.Len() != 1 {
+		t.Fatalf("cache.Len after missing-dir scan = %d, want 1", cache.Len())
+	}
+	// The survivor must be the live account's entry, not the stale one.
+	if _, hit := cache.get(stale, 1, 2); hit {
+		t.Errorf("stale entry under the missing tree survived; want it pruned")
+	}
+}
+
+// TestCacheAlternatingAccountsRetainEntries is the regression test for the
+// dashboard refresh loop. One Cache is shared by every account, but a scan
+// can only build a seen set for its own projects tree, so scanning account
+// B must not evict account A. Without that scoping the two accounts evict
+// each other on every refresh and the cache degrades to no cache at all,
+// which gets worse as history grows.
+func TestCacheAlternatingAccountsRetainEntries(t *testing.T) {
+	root := t.TempDir()
+	rootA := filepath.Join(root, "account-a", "projects")
+	rootB := filepath.Join(root, "account-b", "projects")
+	for _, dir := range []string{rootA, rootB} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		writeJSONL(t, dir, "s1.jsonl")
+		writeJSONL(t, dir, "s2.jsonl")
+	}
+
+	cache := NewCache()
+	firstA, err := ScanAccountSessionsWithCache(rootA, cache)
+	if err != nil {
+		t.Fatalf("scan A: %v", err)
+	}
+	if len(firstA) != 2 {
+		t.Fatalf("scan A len = %d, want 2", len(firstA))
+	}
+	if _, err := ScanAccountSessionsWithCache(rootB, cache); err != nil {
+		t.Fatalf("scan B: %v", err)
+	}
+	if cache.Len() != 4 {
+		t.Fatalf("cache.Len after A then B = %d, want 4 (scanning B must not evict A)", cache.Len())
+	}
+
+	// Entry-slice identity is what distinguishes a cache hit from a silent
+	// reparse; a count alone would pass on a cache that refilled itself.
+	entryPtrs := make(map[string]*SessionEntry, len(firstA))
+	for i := range firstA {
+		if len(firstA[i].Entries) > 0 {
+			entryPtrs[firstA[i].Path] = &firstA[i].Entries[0]
+		}
+	}
+
+	secondA, err := ScanAccountSessionsWithCache(rootA, cache)
+	if err != nil {
+		t.Fatalf("rescan A: %v", err)
+	}
+	if len(secondA) != 2 {
+		t.Fatalf("rescan A len = %d, want 2", len(secondA))
+	}
+	for i := range secondA {
+		want, ok := entryPtrs[secondA[i].Path]
+		if !ok {
+			t.Errorf("rescan A returned unexpected path %q", secondA[i].Path)
+			continue
+		}
+		if len(secondA[i].Entries) == 0 {
+			t.Errorf("rescan A: %q has no entries", secondA[i].Path)
+			continue
+		}
+		if &secondA[i].Entries[0] != want {
+			t.Errorf("rescan A: %q was reparsed after scanning B; the cached entry did not survive", secondA[i].Path)
+		}
+	}
+}
+
+// TestCachePruneScopeIgnoresPrefixSiblings guards the prefix comparison
+// itself. Two projects trees whose paths share a textual prefix belong to
+// different accounts, so a scan of the shorter path must not sweep the
+// longer one.
+func TestCachePruneScopeIgnoresPrefixSiblings(t *testing.T) {
+	root := t.TempDir()
+	proj := filepath.Join(root, "projects")
+	sibling := filepath.Join(root, "projects-archive")
+	for _, dir := range []string{proj, sibling} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		writeJSONL(t, dir, "a.jsonl")
+	}
+
+	cache := NewCache()
+	if _, err := ScanAccountSessionsWithCache(sibling, cache); err != nil {
+		t.Fatalf("scan sibling: %v", err)
+	}
+	if _, err := ScanAccountSessionsWithCache(proj, cache); err != nil {
+		t.Fatalf("scan proj: %v", err)
+	}
+	if cache.Len() != 2 {
+		t.Errorf("cache.Len = %d, want 2 (%q must not prune %q)", cache.Len(), proj, sibling)
+	}
+}
+
+// TestCacheRetainRootsReleasesUnscannedTrees covers the release path used
+// at the end of a refresh. Scoped pruning cannot reclaim a tree that is no
+// longer scanned at all, because nothing walks it; RetainRoots is what
+// keeps an account that has gone away from occupying memory forever.
+func TestCacheRetainRootsReleasesUnscannedTrees(t *testing.T) {
+	root := t.TempDir()
+	rootA := filepath.Join(root, "account-a", "projects")
+	rootB := filepath.Join(root, "account-b", "projects")
+	for _, dir := range []string{rootA, rootB} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		writeJSONL(t, dir, "a.jsonl")
+	}
+
+	cache := NewCache()
+	for _, dir := range []string{rootA, rootB} {
+		if _, err := ScanAccountSessionsWithCache(dir, cache); err != nil {
+			t.Fatalf("scan %s: %v", dir, err)
+		}
+	}
+	if cache.Len() != 2 {
+		t.Fatalf("cache.Len after scanning both = %d, want 2", cache.Len())
+	}
+
+	// Account B disappears: the next refresh only reports root A.
+	cache.RetainRoots([]string{rootA})
+	if cache.Len() != 1 {
+		t.Errorf("cache.Len after retaining A = %d, want 1", cache.Len())
+	}
+
+	// No roots at all means nothing is being scanned, so nothing is kept.
+	cache.RetainRoots(nil)
 	if cache.Len() != 0 {
-		t.Errorf("cache.Len after missing-dir scan = %d, want 0", cache.Len())
+		t.Errorf("cache.Len after retaining nothing = %d, want 0", cache.Len())
 	}
 }

--- a/tui/internal/usage/parser.go
+++ b/tui/internal/usage/parser.go
@@ -83,20 +83,69 @@ func (c *Cache) put(path string, size, modUnix int64, s Session) {
 	c.entries[path] = cacheEntry{size: size, modUnix: modUnix, session: s}
 }
 
-// prune removes cache entries whose paths are not present in seen. This
-// drops entries for files that have been deleted or moved out of the
-// projects tree, keeping cache memory bounded by current state.
-func (c *Cache) prune(seen map[string]struct{}) {
+// pruneScope removes cache entries under root whose paths are not present
+// in seen. This drops entries for files that have been deleted or moved
+// out of that projects tree, keeping cache memory bounded by current state.
+//
+// Entries outside root are deliberately left alone. One Cache is shared by
+// every account in a dashboard refresh, but a scan only ever builds a seen
+// set for its own projects tree, so sweeping the whole map here would make
+// every sibling account collateral damage of scanning one account. Roots
+// that stop being scanned entirely are released by RetainRoots instead.
+func (c *Cache) pruneScope(root string, seen map[string]struct{}) {
 	if c == nil {
 		return
 	}
+	prefix := rootPrefix(root)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for path := range c.entries {
+		if !strings.HasPrefix(path, prefix) {
+			continue
+		}
 		if _, ok := seen[path]; !ok {
 			delete(c.entries, path)
 		}
 	}
+}
+
+// RetainRoots drops every cache entry that does not live under one of the
+// given roots. Callers that scan a set of projects directories per refresh
+// call this once afterwards with the roots they actually scanned, so an
+// account that has gone away releases its sessions; scoped pruning alone
+// would keep them for the process lifetime because nothing scans that tree
+// any more. Passing no roots empties the cache.
+func (c *Cache) RetainRoots(roots []string) {
+	if c == nil {
+		return
+	}
+	prefixes := make([]string, 0, len(roots))
+	for _, root := range roots {
+		prefixes = append(prefixes, rootPrefix(root))
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for path := range c.entries {
+		keep := false
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(path, prefix) {
+				keep = true
+				break
+			}
+		}
+		if !keep {
+			delete(c.entries, path)
+		}
+	}
+}
+
+// rootPrefix returns root cleaned and terminated with a separator. The
+// trailing separator is what stops a prefix test from matching a sibling
+// whose name merely starts with the root: ".../projects" must not capture
+// ".../projects-archive/x.jsonl". Cached paths come from filepath.Join
+// during the walk, so they are already in this cleaned form.
+func rootPrefix(root string) string {
+	return filepath.Clean(root) + string(filepath.Separator)
 }
 
 // Len returns the number of cached entries. Intended for tests and
@@ -121,20 +170,19 @@ func ScanAccountSessions(projectsDir string) ([]Session, error) {
 // ScanAccountSessionsWithCache walks the projects dir and returns parsed
 // sessions for every .jsonl file. When cache is non-nil, files whose
 // path, size, and mtime match a cached entry are returned from the
-// cache without re-reading the file. After the scan, cache entries for
-// files no longer present on disk are pruned.
+// cache without re-reading the file. After the scan, cache entries under
+// projectsDir for files no longer present on disk are pruned; entries
+// belonging to other projects directories are left untouched so one cache
+// can serve several accounts.
 func ScanAccountSessionsWithCache(projectsDir string, cache *Cache) ([]Session, error) {
 	var sessions []Session
 	if _, err := os.Stat(projectsDir); err != nil {
 		if os.IsNotExist(err) {
-			// Even with a missing dir we should prune anything still in
-			// the cache that pointed under this tree, otherwise switching
-			// away from a state dir would leak entries. Callers that share
-			// one cache across multiple projects dirs handle this via the
-			// per-call seen set returned to prune below.
-			if cache != nil {
-				cache.prune(map[string]struct{}{})
-			}
+			// A tree that has disappeared has no live files, so everything
+			// cached under it is stale. Scope the sweep to that tree only:
+			// the caller may be mid-way through a refresh whose remaining
+			// accounts still have valid entries in this same cache.
+			cache.pruneScope(projectsDir, nil)
 			return nil, nil
 		}
 		return nil, err
@@ -186,7 +234,7 @@ func ScanAccountSessionsWithCache(projectsDir string, cache *Cache) ([]Session, 
 		return nil, fmt.Errorf("walk projects dir: %w", err)
 	}
 
-	cache.prune(seen)
+	cache.pruneScope(projectsDir, seen)
 	return sessions, nil
 }
 


### PR DESCRIPTION
## What

Fixes the TUI usage cache so scanning one account no longer evicts every
other account's entries, and records the measurement that shows why it
matters.

This is the first axis of #335 merge-order stage 5 (`## How` §5). Stage 5
bundles five independent concerns — Node heap validation, resource budget
visibility, transactional `scale`, this cache defect, and the container
benchmark matrix — in three different languages. They are split for the same
reason stage 4 was split into #338 and #339: a regression in one axis should
not have to be untangled from another in the same CI run.

Acceptance criterion addressed: *"Alternating scans of two account histories
retain valid TUI cache entries and the large-history benchmark is
documented."*

## Why

`account.Manager` holds one `usage.Cache` and `buildAccounts` calls
`ScanAccountSessionsWithCache` once per account. Each call built its `seen`
set from a single projects tree, then called `prune(seen)`, which swept the
**entire** map. Scanning account B therefore deleted account A's entries.

With two accounts alternating, each refresh evicted the other account and
reparsed everything: the cache was not merely ineffective, it was pure
overhead — it paid for the map writes and then threw the results away. The
cost grew with accumulated history rather than with what actually changed.

The missing-directory branch was the sharper edge. It called
`prune(map[string]struct{}{})`, emptying the cache outright, so one account
whose state directory happened to be absent discarded every sibling's
entries. Its comment claimed "callers that share one cache across multiple
projects dirs handle this via the per-call seen set" — the caller does no
such thing.

## How

The root cause is a scope mismatch: `seen` is per-tree, `prune` was global.

- `prune` → `pruneScope(root, seen)`, which only considers entries under
  `root`. Deleted files inside a scanned tree are still reclaimed, so
  `TestCachePrunesDeletedFiles` keeps its meaning.
- New `Cache.RetainRoots(roots)`, called once at the end of `buildAccounts`
  with the trees actually visited. Scoped pruning alone cannot reclaim a
  tree nobody scans any more, so without this an account that goes away
  would occupy memory for the process lifetime. This preserves the memory
  bound the old global sweep provided, which is the one property worth
  keeping from it.
- Prefix comparison goes through `rootPrefix`, which appends a separator so
  `.../projects` cannot capture `.../projects-archive`.

### One test asserted the defect

`TestCacheMissingDirReturnsNil` required `cache.Len() == 0` after scanning a
missing directory — that is, it pinned the whole-cache wipe as intended
behaviour. Changing a test to match new behaviour is normally a red flag, so
stating the justification explicitly: the assertion described a caller that
owns the cache alone, while the actual caller shares one cache across
accounts. It is rewritten as `TestCacheMissingDirPrunesOnlyThatTree`, which
keeps the original nil/no-error assertions and additionally requires the
sweep to stay inside the missing tree.

## Where

| File | Change |
|---|---|
| `tui/internal/usage/parser.go` | `pruneScope`, `RetainRoots`, `rootPrefix`; both call sites |
| `tui/internal/account/manager_helpers.go` | collect scanned roots, release once per refresh |
| `tui/internal/usage/cache_test.go` | 3 new tests, 1 rewritten |
| `tui/internal/usage/cache_bench_test.go` | new large-history benchmark |
| `docs/PERFORMANCE.md` | new; measurements and how to reproduce |
| `README.md` | link from the TUI section |
| `.github/workflows/ci.yml` | benchmark smoke run |

## Verification

`go test ./...`, `gofmt -l .`, and `go vet ./...` are clean.

**The new tests were checked against the defect rather than only against the
fix.** Two mutations were applied and reverted:

| Mutation | Result |
|---|---|
| `pruneScope` restored to a global sweep | 4 failures: alternating-accounts, missing-dir, prefix-sibling, retain-roots |
| `rootPrefix` returns the root without a trailing separator | exactly 1 failure: prefix-sibling |

The second matters as much as the first: a single, localised failure means
the suite points at the defect instead of going uniformly red.

### Benchmark

`BenchmarkAlternatingAccountScans` reproduces the refresh pattern — two
accounts, one shared cache, scanned in turn. Median of 5 on Windows 11 /
i5-14600KF / Go 1.26.2 — newer than the 1.24 CI pins, so these are one
machine's figures. 40 assistant entries per session file:

| History per account | `cache=off` | `cache=on` | Ratio |
|---|---|---|---|
| 20 files | 8.29 ms | 0.216 ms | 38x |
| 400 files | 275 ms | 0.880 ms | 313x |

| History per account | `cache=off` | `cache=on` |
|---|---|---|
| 20 files | 43.3 MB, 19,858 allocs | 32.2 KB, 214 allocs |
| 400 files | 862.7 MB, 396,070 allocs | 574 KB, 3,286 allocs |

`cache=off` is the no-cache baseline, and it is also what the two-account
refresh had degenerated into: the same parse volume, plus the cache churn.
The allocation column is the reason to fix this rather than the wall time —
a dashboard refreshing on a timer was producing roughly 863 MB of garbage
per cycle at 400 files per account.

The regression signal is the two arms **converging**, not any absolute
figure, so nothing here is asserted as a threshold. CI runs the benchmarks
at `-benchtime=1x` purely so a harness that panics cannot stay green:
`go test ./...` compiles benchmark functions but never executes them.

## Notes

- No credential values are read, printed, or fixtured; the benchmark and
  tests generate their own placeholder JSONL.
- No compose file, generator, or shell script is touched, so generator
  parity and compose freshness are unaffected.
- `docs/PERFORMANCE.md` states plainly what it does **not** cover, so it is
  not mistaken for the stage-5 capacity report that #335 still requires.

Relates to #335
