### PR TITLE
feat(compose): derive the Node heap limit from the memory cap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,6 +114,26 @@ PROJECT_DIR=/absolute/path/to/your/project
 # GH_USER_B=github-login-b
 # GH_TOKEN_B=
 
+# ==== Container resources (optional) ====
+# The per-container CPU and memory envelope. Values are baked into the
+# generated compose files, so regenerate (scripts/generate-compose.sh or .ps1)
+# after changing any of them.
+# CONTAINER_CPU_LIMIT=2
+# CONTAINER_CPU_RESERVATION=1
+# CONTAINER_MEM_LIMIT=4G
+# CONTAINER_MEM_RESERVATION=2G
+#
+# The Node old-space limit, in MiB. Leave it unset: it is then derived from
+# CONTAINER_MEM_LIMIT, reserving a quarter of the cap (at least 512 MiB) for
+# everything inside the container that is not the JavaScript heap -- native
+# allocations, every subprocess an agent spawns, and page cache. A 4G cap
+# yields a 3072 MiB heap.
+#
+# Setting it explicitly is checked against the cap: a heap that would leave
+# less than 512 MiB free is refused at generation time rather than becoming a
+# container the kernel OOM-kills under load.
+# CONTAINER_NODE_HEAP_MB=3072
+
 # ==== Linux: UID/GID (auto-set by install.sh) ====
 # UID=1000
 # GID=1000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,7 @@ jobs:
           - tests/test_runtime_registry_equivalence.sh
           - tests/test_compose_generator_equivalence.sh
           - tests/test_isolation_modes.sh
+          - tests/test_container_memory.sh
           - tests/test_github_per_account_compose.sh
           - tests/test_github_account_selection.sh
           - tests/test_entrypoint_github_auth.sh
@@ -214,6 +215,7 @@ jobs:
         test:
           - tests/test_parse_env.ps1
           - tests/test_isolation_modes.ps1
+          - tests/test_container_memory.ps1
           - tests/test_powershell_platform_guard.ps1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,15 @@ RUN if [[ -n "${CODEX_CLI_VERSION:-}" ]]; then \
     fi \
     && npm cache clean --force
 
-# Memory heap limit
+# Memory heap limit — image default only.
+#
+# Every compose service overrides this with a value the generator derived from
+# that service's own memory cap and validated to leave headroom for native
+# allocations, subprocesses and page cache (scripts/lib/resources.sh). This
+# line is what a plain `docker run` of the image gets, where there is no
+# declared cap to derive from. Running it that way, set --max-old-space-size
+# to roughly three quarters of whatever --memory is passed; see "Resource
+# Requirements" in README.md.
 ENV NODE_OPTIONS=--max-old-space-size=4096
 
 # Pre-create ccstatusline XDG config dir world-writable.

--- a/README.md
+++ b/README.md
@@ -1062,9 +1062,57 @@ CONTAINER_MEM_RESERVATION=2G
 ```
 
 Re-run `scripts/generate-compose.sh` (or `.ps1`) after changing these so the
-generated compose files pick up the new values. The table below assumes
-defaults. Docker RAM is the recommended Docker Desktop memory allocation to
-allow all containers to run at peak load.
+generated compose files pick up the new values.
+
+### Node heap headroom
+
+The container memory limit caps *everything* inside the container. The Node
+old-space limit caps only the JavaScript heap, and the two are not the same
+budget: V8's other heap spaces, native allocations from node modules, every
+subprocess an agent spawns (git, ripgrep, package managers, compilers) and the
+page cache for the bind mounts all draw on the container limit as well.
+
+A heap allowed to reach the cap on its own is therefore OOM-killed before V8
+ever reaches the ceiling that would have made it collect garbage instead — and
+an OOM kill is the less useful of the two failures, since it takes the whole
+container down with no JavaScript stack.
+
+The generator derives the heap from the cap rather than setting it beside it:
+
+| `CONTAINER_MEM_LIMIT` | Reserved | `--max-old-space-size` |
+|:---|:---|:---|
+| 1G | 512 MiB | 512 |
+| 2G | 512 MiB | 1536 |
+| 4G (default) | 1024 MiB | 3072 |
+| 8G | 2048 MiB | 6144 |
+| 16G | 4096 MiB | 12288 |
+
+The reservation is a quarter of the cap, with a floor of 512 MiB — a flat
+percentage collapses to nothing on small caps, where the fixed costs do not
+shrink along with the cap. **This is a convention, not a measurement**: no
+steady-state non-heap footprint has been measured for these containers yet, so
+the number is stated as a convention on purpose, to be replaced by a measured
+one rather than reinterpreted.
+
+Override it with `CONTAINER_NODE_HEAP_MB` (in MiB, the unit
+`--max-old-space-size` actually uses). An explicit value is checked against the
+cap, and a combination leaving less than 512 MiB free is refused when compose
+files are generated — before any container starts — rather than at run time:
+
+```
+$ CONTAINER_NODE_HEAP_MB=4096 scripts/generate-compose.sh
+Error: the Node heap limit does not leave enough of the container memory cap free.
+       CONTAINER_MEM_LIMIT=4G is 4096 MiB; a 4096 MiB heap leaves 0 MiB, and at least 512 MiB is required.
+       Set CONTAINER_NODE_HEAP_MB to at most 3584, or raise CONTAINER_MEM_LIMIT.
+```
+
+Installations that generated compose files before this existed carried a
+4096 MiB heap under a 4 GiB cap — exactly zero headroom. Regenerating lowers it
+to 3072 MiB. That is a deliberate change of an existing default rather than a
+preserved one.
+
+The table below assumes defaults. Docker RAM is the recommended Docker Desktop
+memory allocation to allow all containers to run at peak load.
 
 | Instances | Docker RAM (recommended) | Host RAM (Linux / macOS / Windows) |
 |:---------:|:------------------------:|:----------------------------------:|

--- a/docker-compose.isolated.yml
+++ b/docker-compose.isolated.yml
@@ -61,7 +61,7 @@ services:
       - CLAUDE_CONFIG_DIR=/home/node/.claude
       - CLAUDE_CONFIG_SOURCE=${CLAUDE_CONFIG_SOURCE:-}
       - CLAUDE_NORMALIZE_CRLF=${CLAUDE_NORMALIZE_CRLF:-}
-      - NODE_OPTIONS=--max-old-space-size=4096
+      - NODE_OPTIONS=--max-old-space-size=3072
       - GIT_USER_NAME=${GIT_USER_NAME:-}
       - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}
       - GIT_CONFIG_GLOBAL=/home/node/.claude/gitconfig
@@ -98,7 +98,7 @@ services:
       - CLAUDE_CONFIG_DIR=/home/node/.claude
       - CLAUDE_CONFIG_SOURCE=${CLAUDE_CONFIG_SOURCE:-}
       - CLAUDE_NORMALIZE_CRLF=${CLAUDE_NORMALIZE_CRLF:-}
-      - NODE_OPTIONS=--max-old-space-size=4096
+      - NODE_OPTIONS=--max-old-space-size=3072
       - GIT_USER_NAME=${GIT_USER_NAME:-}
       - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}
       - GIT_CONFIG_GLOBAL=/home/node/.claude/gitconfig

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - CLAUDE_CONFIG_DIR=/home/node/.claude
       - CLAUDE_CONFIG_SOURCE=${CLAUDE_CONFIG_SOURCE:-}
       - CLAUDE_NORMALIZE_CRLF=${CLAUDE_NORMALIZE_CRLF:-}
-      - NODE_OPTIONS=--max-old-space-size=4096
+      - NODE_OPTIONS=--max-old-space-size=3072
       - GH_TOKEN=${GH_TOKEN:-}
       - GIT_USER_NAME=${GIT_USER_NAME:-}
       - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}
@@ -71,7 +71,7 @@ services:
       - CLAUDE_CONFIG_DIR=/home/node/.claude
       - CLAUDE_CONFIG_SOURCE=${CLAUDE_CONFIG_SOURCE:-}
       - CLAUDE_NORMALIZE_CRLF=${CLAUDE_NORMALIZE_CRLF:-}
-      - NODE_OPTIONS=--max-old-space-size=4096
+      - NODE_OPTIONS=--max-old-space-size=3072
       - GH_TOKEN=${GH_TOKEN:-}
       - GIT_USER_NAME=${GIT_USER_NAME:-}
       - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}

--- a/docs/ISOLATION.md
+++ b/docs/ISOLATION.md
@@ -387,7 +387,24 @@ Issue #335 is delivered in six stages. Each is a separate PR.
 3. **Independent workspace setup and isolated mount generation.** ✅
 4. **Runtime, configuration, credential and network hardening.** ✅
 5. Resource validation, transactional scaling, TUI cache correction, benchmarks.
+   Partly delivered — see below.
 6. Cross-platform rollout, migration documentation, final benchmark report.
+
+Stage 5 is not one piece of work either. It bundles five independent axes
+across three languages, and they are landing separately for the same reason
+stage 4 split in two:
+
+| Axis | State |
+|---|---|
+| TUI usage-cache correction and large-history benchmark | ✅ |
+| Node heap limit validated below the container memory cap | ✅ |
+| Per-account and aggregate resource budgets surfaced before startup | open |
+| Transactional `scale` | open |
+| 1/2/4-account benchmark matrix and reviewed budgets | open |
+
+The heap axis is documented under
+[Node heap headroom](../README.md#node-heap-headroom) rather than here: it
+applies to every mode, not only to `isolated`.
 
 `isolated` became usable at stage 3, which removed a refusal rather than adding
 a name — the contract had accepted the value since stage 1 precisely so that

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -101,12 +101,20 @@ the benchmark is corroboration rather than the gate.
 
 ## Not covered yet
 
-Issue #335 stage 5 also asks for a Node heap limit validated against the
-container memory cap, per-account and aggregate resource budgets surfaced
-before startup, transactional `scale`, and a reproducible 1/2/4-account
-benchmark matrix across all three isolation modes recording startup time,
-idle and peak memory, CPU and wall time for a representative workload, and
-disk usage. None of that is measured here. Until it is, this file is not a
-capacity statement, and the syntactic account ceiling described in
-[`README.md`](../README.md) remains a parser range rather than a supported
+Issue #335 stage 5 also asks for per-account and aggregate resource budgets
+surfaced before startup, transactional `scale`, and a reproducible
+1/2/4-account benchmark matrix across all three isolation modes recording
+startup time, idle and peak memory, CPU and wall time for a representative
+workload, and disk usage. None of that is measured here. Until it is, this
+file is not a capacity statement, and the syntactic account ceiling described
+in [`README.md`](../README.md) remains a parser range rather than a supported
 simultaneous capacity.
+
+The stage-5 item this file used to list first — a Node heap limit validated
+against the container memory cap — has since been implemented and is
+documented under [Node heap headroom](../README.md#node-heap-headroom). It is
+worth being precise about what that did and did not settle: the heap now
+cannot exceed the cap, but the headroom it reserves is a stated convention
+rather than a measured non-heap footprint. Measuring it is part of the
+benchmark matrix above, and one of the things this file will be able to
+replace a convention with once that exists.

--- a/scripts/ClaudeDocker.psm1
+++ b/scripts/ClaudeDocker.psm1
@@ -787,6 +787,160 @@ function Write-UnusedWorkspacePathWarning {
     }
 }
 
+# --- Container Resource Envelope ---------------------------------------------
+#
+# Bash mirror: scripts/lib/resources.sh. The generated compose files carry the
+# container memory cap and the Node old-space limit as two literals that have
+# to agree; until issue #335 both were fixed values that happened to be equal,
+# so V8 was allowed to grow its heap to the whole cgroup limit and the kernel
+# reached the OOM killer before V8 reached the ceiling that would have made it
+# collect garbage instead. The heap is therefore derived from the cap, and an
+# explicitly configured heap is checked against it before any file is written.
+
+# Smallest slice of the cap that must stay outside the Node heap. A floor
+# rather than the whole rule: a percentage alone collapses to nothing on small
+# caps, where the fixed costs (V8 itself, the runtime's node processes, git)
+# do not shrink with the cap.
+$script:NodeHeapMinHeadroomMib = 512
+
+# Fraction of the cap reserved when that exceeds the floor, as a divisor.
+# 25% is a convention, not a measurement -- see the note in
+# scripts/lib/resources.sh, which this mirrors.
+$script:NodeHeapHeadroomDivisor = 4
+
+# Fractional digits kept when a byte value carries a decimal point. Three is
+# 1 MiB of precision at GiB scale, and it is also what keeps the arithmetic
+# inside [long] at the largest unit this accepts.
+$script:ResourceFractionDigits = 3
+
+function ConvertTo-MebibyteCount {
+    <#
+    .SYNOPSIS
+    Convert a Docker byte value to a whole number of MiB.
+    .DESCRIPTION
+    The accepted syntax is the one Docker itself parses
+    (go-units.RAMInBytes, reached through deploy.resources.limits.memory): a
+    number with an optional k/m/g/t/p scale, an optional 'i', an optional 'b',
+    and optional spaces, all case-insensitive -- 4G, 4g, 4GB, 4GiB, 4 g and
+    4294967296 are the same value. Decimals are accepted for the same reason:
+    1.5G is a working CONTAINER_MEM_LIMIT today, and this validator has no
+    business rejecting a cap Docker would have taken.
+
+    Returns $null when Value is not one of those, so the caller owns the
+    diagnostic and can name the key the value came from.
+
+    The result is floored, which is the conservative direction for every
+    caller here: a cap reads as smaller than it is, never as larger.
+
+    Arithmetic is [long]. A 4G cap is 4294967296 bytes, which overflows [int].
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$Value)
+
+    $normalized = ($Value -replace '\s', '').ToLowerInvariant()
+    if ([string]::IsNullOrEmpty($normalized)) { return $null }
+
+    # Group 1 whole part, group 3 fractional digits, group 5 the scale letter
+    # (empty for plain bytes, whether written as 4 or 4b).
+    if ($normalized -notmatch '^([0-9]+)(\.([0-9]+))?(([kmgtp])i?b?|b)?$') { return $null }
+
+    [long]$intPart = $Matches[1]
+    # A group that did not participate is absent from $Matches rather than
+    # present and empty, so both optional groups are read defensively. Reading
+    # them directly would make an absent scale $null, which the switch below
+    # would fall through, leaving the multiplier 0 and the whole value silently
+    # wrong instead of rejected.
+    $frac = if ($Matches.Contains(3)) { [string]$Matches[3] } else { '' }
+    $scale = if ($Matches.Contains(5)) { [string]$Matches[5] } else { '' }
+
+    [long]$mult = switch ($scale) {
+        ''  { 1 }
+        'k' { 1KB }
+        'm' { 1MB }
+        'g' { 1GB }
+        't' { 1TB }
+        'p' { 1PB }
+    }
+
+    [long]$bytes = $intPart * $mult
+    if (-not [string]::IsNullOrEmpty($frac)) {
+        if ($frac.Length -gt $script:ResourceFractionDigits) {
+            $frac = $frac.Substring(0, $script:ResourceFractionDigits)
+        }
+        [long]$denominator = [math]::Pow(10, $frac.Length)
+        # Floor, not a [long] cast: PowerShell rounds half to even on a cast,
+        # so 1.5 would become 2 where the bash mirror truncates to 1.
+        $bytes += [long][math]::Floor(([long]$frac * $mult) / $denominator)
+    }
+
+    return [long]([math]::Floor($bytes / 1MB))
+}
+
+function Get-NodeHeapHeadroomMib {
+    <#
+    .SYNOPSIS
+    MiB that should stay outside the Node heap for a container capped at CapMib.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][long]$CapMib)
+
+    $headroom = [math]::Floor($CapMib / $script:NodeHeapHeadroomDivisor)
+    if ($headroom -lt $script:NodeHeapMinHeadroomMib) {
+        $headroom = $script:NodeHeapMinHeadroomMib
+    }
+    return [long]$headroom
+}
+
+function Resolve-NodeHeapMib {
+    <#
+    .SYNOPSIS
+    Validated Node old-space limit, in MiB, for a container capped at MemLimit.
+    .DESCRIPTION
+    With ConfiguredHeapMb empty the value is derived from the cap; otherwise
+    ConfiguredHeapMb is used as given. Either way the result is checked
+    against the cap, and an unusable combination throws so the generator can
+    refuse to open the first output file rather than write a stack that
+    OOM-kills at run time.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$MemLimit,
+        [AllowEmptyString()][string]$ConfiguredHeapMb = ''
+    )
+
+    $capMib = ConvertTo-MebibyteCount -Value $MemLimit
+    if ($null -eq $capMib) {
+        throw "CONTAINER_MEM_LIMIT must be a byte value such as 4G, 4096m or 4294967296 (got: $MemLimit)"
+    }
+
+    # Checked before the heap so the advice below can always name a positive
+    # ceiling to lower the heap to.
+    if ($capMib -le $script:NodeHeapMinHeadroomMib) {
+        throw ("CONTAINER_MEM_LIMIT=$MemLimit ($capMib MiB) leaves no room for a Node heap. " +
+            "At least $($script:NodeHeapMinHeadroomMib) MiB of the cap must stay outside the heap, so the cap has to exceed that.")
+    }
+
+    if (-not [string]::IsNullOrEmpty($ConfiguredHeapMb)) {
+        if ($ConfiguredHeapMb -notmatch '^[0-9]+$' -or [long]$ConfiguredHeapMb -eq 0) {
+            throw "CONTAINER_NODE_HEAP_MB must be a positive whole number of MiB (got: $ConfiguredHeapMb)"
+        }
+        [long]$heap = $ConfiguredHeapMb
+    }
+    else {
+        [long]$heap = $capMib - (Get-NodeHeapHeadroomMib -CapMib $capMib)
+    }
+
+    $headroom = $capMib - $heap
+    if ($headroom -lt $script:NodeHeapMinHeadroomMib) {
+        throw ("The Node heap limit does not leave enough of the container memory cap free. " +
+            "CONTAINER_MEM_LIMIT=$MemLimit is $capMib MiB; a $heap MiB heap leaves $headroom MiB, " +
+            "and at least $($script:NodeHeapMinHeadroomMib) MiB is required. " +
+            "Set CONTAINER_NODE_HEAP_MB to at most $($capMib - $script:NodeHeapMinHeadroomMib), or raise CONTAINER_MEM_LIMIT.")
+    }
+
+    return $heap
+}
+
 # --- Docker Compose Helpers --------------------------------------------------
 
 function Get-ComposeArgs {
@@ -910,6 +1064,8 @@ Export-ModuleMember -Function @(
     'Get-SupportedIsolationMode', 'Write-UnusedWorkspacePathWarning',
     'Test-IsolatedNetworkModeKnown', 'Get-IsolatedNetworkModeSummary',
     'Get-IsolatedNetworkMode',
+    # Container resource envelope
+    'ConvertTo-MebibyteCount', 'Get-NodeHeapHeadroomMib', 'Resolve-NodeHeapMib',
     # .env
     'Read-EnvFile', 'Get-EnvValue', 'Write-EnvContent', 'Set-EnvValue',
     # Docker Compose

--- a/scripts/generate-compose.ps1
+++ b/scripts/generate-compose.ps1
@@ -138,6 +138,24 @@ $CpuReservation = Resolve-EnvOrDefault 'CONTAINER_CPU_RESERVATION' '1'
 $MemLimit       = Resolve-EnvOrDefault 'CONTAINER_MEM_LIMIT' '4G'
 $MemReservation = Resolve-EnvOrDefault 'CONTAINER_MEM_RESERVATION' '2G'
 
+# Node old-space limit, derived from the memory cap unless it is set
+# explicitly. This one does NOT reproduce its historical value: the old
+# hardcoded 4096 MiB heap sat exactly on the 4G cap, which is the defect issue
+# #335 records rather than a default worth preserving. Regenerating lowers the
+# heap to 3072 MiB at the default cap.
+#
+# Validated here, next to GH_AUTH_MODE and ISOLATION_MODE, for the same
+# reason: the pair (cap, heap) is baked into the output as two literals, so a
+# combination that would OOM-kill has to be rejected before the first output
+# file is opened rather than discovered by a container dying under load.
+try {
+    $NodeHeapMb = Resolve-NodeHeapMib -MemLimit $MemLimit -ConfiguredHeapMb (Resolve-EnvOrDefault 'CONTAINER_NODE_HEAP_MB' '')
+}
+catch {
+    Write-Error $_.Exception.Message
+    exit 1
+}
+
 # GitHub authentication is shared by default for backward compatibility.
 # Validate per-account mappings before opening any output file so failures do
 # not leave partially regenerated compose files behind.
@@ -314,7 +332,11 @@ function Get-AccountEnvironmentLines {
     if ($AgentRuntime -eq 'claude') {
         $lines.Add('      - CLAUDE_NORMALIZE_CRLF=${CLAUDE_NORMALIZE_CRLF:-}')
     }
-    $lines.Add('      - NODE_OPTIONS=--max-old-space-size=4096')
+    # Baked as a literal, like the memory cap it is derived from. Emitting
+    # ${CONTAINER_NODE_HEAP_MB:-...} instead would let the heap be changed in
+    # .env without the cap moving with it, which is precisely the pairing this
+    # value is validated to preserve.
+    $lines.Add("      - NODE_OPTIONS=--max-old-space-size=${NodeHeapMb}")
     # Only emit provider API keys when a per-account key is set at
     # generate time. Emitting an empty key makes SDKs prefer the blank env
     # var over persisted credentials in the mounted state dir. The variable

--- a/scripts/generate-compose.sh
+++ b/scripts/generate-compose.sh
@@ -37,6 +37,8 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 . "$SCRIPT_DIR/lib/runtime.sh"
 # shellcheck source=lib/isolation.sh
 . "$SCRIPT_DIR/lib/isolation.sh"
+# shellcheck source=lib/resources.sh
+. "$SCRIPT_DIR/lib/resources.sh"
 
 # --- Read configuration -------------------------------------------------------
 
@@ -100,6 +102,18 @@ CPU_LIMIT="${CONTAINER_CPU_LIMIT:-2}"
 CPU_RESERVATION="${CONTAINER_CPU_RESERVATION:-1}"
 MEM_LIMIT="${CONTAINER_MEM_LIMIT:-4G}"
 MEM_RESERVATION="${CONTAINER_MEM_RESERVATION:-2G}"
+
+# Node old-space limit, derived from the memory cap unless it is set
+# explicitly. This one does NOT reproduce its historical value: the old
+# hardcoded 4096 MiB heap sat exactly on the 4G cap, which is the defect
+# issue #335 records rather than a default worth preserving. Regenerating
+# lowers the heap to 3072 MiB at the default cap.
+#
+# Validated here, next to GH_AUTH_MODE and ISOLATION_MODE, for the same
+# reason: the pair (cap, heap) is baked into the output as two literals, so a
+# combination that would OOM-kill has to be rejected before the first output
+# file is opened rather than discovered by a container dying under load.
+NODE_HEAP_MB="$(resolve_node_heap_mib "$MEM_LIMIT" "${CONTAINER_NODE_HEAP_MB:-}")" || exit 1
 
 # GitHub authentication is shared by default for backward compatibility.
 # Per-account mode is validated before any compose file is opened so a missing
@@ -246,7 +260,11 @@ emit_account_environment() {
     if [[ "$AGENT_RUNTIME" == "claude" ]]; then
         echo "      - CLAUDE_NORMALIZE_CRLF=\${CLAUDE_NORMALIZE_CRLF:-}"
     fi
-    echo "      - NODE_OPTIONS=--max-old-space-size=4096"
+    # Baked as a literal, like the memory cap it is derived from. Emitting
+    # \${CONTAINER_NODE_HEAP_MB:-...} instead would let the heap be changed in
+    # .env without the cap moving with it, which is precisely the pairing this
+    # value is validated to preserve.
+    echo "      - NODE_OPTIONS=--max-old-space-size=${NODE_HEAP_MB}"
 
     # Only emit provider API keys when a per-account key is set at
     # generate time. Emitting an empty key makes SDKs prefer the

--- a/scripts/lib/resources.sh
+++ b/scripts/lib/resources.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# resources.sh — Container resource envelope helpers for bash callers.
+#
+# Library file meant to be `source`d, but the shebang serves as an
+# unambiguous shell directive for tooling (shellcheck SC2148).
+#
+# The generated compose files carry two memory settings that have to agree:
+#
+#   deploy.resources.limits.memory  the cap the kernel enforces on the whole
+#                                   container (CONTAINER_MEM_LIMIT)
+#   NODE_OPTIONS=--max-old-space-size=N
+#                                   the ceiling V8 lets its old space grow to
+#                                   before it gives up and throws
+#
+# Until issue #335 both were fixed values that happened to be equal: a 4 GiB
+# cap and a 4096 MiB heap. That is not a safe pair. The old space is only one
+# of several things inside the container's memory cgroup -- V8's other heap
+# spaces, native allocations from node modules, every subprocess an agent
+# spawns (git, ripgrep, package managers, compilers) and the page cache for
+# the bind mounts all draw on the same cap. A heap allowed to reach the cap on
+# its own means the container is killed by the OOM killer at some point before
+# V8 ever reaches the limit that would have made it collect garbage instead.
+# An OOM kill is also the less useful of the two failures: it takes the whole
+# container down with no JavaScript stack, where the heap limit surfaces as a
+# catchable allocation error in the process that caused it.
+#
+# So the heap limit is derived from the cap rather than set beside it, and an
+# explicitly configured value is checked against the cap before any compose
+# file is written.
+#
+# Public functions:
+#   resource_mib_from_byte_value VALUE     # Compose byte value -> whole MiB
+#   node_heap_headroom_mib CAP_MIB         # headroom this cap should reserve
+#   resolve_node_heap_mib CAP [HEAP_MB]    # validated heap in MiB, or fail
+#
+# Requires: nothing. Deliberately free of .env lookups so the arithmetic can
+# be exercised directly; callers pass the resolved values in.
+
+# Guard against double-sourcing.
+if [[ -n "${_CLAUDE_DOCKER_RESOURCES_SH_SOURCED:-}" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+_CLAUDE_DOCKER_RESOURCES_SH_SOURCED=1
+
+# Smallest slice of the container memory cap that must stay outside the Node
+# heap. A floor rather than the whole rule: a percentage alone collapses to
+# nothing on small caps, where the fixed costs (V8 itself, the runtime's own
+# node processes, git) do not shrink with the cap.
+NODE_HEAP_MIN_HEADROOM_MIB=512
+
+# Fraction of the cap reserved when that is larger than the floor, expressed
+# as a divisor: 4 means a quarter of the cap.
+#
+# 25% is a convention, not a measurement. Nothing in this repository has yet
+# measured the steady-state non-heap footprint of an agent container, and the
+# benchmark matrix that would (issue #335, "1/2/4-account benchmark results")
+# is still open. It is stated here as a convention on purpose, so that
+# replacing it later is a matter of substituting a measured number rather than
+# discovering what the number was supposed to mean.
+NODE_HEAP_HEADROOM_DIVISOR=4
+
+# Fractional digits kept when a byte value carries a decimal point. Three is
+# 1 MiB of precision at GiB scale, and it is also what keeps the arithmetic
+# inside a signed 64-bit integer at the largest unit this accepts: 999 * 1 PiB
+# is 1.1e18, where a fourth digit would overflow.
+RESOURCE_FRACTION_DIGITS=3
+
+# resource_mib_from_byte_value VALUE
+# Print VALUE as a whole number of MiB, or return 1 without printing.
+#
+# The accepted syntax is the one Docker itself parses (go-units.RAMInBytes,
+# reached through deploy.resources.limits.memory): a number with an optional
+# k/m/g/t/p scale, an optional `i`, an optional `b`, and optional spaces, all
+# case-insensitive -- 4G, 4g, 4GB, 4GiB, 4 g and 4294967296 are the same
+# value. Decimals are accepted for the same reason: `1.5G` is a working
+# CONTAINER_MEM_LIMIT today, and this validator has no business rejecting a
+# cap that Docker would have taken.
+#
+# The result is floored, which is the conservative direction for every caller
+# here: a cap of 1536k floors to 1 MiB rather than rounding up to 2, so a
+# headroom check reads the cap as smaller than it is and never as larger.
+resource_mib_from_byte_value() {
+    local raw="${1:-}"
+    local value int_part frac scale mult bytes denom
+
+    value="$(printf '%s' "$raw" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+    [[ -n "$value" ]] || return 1
+
+    # Group 1 whole part, group 3 fractional digits, group 5 the scale letter
+    # (empty for plain bytes, whether written as `4` or `4b`).
+    if [[ "$value" =~ ^([0-9]+)(\.([0-9]+))?(([kmgtp])i?b?|b)?$ ]]; then
+        int_part="${BASH_REMATCH[1]}"
+        frac="${BASH_REMATCH[3]}"
+        scale="${BASH_REMATCH[5]}"
+    else
+        return 1
+    fi
+
+    case "$scale" in
+        '')  mult=1 ;;
+        k)   mult=1024 ;;
+        m)   mult=$(( 1024 ** 2 )) ;;
+        g)   mult=$(( 1024 ** 3 )) ;;
+        t)   mult=$(( 1024 ** 4 )) ;;
+        p)   mult=$(( 1024 ** 5 )) ;;
+    esac
+
+    bytes=$(( int_part * mult ))
+    if [[ -n "$frac" ]]; then
+        frac="${frac:0:RESOURCE_FRACTION_DIGITS}"
+        denom=$(( 10 ** ${#frac} ))
+        # 10# forces base 10: a fraction like .05 arrives as the string 05,
+        # which bash arithmetic would otherwise read as octal.
+        bytes=$(( bytes + (10#$frac * mult) / denom ))
+    fi
+
+    printf '%s' "$(( bytes / 1024 / 1024 ))"
+}
+
+# node_heap_headroom_mib CAP_MIB
+# Print the number of MiB that should stay outside the Node heap for a
+# container capped at CAP_MIB.
+node_heap_headroom_mib() {
+    local cap_mib="${1:-0}"
+    local headroom=$(( cap_mib / NODE_HEAP_HEADROOM_DIVISOR ))
+
+    if (( headroom < NODE_HEAP_MIN_HEADROOM_MIB )); then
+        headroom=$NODE_HEAP_MIN_HEADROOM_MIB
+    fi
+
+    printf '%s' "$headroom"
+}
+
+# resolve_node_heap_mib MEM_LIMIT [CONFIGURED_HEAP_MB]
+# Print the Node old-space limit, in MiB, for a container whose memory cap is
+# MEM_LIMIT. With CONFIGURED_HEAP_MB empty the value is derived from the cap;
+# otherwise CONFIGURED_HEAP_MB is used as given. Either way the result is
+# checked against the cap.
+#
+# Diagnostics go to stderr and the function returns 1, so a caller can treat
+# it exactly like the other generator-side validators: refuse to open the
+# first output file rather than write a stack that OOM-kills at run time.
+resolve_node_heap_mib() {
+    local mem_limit="${1:-}" configured="${2:-}"
+    local cap_mib heap headroom
+
+    if ! cap_mib="$(resource_mib_from_byte_value "$mem_limit")"; then
+        echo "Error: CONTAINER_MEM_LIMIT must be a byte value such as 4G, 4096m or 4294967296 (got: ${mem_limit})" >&2
+        return 1
+    fi
+
+    # Checked before the heap so that the advice below can always name a
+    # positive ceiling to lower the heap to.
+    if (( cap_mib <= NODE_HEAP_MIN_HEADROOM_MIB )); then
+        echo "Error: CONTAINER_MEM_LIMIT=${mem_limit} (${cap_mib} MiB) leaves no room for a Node heap." >&2
+        echo "       At least ${NODE_HEAP_MIN_HEADROOM_MIB} MiB of the cap must stay outside the heap, so the cap has to exceed that." >&2
+        return 1
+    fi
+
+    if [[ -n "$configured" ]]; then
+        if [[ ! "$configured" =~ ^[0-9]+$ ]] || (( configured == 0 )); then
+            echo "Error: CONTAINER_NODE_HEAP_MB must be a positive whole number of MiB (got: ${configured})" >&2
+            return 1
+        fi
+        heap="$configured"
+    else
+        local reserved
+        reserved="$(node_heap_headroom_mib "$cap_mib")"
+        heap=$(( cap_mib - reserved ))
+    fi
+
+    headroom=$(( cap_mib - heap ))
+    if (( headroom < NODE_HEAP_MIN_HEADROOM_MIB )); then
+        echo "Error: the Node heap limit does not leave enough of the container memory cap free." >&2
+        echo "       CONTAINER_MEM_LIMIT=${mem_limit} is ${cap_mib} MiB; a ${heap} MiB heap leaves ${headroom} MiB, and at least ${NODE_HEAP_MIN_HEADROOM_MIB} MiB is required." >&2
+        echo "       Set CONTAINER_NODE_HEAP_MB to at most $(( cap_mib - NODE_HEAP_MIN_HEADROOM_MIB )), or raise CONTAINER_MEM_LIMIT." >&2
+        return 1
+    fi
+
+    printf '%s' "$heap"
+}

--- a/tests/lib/compose_assert.sh
+++ b/tests/lib/compose_assert.sh
@@ -294,6 +294,13 @@ duplicate_writable_sources() {
 #
 # Either field is empty when the service does not declare it, which callers
 # should treat as a failure rather than as "no assertion applies".
+#
+# The heap extraction guards `capture` with `test` rather than suppressing its
+# no-match error with the optional operator. `capture(...)?.mib` reads better
+# and works locally on jq 1.8, but optional chaining is a 1.8 addition and
+# ubuntu-latest ships 1.7.1, which rejects it at parse time -- so the whole
+# filter fails to compile and every field comes back empty. Nothing here needs
+# syntax newer than jq 1.5.
 resolved_memory_envelope() {
     local dir="$1" service="$2"
     shift 2
@@ -306,11 +313,12 @@ resolved_memory_envelope() {
     (cd "$dir" && docker compose "${file_args[@]}" config --format json) \
         | jq -r --arg svc "$service" '
             .services[$svc] as $s
-            | ($s.environment.NODE_OPTIONS // "")
-            | capture("--max-old-space-size=(?<mib>[0-9]+)")?.mib // ""
-            | . as $heap
-            | ($s.deploy.resources.limits.memory // "")
-            | (if . == "" then "" else ((tonumber / 1048576) | floor | tostring) end)
-            | "\($heap) \(.)"
+            | ($s.environment.NODE_OPTIONS // "") as $opts
+            | (if ($opts | test("--max-old-space-size=[0-9]+"))
+               then ($opts | capture("--max-old-space-size=(?<mib>[0-9]+)") | .mib)
+               else "" end) as $heap
+            | ($s.deploy.resources.limits.memory // "") as $mem
+            | (if $mem == "" then "" else (($mem | tonumber) / 1048576 | floor | tostring) end) as $cap
+            | "\($heap) \($cap)"
         '
 }

--- a/tests/lib/compose_assert.sh
+++ b/tests/lib/compose_assert.sh
@@ -278,3 +278,39 @@ duplicate_writable_sources() {
         | sort \
         | uniq -d
 }
+
+# resolved_memory_envelope DIR SERVICE FILE...
+# Print "HEAP_MIB CAP_MIB" for SERVICE in the resolved model: the heap ceiling
+# carried by NODE_OPTIONS and the container memory cap, both in MiB.
+#
+# Compose normalizes each of these away from the form the generator wrote.
+# `memory: 4G` resolves to the byte-count string "4294967296", and the
+# environment list resolves to an object, so neither value can be read out of
+# the generated YAML in the shape it is asserted in here.
+#
+# Printing this environment value is safe in a way the generic helper's
+# key-only rule is not: NODE_OPTIONS is a resource setting, and the whole point
+# of the assertion is the number it carries.
+#
+# Either field is empty when the service does not declare it, which callers
+# should treat as a failure rather than as "no assertion applies".
+resolved_memory_envelope() {
+    local dir="$1" service="$2"
+    shift 2
+
+    local file_args=() f
+    for f in "$@"; do
+        file_args+=(-f "$f")
+    done
+
+    (cd "$dir" && docker compose "${file_args[@]}" config --format json) \
+        | jq -r --arg svc "$service" '
+            .services[$svc] as $s
+            | ($s.environment.NODE_OPTIONS // "")
+            | capture("--max-old-space-size=(?<mib>[0-9]+)")?.mib // ""
+            | . as $heap
+            | ($s.deploy.resources.limits.memory // "")
+            | (if . == "" then "" else ((tonumber / 1048576) | floor | tostring) end)
+            | "\($heap) \(.)"
+        '
+}

--- a/tests/test_container_memory.ps1
+++ b/tests/test_container_memory.ps1
@@ -1,0 +1,179 @@
+# test_container_memory.ps1 — Node heap limit arithmetic parity for the
+# PowerShell layer (issue #335, stage 5).
+#
+# Run:  pwsh -NoProfile -File tests/test_container_memory.ps1
+# Exits non-zero on any failure.
+#
+# The bash side is covered by tests/test_container_memory.sh. This file exists
+# because a Windows user and a Linux user configuring the same repository must
+# get the same heap: the two implementations are independent, and the ways they
+# can drift are quiet ones. Both parse a byte value by hand, and PowerShell
+# differs from bash in exactly the places this arithmetic touches -- a [long]
+# cast rounds half to even where bash truncates, [int] overflows at 2 GiB where
+# bash does not, and a regex group that did not participate is absent from
+# $Matches rather than present and empty. Each of those produces a number
+# rather than an error, so the tables below are deliberately the same tables
+# the bash test asserts.
+#
+# Generator sequencing is asserted on the bash side only: generate-compose.ps1
+# is Windows-only by design, and this suite runs on Linux in CI.
+#
+# Every value here is a size; no test writes or prints a credential.
+
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent $ScriptDir
+
+Import-Module (Join-Path $ProjectRoot 'scripts' 'ClaudeDocker.psm1') -Force
+
+$script:Pass = 0
+$script:Fail = 0
+
+function Assert-Eq {
+    param(
+        [Parameter(Mandatory)][string]$Label,
+        [Parameter(Mandatory)][AllowEmptyString()][AllowNull()][object]$Expected,
+        [Parameter(Mandatory)][AllowEmptyString()][AllowNull()][object]$Actual
+    )
+    if ([string]$Expected -eq [string]$Actual) {
+        Write-Host ("  PASS  {0}" -f $Label)
+        $script:Pass++
+    } else {
+        Write-Host ("  FAIL  {0}`n        expected: {1}`n        actual:   {2}" -f `
+            $Label, ([string]$Expected), ([string]$Actual))
+        $script:Fail++
+    }
+}
+
+function Assert-Throws {
+    param(
+        [Parameter(Mandatory)][string]$Label,
+        [Parameter(Mandatory)][scriptblock]$Action
+    )
+    try {
+        & $Action | Out-Null
+        Write-Host ("  FAIL  {0}`n        expected a terminating error, got none" -f $Label)
+        $script:Fail++
+    }
+    catch {
+        Write-Host ("  PASS  {0}" -f $Label)
+        $script:Pass++
+    }
+}
+
+Write-Host '== ConvertTo-MebibyteCount =='
+
+# The accepted syntax is not this project's invention: it is what Docker's own
+# go-units parser takes for deploy.resources.limits.memory. Narrowing it here
+# and not in bash, or the other way round, makes the same .env generate on one
+# platform and fail on the other.
+# A list of pairs rather than a hashtable: PowerShell hash literal keys are
+# case-insensitive, so '4G' and '4g' would collide -- in the very table whose
+# purpose is asserting that case does not change the result.
+$accepted = @(
+    @('4G', 4096),
+    @('4g', 4096),
+    @('4GB', 4096),
+    @('4gb', 4096),
+    @('4GiB', 4096),
+    @('4 G', 4096),
+    @('4096m', 4096),
+    @('4096M', 4096),
+    @('4194304k', 4096),
+    @('4294967296', 4096),
+    @('4294967296b', 4096),
+    @('1.5G', 1536),
+    @('0.5G', 512),
+    @('2.25G', 2304),
+    # Not extra coverage of the same thing. 1.08G pins base-10 reading of the
+    # fraction -- its bash mirror would read 08 as an invalid octal literal
+    # without an explicit prefix -- and 1.9999G pins the documented precision
+    # cap: the fraction is truncated to three digits, so it resolves the same
+    # as 1.999G rather than overflowing at the largest accepted unit.
+    @('1.08G', 1105),
+    @('1.9999G', 2046),
+    @('1T', 1048576),
+    @('1536k', 1)
+)
+foreach ($case in $accepted) {
+    Assert-Eq ("parse: {0} -> {1} MiB" -f $case[0], $case[1]) `
+        $case[1] (ConvertTo-MebibyteCount -Value $case[0])
+}
+
+# Rejected inputs return $null rather than throwing, so the caller can name the
+# key the value came from. The wrong number here would be worse than no number:
+# it silently moves the cap the heap is validated against.
+foreach ($bad in @('', 'bogus', '-1', '4x', '4bb', 'G4', '4G4', '1..5G', '4,096m')) {
+    Assert-Eq ("parse: '{0}' rejected" -f $bad) $true `
+        ($null -eq (ConvertTo-MebibyteCount -Value $bad))
+}
+
+Write-Host '== Get-NodeHeapHeadroomMib =='
+
+# The floor is what makes small caps safe: a flat 25% would leave 256 MiB of a
+# 1 GiB container for everything that is not the JavaScript heap, and the fixed
+# costs -- V8 itself, the runtime's node processes, git -- do not shrink with
+# the cap.
+Assert-Eq 'headroom: floor applies at a 1024 MiB cap' 512 (Get-NodeHeapHeadroomMib -CapMib 1024)
+Assert-Eq 'headroom: proportion applies at an 8192 MiB cap' 2048 (Get-NodeHeapHeadroomMib -CapMib 8192)
+
+Write-Host '== Resolve-NodeHeapMib =='
+
+$derived = @(
+    @('1G', 512),
+    @('2G', 1536),
+    @('4G', 3072),
+    @('8G', 6144),
+    @('16G', 12288),
+    @('1024m', 512),
+    @('513m', 1)
+)
+foreach ($case in $derived) {
+    Assert-Eq ("derive: cap {0} -> heap {1} MiB" -f $case[0], $case[1]) `
+        $case[1] (Resolve-NodeHeapMib -MemLimit $case[0])
+}
+
+# A cap at or below the headroom floor has no valid heap at all.
+foreach ($cap in @('512m', '256m')) {
+    Assert-Throws ("derive: cap {0} refused" -f $cap) { Resolve-NodeHeapMib -MemLimit $cap }
+}
+Assert-Throws 'derive: unparseable cap refused' { Resolve-NodeHeapMib -MemLimit 'four-gigs' }
+
+# An explicitly configured heap is used as given when it fits, and refused when
+# it does not. The boundary is exact on purpose: one MiB either side of it
+# decides whether a stack is generated at all.
+Assert-Eq 'explicit: 3584 MiB accepted at a 4G cap (exactly 512 MiB headroom)' `
+    3584 (Resolve-NodeHeapMib -MemLimit '4G' -ConfiguredHeapMb '3584')
+Assert-Throws 'explicit: 3585 MiB refused at a 4G cap (511 MiB headroom)' `
+    { Resolve-NodeHeapMib -MemLimit '4G' -ConfiguredHeapMb '3585' }
+foreach ($bad in @('0', '-512', 'abc', '3.5')) {
+    Assert-Throws ("explicit: heap '{0}' rejected" -f $bad) `
+        { Resolve-NodeHeapMib -MemLimit '4G' -ConfiguredHeapMb $bad }
+}
+
+# The diagnostic has to name the key the user changes. A refusal that says only
+# "invalid" leaves them editing the wrong line.
+try {
+    Resolve-NodeHeapMib -MemLimit '4G' -ConfiguredHeapMb '4096' | Out-Null
+    Assert-Eq 'diagnostic: names CONTAINER_NODE_HEAP_MB' $true $false
+}
+catch {
+    Assert-Eq 'diagnostic: names CONTAINER_NODE_HEAP_MB' $true `
+        ($_.Exception.Message -like '*CONTAINER_NODE_HEAP_MB*')
+}
+try {
+    Resolve-NodeHeapMib -MemLimit '384m' | Out-Null
+    Assert-Eq 'diagnostic: names CONTAINER_MEM_LIMIT' $true $false
+}
+catch {
+    Assert-Eq 'diagnostic: names CONTAINER_MEM_LIMIT' $true `
+        ($_.Exception.Message -like '*CONTAINER_MEM_LIMIT*')
+}
+
+Write-Host ''
+Write-Host ("== Summary: PASS={0} FAIL={1} ==" -f $script:Pass, $script:Fail)
+if ($script:Fail -gt 0) { exit 1 }
+exit 0

--- a/tests/test_container_memory.sh
+++ b/tests/test_container_memory.sh
@@ -1,0 +1,385 @@
+#!/usr/bin/env bash
+# test_container_memory.sh -- Node heap limit against the container memory cap
+# (issue #335, stage 5).
+#
+# The generated compose files carry two numbers that have to agree: the cgroup
+# memory cap and the ceiling V8 is allowed to grow its old space to. Before
+# this they were independent literals that happened to be equal -- a 4 GiB cap
+# and a 4096 MiB heap -- so a container reached the OOM killer before V8
+# reached the limit that would have made it collect garbage instead.
+#
+# What is under test is therefore a relationship, not a value, and it fails
+# quietly in both directions:
+#
+# 1. Arithmetic. A parser that rejects `1.5G`, or reads `4G` as 4 bytes, turns
+#    a working installation into a failed generation or an unguarded heap.
+#    Section 1 pins the accepted syntax against what Docker itself parses.
+#
+# 2. Sequencing. The pair is baked into the output as two literals, so an
+#    unusable combination has to be refused before the first output file is
+#    opened. Section 3 asserts the refusal AND that nothing was written -- a
+#    validator that runs halfway through generation leaves a stack whose two
+#    numbers disagree, which is worse than the state it replaced.
+#
+# 3. Resolution. `memory: 4G` resolves to a byte-count string and the
+#    environment list resolves to an object, so section 4 reads both from
+#    `docker compose config` rather than from the YAML the generator wrote.
+#
+# Every generator runs inside a throwaway sandbox holding only the files it
+# reads. The committed compose files are digested before and after as an
+# observable guard, the same protocol test_isolation_modes.sh uses.
+#
+# No fixture carries a credential; the only values here are sizes.
+#
+# Run:  bash tests/test_container_memory.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/compose_assert.sh
+. "$SCRIPT_DIR/lib/compose_assert.sh"
+# shellcheck source=../scripts/lib/resources.sh
+. "$PROJECT_ROOT/scripts/lib/resources.sh"
+
+OUTPUTS=(
+    docker-compose.yml
+    docker-compose.worktree.yml
+    docker-compose.isolated.yml
+    docker-compose.linux.yml
+)
+
+PLACEHOLDER_HOME="/tmp/claude-docker-memory-home"
+PLACEHOLDER_PROJECT="/tmp/claude-docker-memory-project"
+PLACEHOLDER_ISO_A="/tmp/claude-docker-memory-clone-a"
+PLACEHOLDER_ISO_B="/tmp/claude-docker-memory-clone-b"
+
+PASS=0
+FAIL=0
+
+pass() { printf '  PASS  %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  FAIL  %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+# The bash generator refuses to run on native Windows shells, so this test is
+# a Linux/macOS/WSL one. Say so rather than reporting failures the caller has
+# no way to act on.
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+        echo "NOTE: generate-compose.sh does not run on native Windows shells; use WSL." >&2
+        echo "== Summary: SKIPPED (native Windows shell) =="
+        exit 0 ;;
+esac
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+compose_digest() {
+    local f
+    for f in "${OUTPUTS[@]}"; do
+        if [[ -f "$PROJECT_ROOT/$f" ]]; then
+            cksum <"$PROJECT_ROOT/$f"
+        else
+            echo "absent $f"
+        fi
+    done
+}
+DIGEST_BEFORE="$(compose_digest)"
+
+# make_bare_sandbox NAME -- project root holding only what a generator reads,
+# with no compose files present. scripts/ is copied wholesale so the sandbox
+# stays correct when a new lib module is added.
+make_bare_sandbox() {
+    local dir="$WORK/$1"
+    mkdir -p "$dir/tui/internal/config"
+    cp -r "$PROJECT_ROOT/scripts" "$dir/scripts"
+    cp "$PROJECT_ROOT/tui/internal/config/runtimes.json" "$dir/tui/internal/config/"
+    [[ -f "$PROJECT_ROOT/VERSION" ]] && cp "$PROJECT_ROOT/VERSION" "$dir/"
+    printf '%s' "$dir"
+}
+
+# write_env DIR LINE...  -- stage a placeholder .env in a sandbox.
+write_env() {
+    local dir="$1"
+    shift
+    printf '%s\n' "$@" >"$dir/.env"
+}
+
+# run_generator DIR -- run the bash generator in DIR with the caller's memory
+# keys cleared first, so a value left in the developer's shell cannot change
+# what a case means. Output lands in DIR/.gen.log; the exit status is returned.
+run_generator() {
+    local dir="$1"
+    local rc=0
+    env -u CONTAINER_MEM_LIMIT -u CONTAINER_NODE_HEAP_MB -u NUM_ACCOUNTS \
+        -u ISOLATION_MODE -u ISOLATED_WORKSPACE_A \
+        bash "$dir/scripts/generate-compose.sh" >"$dir/.gen.log" 2>&1 || rc=$?
+    return "$rc"
+}
+
+# assert_no_output_written DIR LABEL -- fail when a refused generation left any
+# compose file behind. The sandbox starts with none, so any file at all is a
+# partial write.
+assert_no_output_written() {
+    local dir="$1" label="$2"
+    local found=() f
+    for f in "${OUTPUTS[@]}"; do
+        [[ -f "$dir/$f" ]] && found+=("$f")
+    done
+    if [[ "${#found[@]}" -eq 0 ]]; then
+        pass "$label: nothing written"
+    else
+        fail "$label: partial output left behind (${found[*]})"
+    fi
+}
+
+# --- 1. Byte-value parsing ----------------------------------------------------
+#
+# The accepted syntax is not this project's invention: it is what Docker's own
+# go-units parser takes for deploy.resources.limits.memory. Narrowing it would
+# make generation fail on caps that work today, which is a regression this
+# change has no reason to introduce.
+
+echo "== byte-value parsing =="
+
+# INPUT|EXPECTED_MIB
+while IFS='|' read -r input expected; do
+    [[ -n "$input" ]] || continue
+    actual="$(resource_mib_from_byte_value "$input" || echo REJECTED)"
+    if [[ "$actual" == "$expected" ]]; then
+        pass "parse: $input -> $expected MiB"
+    else
+        fail "parse: $input -> $actual MiB (want $expected)"
+    fi
+done <<'EOF'
+4G|4096
+4g|4096
+4GB|4096
+4gb|4096
+4GiB|4096
+4 G|4096
+4096m|4096
+4096M|4096
+4194304k|4096
+4294967296|4096
+4294967296b|4096
+1.5G|1536
+0.5G|512
+2.25G|2304
+1.08G|1105
+1.9999G|2046
+1T|1048576
+1536k|1
+EOF
+
+# The last two rows above are not extra coverage of the same thing.
+#
+# 1.08G pins base-10 reading of the fraction: bash arithmetic treats a leading
+# zero as octal, and 08 is not a valid octal literal, so dropping the 10#
+# prefix turns this input into a hard error rather than a wrong number.
+#
+# 1.9999G pins the documented precision cap. The fraction is truncated to
+# three digits, so this resolves the same as 1.999G -- deliberate, because a
+# longer fraction at the largest accepted unit overflows a signed 64-bit
+# integer, and an overflowed cap is a silently wrong one.
+
+# Rejected inputs. Each would otherwise be read as some number, and the wrong
+# number here is worse than no number: it silently moves the cap the heap is
+# validated against.
+for bad in "" "bogus" "-1" "4x" "4bb" "G4" "4G4" "1..5G" "4,096m"; do
+    if resource_mib_from_byte_value "$bad" >/dev/null 2>&1; then
+        fail "parse: '$bad' accepted, should be rejected"
+    else
+        pass "parse: '$bad' rejected"
+    fi
+done
+
+# --- 2. Heap derivation -------------------------------------------------------
+
+echo "== heap derivation =="
+
+while IFS='|' read -r cap expected; do
+    [[ -n "$cap" ]] || continue
+    actual="$(resolve_node_heap_mib "$cap" 2>/dev/null || echo REJECTED)"
+    if [[ "$actual" == "$expected" ]]; then
+        pass "derive: cap $cap -> heap $expected MiB"
+    else
+        fail "derive: cap $cap -> heap $actual MiB (want $expected)"
+    fi
+done <<'EOF'
+1G|512
+2G|1536
+4G|3072
+8G|6144
+16G|12288
+1024m|512
+513m|1
+512m|REJECTED
+256m|REJECTED
+EOF
+
+# The floor is what makes small caps safe: a flat 25% would leave 256 MiB of a
+# 1 GiB container for everything that is not the JavaScript heap, and the fixed
+# costs -- V8 itself, the runtime's node processes, git -- do not shrink with
+# the cap.
+if [[ "$(node_heap_headroom_mib 1024)" == "512" && "$(node_heap_headroom_mib 8192)" == "2048" ]]; then
+    pass "headroom: floor applies below 2G, proportion above it"
+else
+    fail "headroom: want 512 at 1024 MiB and 2048 at 8192 MiB, got $(node_heap_headroom_mib 1024) and $(node_heap_headroom_mib 8192)"
+fi
+
+# An explicitly configured heap is used as given when it fits, and refused when
+# it does not. The boundary is exact on purpose: one MiB either side of it
+# decides whether a container is generated at all.
+if [[ "$(resolve_node_heap_mib 4G 3584 2>/dev/null)" == "3584" ]]; then
+    pass "explicit: 3584 MiB heap accepted at a 4G cap (exactly 512 MiB headroom)"
+else
+    fail "explicit: 3584 MiB heap refused at a 4G cap"
+fi
+if resolve_node_heap_mib 4G 3585 >/dev/null 2>&1; then
+    fail "explicit: 3585 MiB heap accepted at a 4G cap (511 MiB headroom)"
+else
+    pass "explicit: 3585 MiB heap refused at a 4G cap"
+fi
+for bad in 0 -512 abc 3.5; do
+    if resolve_node_heap_mib 4G "$bad" >/dev/null 2>&1; then
+        fail "explicit: heap '$bad' accepted"
+    else
+        pass "explicit: heap '$bad' rejected"
+    fi
+done
+
+# --- 3. Generator sequencing --------------------------------------------------
+
+echo "== generator =="
+
+dir="$(make_bare_sandbox gen-default)"
+write_env "$dir" "HOME=$PLACEHOLDER_HOME" "PROJECT_DIR=$PLACEHOLDER_PROJECT"
+if run_generator "$dir"; then
+    if grep -q -- '--max-old-space-size=3072' "$dir/docker-compose.yml" &&
+       grep -q -- '--max-old-space-size=3072' "$dir/docker-compose.isolated.yml"; then
+        pass "default: 4G cap yields a 3072 MiB heap in both stacks"
+    else
+        fail "default: heap is not 3072 MiB in both stacks"
+    fi
+else
+    fail "default: generation failed"
+    cat "$dir/.gen.log" >&2
+fi
+
+dir="$(make_bare_sandbox gen-custom-cap)"
+write_env "$dir" "HOME=$PLACEHOLDER_HOME" "PROJECT_DIR=$PLACEHOLDER_PROJECT" \
+    "CONTAINER_MEM_LIMIT=8G"
+if run_generator "$dir" && grep -q -- '--max-old-space-size=6144' "$dir/docker-compose.yml"; then
+    pass "custom cap: 8G yields a 6144 MiB heap"
+else
+    fail "custom cap: 8G did not yield a 6144 MiB heap"
+fi
+
+dir="$(make_bare_sandbox gen-explicit-heap)"
+write_env "$dir" "HOME=$PLACEHOLDER_HOME" "PROJECT_DIR=$PLACEHOLDER_PROJECT" \
+    "CONTAINER_NODE_HEAP_MB=2048"
+if run_generator "$dir" && grep -q -- '--max-old-space-size=2048' "$dir/docker-compose.yml"; then
+    pass "explicit heap: an in-range value is emitted as configured"
+else
+    fail "explicit heap: 2048 MiB not emitted"
+fi
+
+# The three refusals. Each asserts the exit status, that the diagnostic names
+# the key the user has to change, and that no file was written.
+dir="$(make_bare_sandbox gen-heap-at-cap)"
+write_env "$dir" "HOME=$PLACEHOLDER_HOME" "PROJECT_DIR=$PLACEHOLDER_PROJECT" \
+    "CONTAINER_NODE_HEAP_MB=4096"
+if run_generator "$dir"; then
+    fail "heap at cap: generation succeeded with no headroom"
+else
+    if grep -q 'CONTAINER_NODE_HEAP_MB' "$dir/.gen.log"; then
+        pass "heap at cap: refused, diagnostic names CONTAINER_NODE_HEAP_MB"
+    else
+        fail "heap at cap: refused without naming CONTAINER_NODE_HEAP_MB"
+    fi
+    assert_no_output_written "$dir" "heap at cap"
+fi
+
+dir="$(make_bare_sandbox gen-cap-too-small)"
+write_env "$dir" "HOME=$PLACEHOLDER_HOME" "PROJECT_DIR=$PLACEHOLDER_PROJECT" \
+    "CONTAINER_MEM_LIMIT=384m"
+if run_generator "$dir"; then
+    fail "tiny cap: generation succeeded with a cap below the headroom floor"
+else
+    if grep -q 'CONTAINER_MEM_LIMIT' "$dir/.gen.log"; then
+        pass "tiny cap: refused, diagnostic names CONTAINER_MEM_LIMIT"
+    else
+        fail "tiny cap: refused without naming CONTAINER_MEM_LIMIT"
+    fi
+    assert_no_output_written "$dir" "tiny cap"
+fi
+
+dir="$(make_bare_sandbox gen-bad-cap)"
+write_env "$dir" "HOME=$PLACEHOLDER_HOME" "PROJECT_DIR=$PLACEHOLDER_PROJECT" \
+    "CONTAINER_MEM_LIMIT=four-gigs"
+if run_generator "$dir"; then
+    fail "unparseable cap: generation succeeded"
+else
+    pass "unparseable cap: refused"
+    assert_no_output_written "$dir" "unparseable cap"
+fi
+
+# --- 4. Resolved model --------------------------------------------------------
+#
+# The assertion is the invariant itself rather than either literal: whatever
+# the cap is, the heap has to sit below it with the documented headroom. Read
+# from `docker compose config`, because that is the only place both numbers
+# exist in comparable units.
+
+echo "== resolved model =="
+
+if compose_assert_requires; then
+    dir="$(make_bare_sandbox resolved)"
+    write_env "$dir" "HOME=$PLACEHOLDER_HOME" "PROJECT_DIR=$PLACEHOLDER_PROJECT" \
+        "ISOLATION_MODE=isolated" \
+        "ISOLATED_WORKSPACE_A=$PLACEHOLDER_ISO_A" \
+        "ISOLATED_WORKSPACE_B=$PLACEHOLDER_ISO_B" \
+        "CONTAINER_MEM_LIMIT=6G"
+    if ! run_generator "$dir"; then
+        fail "resolved: generation failed"
+        cat "$dir/.gen.log" >&2
+    else
+        for spec in "base:claude-a:docker-compose.yml" \
+                    "base:claude-b:docker-compose.yml" \
+                    "isolated:claude-a:docker-compose.yml docker-compose.isolated.yml" \
+                    "isolated:claude-b:docker-compose.yml docker-compose.isolated.yml"; do
+            label="${spec%%:*}"
+            rest="${spec#*:}"
+            service="${rest%%:*}"
+            # shellcheck disable=SC2086  # deliberate word-split into -f arguments
+            read -r heap cap <<<"$(resolved_memory_envelope "$dir" "$service" ${rest#*:})"
+
+            if [[ -z "$heap" || -z "$cap" ]]; then
+                fail "resolved $label/$service: heap or cap missing (heap='$heap' cap='$cap')"
+            elif (( cap != 6144 )); then
+                fail "resolved $label/$service: cap resolved to $cap MiB, want 6144"
+            elif (( heap >= cap )); then
+                fail "resolved $label/$service: heap $heap MiB is not below the $cap MiB cap"
+            elif (( cap - heap < 512 )); then
+                fail "resolved $label/$service: only $(( cap - heap )) MiB of headroom"
+            else
+                pass "resolved $label/$service: heap $heap MiB under a $cap MiB cap"
+            fi
+        done
+    fi
+else
+    echo "  SKIP  resolved-model assertions (docker/jq unavailable)"
+fi
+
+# --- 5. Committed files untouched --------------------------------------------
+
+if [[ "$(compose_digest)" == "$DIGEST_BEFORE" ]]; then
+    pass "committed compose files untouched"
+else
+    fail "committed compose files were modified by this test"
+fi
+
+echo
+echo "== Summary: PASS=$PASS FAIL=$FAIL =="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## What

Derives the Node old-space limit from the container memory cap instead of
setting it beside the cap, and validates an explicitly configured value before
any compose file is written.

Merge-order stage 5 of #335 bundles five independent axes across three
languages. This is the second of them; the TUI usage-cache axis landed in #340.
They are being landed separately for the same reason stage 4 split into #338
and #339 — a regression in one axis should not have to be untangled from
another in the same CI run.

## Why

The generated stacks carried `--max-old-space-size=4096` under a `4G` cap.
Those are not two settings for the same budget: the cap bounds everything in
the container's memory cgroup, while the old-space limit bounds only the
JavaScript heap. V8's other heap spaces, native allocations from node modules,
every subprocess an agent spawns (git, ripgrep, package managers, compilers)
and the page cache for the bind mounts all draw on the cap as well.

A heap permitted to reach the cap on its own is therefore OOM-killed before V8
ever reaches the ceiling that would have made it collect garbage instead. That
is also the less useful of the two failures: an OOM kill takes the whole
container down with no JavaScript stack, where the heap limit surfaces as a
catchable allocation error in the process that caused it.

## How

`scripts/lib/resources.sh` and its PowerShell mirror in `ClaudeDocker.psm1`
resolve the heap:

| `CONTAINER_MEM_LIMIT` | Reserved | `--max-old-space-size` |
|:---|:---|:---|
| 1G | 512 MiB | 512 |
| 2G | 512 MiB | 1536 |
| 4G (default) | 1024 MiB | 3072 |
| 8G | 2048 MiB | 6144 |
| 16G | 4096 MiB | 12288 |

A quarter of the cap with a floor of 512 MiB. The floor is what makes small
caps safe — a flat percentage collapses to nothing where the fixed costs do
not shrink with the cap. The 25% is documented as a **convention rather than a
measurement**, on purpose: nothing here has measured the steady-state non-heap
footprint yet, and the benchmark matrix that would is still open in this
issue's stage 5. Stating it as a convention makes replacing it a substitution
rather than an archaeology exercise.

`CONTAINER_NODE_HEAP_MB` overrides the derivation and is checked against the
cap. The validation sits next to the existing `GH_AUTH_MODE` and
`ISOLATION_MODE` checks, for the same reason those are there: the cap and the
heap are baked into the output as two literals, so an unusable pair has to be
refused before the first output file is opened.

```
$ CONTAINER_NODE_HEAP_MB=4096 scripts/generate-compose.sh
Error: the Node heap limit does not leave enough of the container memory cap free.
       CONTAINER_MEM_LIMIT=4G is 4096 MiB; a 4096 MiB heap leaves 0 MiB, and at least 512 MiB is required.
       Set CONTAINER_NODE_HEAP_MB to at most 3584, or raise CONTAINER_MEM_LIMIT.
```

### This changes an existing default

Every other value in the resource envelope reproduces its historical setting so
that regenerating is a no-op. This one does not: the regenerated stacks carry a
3072 MiB heap where they carried 4096. That is the point — the historical value
is the defect the acceptance criterion names, and a validated default equal to
the cap is a contradiction. It is called out in the generator comments, the
README and `.env.example` so it is not mistaken for drift.

### The parser accepts what Docker accepts

`CONTAINER_MEM_LIMIT` is read by Docker's own `go-units.RAMInBytes`, which
takes decimals, the `i` infix and a space before the unit — `1.5G`, `4GiB` and
`4 g` are all valid caps today. A validator that rejected them would turn a
working installation into a failed generation, so the parser matches that
syntax rather than a narrower one. Values are floored to whole MiB, which is
the conservative direction: a cap reads as smaller than it is, never larger.

## Where

- `scripts/lib/resources.sh` (new), `scripts/ClaudeDocker.psm1`
- `scripts/generate-compose.sh`, `scripts/generate-compose.ps1`
- `docker-compose.yml`, `docker-compose.isolated.yml` (regenerated)
- `tests/test_container_memory.sh`, `tests/test_container_memory.ps1` (new),
  `tests/lib/compose_assert.sh`, `.github/workflows/ci.yml`
- `Dockerfile`, `README.md`, `.env.example`, `docs/ISOLATION.md`

## Verification

53 bash assertions and 47 PowerShell ones, deliberately over the same tables:
both implementations parse a byte value by hand, and PowerShell differs from
bash in exactly the places this arithmetic touches — a `[long]` cast rounds
half to even where bash truncates, `[int]` overflows at 2 GiB where bash does
not, and a regex group that did not participate is absent from `$Matches`
rather than present and empty. Each of those produces a number rather than an
error, which is why the tables are duplicated instead of split.

**The resolved model, not the YAML.** `memory: 4G` normalizes to the
byte-count string `"4294967296"` and the environment list normalizes to an
object, so neither number exists in the generated file in the shape the
assertion needs. `resolved_memory_envelope` reads both from
`docker compose config` and the test asserts the *invariant* — heap below cap
with at least 512 MiB free — rather than either literal, across the base and
isolated stacks for both accounts.

**Sequencing is asserted, not assumed.** Each refusal case checks the exit
status, that the diagnostic names the key the user has to change, and that no
compose file was written. A validator that ran halfway through generation would
leave a stack whose two numbers disagree, which is worse than the state it
replaces.

**Mutation-tested.** Two mutations were applied and reverted:

| Mutation | Result |
|---|---|
| Headroom check removed | exactly 2 failures: the 3585 MiB boundary and the heap-at-cap refusal |
| Fractional part ignored | exactly 3 failures: the `1.5G`, `0.5G` and `2.25G` rows |

A single localized failure means the suite points at the defect rather than
going uniformly red.

**Generator parity.** `tests/test_compose_generator_equivalence.sh` skips
without `pwsh`, which is the case in WSL, so the PowerShell generator was run
into a scratch sandbox on Windows and diffed against the bash output: all four
files identical.

Also run: `test_isolation_modes.sh` (19), `test_isolation_modes.ps1` (48),
`test_parse_env.sh` (21), `shellcheck -S warning` clean on every touched
script.

## Acceptance criteria

Ticks one criterion — "The Node heap limit is validated below the container
memory cap with documented headroom; invalid combinations fail before container
startup."

The remaining stage 5 axes (budget visibility, transactional `scale`, the
1/2/4-account benchmark matrix), stage 6, the runtime-sandbox item and the
live-container verification pass are untouched by this PR.

Relates to #335
