### PR TITLE
fix(remove): stop selecting the main worktree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,7 @@ jobs:
           - tests/test_isolation_modes.ps1
           - tests/test_container_memory.ps1
           - tests/test_powershell_platform_guard.ps1
+          - tests/test_worktree_path_guard.ps1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run ${{ matrix.test }}

--- a/scripts/ClaudeDocker.psm1
+++ b/scripts/ClaudeDocker.psm1
@@ -154,6 +154,43 @@ function ConvertTo-ForwardSlash {
     return $Path -replace '\\', '/'
 }
 
+function ConvertTo-ComparablePath {
+    <#
+    .SYNOPSIS
+    Fold a path into a form two path strings can be compared with.
+    .DESCRIPTION
+    On Windows the same directory reaches this module in two spellings:
+    `git worktree list --porcelain` emits forward slashes ("D:/Sources/x")
+    while (Get-Location).Path always emits backslashes ("D:\Sources\x").
+    Comparing those raw strings never matches, which is what let remove.ps1
+    select the repository it was standing in for deletion (#342).
+
+    Both separators fold to '/' and any trailing separator is dropped. The
+    filesystem is not consulted, so a path that no longer exists still folds.
+    Callers must pass absolute paths -- '..' segments are not resolved, and
+    every producer here (git porcelain output, Get-Location) is absolute.
+
+    Comparison by the caller is PowerShell's default case-insensitive one.
+    That is right on Windows, the only platform these removers run on; on a
+    case-sensitive filesystem it can only make two distinct worktrees look
+    equal, which skips a removal rather than performing an extra one.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$Path)
+
+    # ConvertTo-ForwardSlash rejects an empty string, and widening it would
+    # relax a contract other callers rely on to catch a missing path.
+    if ($Path -eq '') { return '' }
+
+    $folded = ConvertTo-ForwardSlash -Path $Path
+    # Trimming a root produces something that is not a path: "C:/" becomes
+    # "C:" and "/" becomes "". No worktree is ever a root, so the only job
+    # here is to leave one intact if it is passed.
+    $trimmed = $folded.TrimEnd('/')
+    if ($trimmed -eq '' -or $trimmed -match '^[A-Za-z]:$') { return $folded }
+    return $trimmed
+}
+
 # --- .env File I/O -----------------------------------------------------------
 
 function ConvertFrom-EnvLine {
@@ -1042,6 +1079,50 @@ function Get-DirectorySize {
     return [long]$size
 }
 
+# --- Worktree Selection -------------------------------------------------------
+
+function Select-RemovableWorktree {
+    <#
+    .SYNOPSIS
+    Given the worktree paths git reported and the tree the caller is standing
+    in, return only the ones that are safe to remove.
+    .DESCRIPTION
+    remove.ps1 and cleanup.ps1 both walked `git worktree list --porcelain` and
+    both excluded the current tree with a raw string comparison that cannot
+    match on Windows (#342). The decision lives here so there is one copy to
+    reason about, and so it can be exercised by a test without running either
+    remover.
+
+    Two independent guards, deliberately not one:
+
+    1. The first porcelain entry is dropped unconditionally. git documents the
+       main working tree as listed first, and it stays first even when the
+       command runs from a linked worktree -- which is exactly the case where
+       the caller's own path does not identify the repository at risk.
+    2. Anything folding to the same path as -CurrentPath is dropped. This is
+       the guard for the ordinary case, and the one the raw comparison lost.
+
+    .PARAMETER WorktreePath
+    Paths in the order `git worktree list --porcelain` reported them. Order
+    carries meaning here; do not sort before calling.
+    .PARAMETER CurrentPath
+    The tree the caller is standing in, in any separator form.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][AllowNull()][string[]]$WorktreePath,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$CurrentPath
+    )
+
+    $paths = @($WorktreePath | Where-Object { $_ })
+    if ($paths.Count -le 1) { return @() }
+
+    $current = ConvertTo-ComparablePath -Path $CurrentPath
+    return @($paths |
+        Select-Object -Skip 1 |
+        Where-Object { (ConvertTo-ComparablePath -Path $_) -ne $current })
+}
+
 # --- Exports -----------------------------------------------------------------
 
 Export-ModuleMember -Function @(
@@ -1051,7 +1132,10 @@ Export-ModuleMember -Function @(
     # Prompts
     'Read-Selection', 'Read-Input', 'Read-Secret', 'Read-Confirmation',
     # Utilities
-    'Test-Command', 'ConvertTo-ForwardSlash', 'Protect-EnvFile',
+    'Test-Command', 'ConvertTo-ForwardSlash', 'ConvertTo-ComparablePath',
+    'Protect-EnvFile',
+    # Worktrees
+    'Select-RemovableWorktree',
     # Accounts
     'Get-NumAccounts', 'Get-AgentRuntime', 'Get-ServicePrefix',
     'Get-PrimaryService', 'Get-AgentStateRoot', 'Get-ServiceNames',

--- a/scripts/cleanup.ps1
+++ b/scripts/cleanup.ps1
@@ -74,16 +74,22 @@ try {
     if ($RepoDir -and (Test-Path (Join-Path $RepoDir '.git'))) {
         Push-Location $RepoDir
         try {
-            $currentDir = (Get-Location).Path
-            $worktrees = & git worktree list --porcelain 2>$null |
+            $listed = @(& git worktree list --porcelain 2>$null |
                 Where-Object { $_ -match '^worktree (.+)$' } |
-                ForEach-Object { $Matches[1] }
+                ForEach-Object { $Matches[1] })
 
-            foreach ($wt in $worktrees) {
-                if ($wt -ne $currentDir) {
-                    Write-Host "  Removing worktree: $wt"
-                    & git worktree remove $wt --force 2>$null
-                }
+            # The raw current-directory comparison this replaces could not
+            # match on Windows -- git reports forward slashes, Get-Location
+            # backslashes -- so -RepoDir itself was offered up for removal
+            # (#342). git refuses for a main working tree, but not when
+            # -RepoDir names a linked one, which is the tree the check
+            # existed to preserve.
+            $removable = @(Select-RemovableWorktree -WorktreePath $listed `
+                -CurrentPath (Get-Location).Path)
+
+            foreach ($wt in $removable) {
+                Write-Host "  Removing worktree: $wt"
+                & git worktree remove $wt --force 2>$null
             }
         }
         finally {

--- a/scripts/remove.ps1
+++ b/scripts/remove.ps1
@@ -28,6 +28,11 @@ Import-Module "$PSScriptRoot\ClaudeDocker.psm1" -Force
 $ProjectRoot = Split-Path $PSScriptRoot -Parent
 Initialize-StepCounter -Total 7
 
+# Worktrees this run decided not to delete, or tried to and could not. The
+# closing summary reports them; it used to assert unconditionally that nothing
+# outside this repository was touched.
+$script:WorktreesLeftBehind = @()
+
 # --- Compose Command Discovery ------------------------------------------------
 
 function Get-FullComposeArgs {
@@ -111,14 +116,41 @@ function Remove-DockerImage {
     }
 }
 
+function Get-ManagedWorktreePath {
+    <#
+    .SYNOPSIS
+    Paths this installer created, folded for comparison.
+    .DESCRIPTION
+    setup-worktrees and setup-isolated record every workspace they create
+    under PROJECT_DIR_<X> / ISOLATED_WORKSPACE_<X>, so .env is the
+    authoritative list of what this tool owns. Anything outside it belongs to
+    the user and must never reach a recursive delete.
+
+    Read from .env rather than derived from NUM_ACCOUNTS: at removal time the
+    count may already have been lowered, and a workspace dropped from the
+    count is still one this tool created.
+    #>
+    param([Parameter(Mandatory)][hashtable]$EnvData)
+
+    $managed = @()
+    foreach ($key in $EnvData.Keys) {
+        if ($key -match '^(PROJECT_DIR|ISOLATED_WORKSPACE)_[A-Z]+$' -and $EnvData[$key]) {
+            $managed += (ConvertTo-ComparablePath -Path $EnvData[$key])
+        }
+    }
+    return $managed
+}
+
 function Remove-Worktrees {
     Write-LogStep 'Removing git worktrees'
 
     $projectDir = ''
+    $managedPaths = @()
     $envFile = Join-Path $ProjectRoot '.env'
     if (Test-Path $envFile) {
         $envData = Read-EnvFile -Path $envFile
         $projectDir = $envData['PROJECT_DIR']
+        $managedPaths = @(Get-ManagedWorktreePath -EnvData $envData)
     }
 
     if (-not $projectDir) {
@@ -126,7 +158,17 @@ function Remove-Worktrees {
         return
     }
 
-    if (-not (Test-Path (Join-Path $projectDir '.git'))) {
+    # In a *linked* worktree `.git` is a file, and Test-Path without -PathType
+    # accepts it. That is how a user's own repository ended up one loop
+    # iteration away from deletion: git lists the main working tree first, so
+    # standing in a linked worktree points this function at somebody else's
+    # tree. remove.sh:169 requires a directory; match it.
+    $gitPath = Join-Path $projectDir '.git'
+    if (Test-Path $gitPath -PathType Leaf) {
+        Write-LogInfo "$projectDir is a linked git worktree, not a main repository - skipping worktree removal"
+        return
+    }
+    if (-not (Test-Path $gitPath -PathType Container)) {
         Write-LogInfo "$projectDir is not a git repository - no worktrees to remove"
         return
     }
@@ -134,21 +176,45 @@ function Remove-Worktrees {
     $worktreeCount = 0
     Push-Location $projectDir
     try {
-        $currentDir = (Get-Location).Path
-        $worktrees = & git worktree list --porcelain 2>$null |
+        $listed = @(& git worktree list --porcelain 2>$null |
             Where-Object { $_ -match '^worktree (.+)$' } |
-            ForEach-Object { $Matches[1] }
+            ForEach-Object { $Matches[1] })
 
-        foreach ($wtPath in $worktrees) {
-            if ($wtPath -ne $currentDir -and (Test-Path $wtPath)) {
-                Write-LogInfo "Removing worktree: $wtPath"
-                & git worktree remove $wtPath --force 2>$null
-                if ($LASTEXITCODE -ne 0) {
-                    Write-LogWarn "Force removing: $wtPath"
-                    Remove-Item $wtPath -Recurse -Force -ErrorAction SilentlyContinue
-                    & git worktree prune 2>$null
-                }
+        $removable = @(Select-RemovableWorktree -WorktreePath $listed `
+            -CurrentPath (Get-Location).Path)
+
+        foreach ($wtPath in $removable) {
+            if (-not (Test-Path $wtPath)) { continue }
+
+            Write-LogInfo "Removing worktree: $wtPath"
+            & git worktree remove $wtPath --force 2>$null
+            if ($LASTEXITCODE -eq 0) {
                 $worktreeCount++
+                continue
+            }
+
+            # git refused. Before escalating to a recursive delete, require the
+            # path to be one this tool created -- git's refusal is often the
+            # last thing standing between the fallback and a directory that was
+            # never ours.
+            if ($managedPaths -notcontains (ConvertTo-ComparablePath -Path $wtPath)) {
+                Write-LogWarn "git refused to remove $wtPath, and it is not a workspace this installer created - left in place."
+                $script:WorktreesLeftBehind += $wtPath
+                continue
+            }
+
+            Write-LogWarn "Force removing: $wtPath"
+            try {
+                Remove-Item -LiteralPath $wtPath -Recurse -Force -ErrorAction Stop
+                & git worktree prune 2>$null
+                $worktreeCount++
+            }
+            catch {
+                # Swallowing this is what reduced a destroyed repository to one
+                # log line; a delete that fails at uninstall time is something
+                # the user has to be told about.
+                Write-LogError "Could not remove $($wtPath): $($_.Exception.Message)"
+                $script:WorktreesLeftBehind += $wtPath
             }
         }
     }
@@ -310,6 +376,15 @@ function Show-RemovalSummary {
     Write-Host '  - Docker Desktop itself'
     Write-Host '  - Your project source code'
     Write-Host ''
+
+    if ($script:WorktreesLeftBehind.Count -gt 0) {
+        Write-Host 'Worktrees left in place (review manually):' -ForegroundColor Yellow
+        foreach ($wt in $script:WorktreesLeftBehind) {
+            Write-Host "  - $wt"
+        }
+        Write-Host ''
+    }
+
     Write-Host 'To reinstall: .\scripts\install.ps1' -ForegroundColor DarkGray
     Write-Host ''
 }

--- a/tests/test_worktree_path_guard.ps1
+++ b/tests/test_worktree_path_guard.ps1
@@ -1,0 +1,149 @@
+# test_worktree_path_guard.ps1 - the path comparison that decides which git
+# worktrees remove.ps1 and cleanup.ps1 delete (issue #342).
+#
+# Run:  pwsh -NoProfile -File tests/test_worktree_path_guard.ps1
+# Exits non-zero on any failure.
+#
+# Both removers used to exclude the tree they were standing in with a raw
+# string comparison. On Windows that comparison cannot match: git reports
+# "D:/Sources/x" and (Get-Location).Path reports "D:\Sources\x". Every listed
+# worktree therefore entered the removal branch, and in remove.ps1 a failed
+# `git worktree remove` escalated to an unguarded recursive delete.
+#
+# The mixed-separator case is the regression. It is asserted directly rather
+# than through either script, because reproducing it end to end means running
+# a remover against a real repository. These functions are pure string work,
+# so the assertions hold identically on the Linux runner and on Windows.
+
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent $ScriptDir
+$ScriptsDir = Join-Path $ProjectRoot 'scripts'
+
+# Two-argument Join-Path only: the three-argument form is PowerShell 7+, and
+# these scripts are also read by Windows PowerShell 5.1.
+Import-Module (Join-Path $ScriptsDir 'ClaudeDocker.psm1') -Force
+
+$script:Pass = 0
+$script:Fail = 0
+
+function Assert-Eq {
+    param(
+        [Parameter(Mandatory)][string]$Label,
+        [Parameter(Mandatory)][AllowEmptyString()][AllowNull()][object]$Expected,
+        [Parameter(Mandatory)][AllowEmptyString()][AllowNull()][object]$Actual
+    )
+    if ([string]$Expected -eq [string]$Actual) {
+        Write-Host ("  PASS  {0}" -f $Label)
+        $script:Pass++
+    } else {
+        Write-Host ("  FAIL  {0}`n        expected: {1}`n        actual:   {2}" -f `
+            $Label, ([string]$Expected), ([string]$Actual))
+        $script:Fail++
+    }
+}
+
+# Removal sets are compared as a joined string so a wrong count and a wrong
+# member both read the same way in the failure output.
+function Assert-Set {
+    param(
+        [Parameter(Mandatory)][string]$Label,
+        [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$Expected,
+        [Parameter(Mandatory)][AllowEmptyCollection()][AllowNull()][string[]]$Actual
+    )
+    Assert-Eq $Label ($Expected -join ' | ') (@($Actual) -join ' | ')
+}
+
+Write-Host '== ConvertTo-ComparablePath =='
+
+Assert-Eq 'backslashes fold to forward slashes' 'D:/Sources/claude-docker' `
+    (ConvertTo-ComparablePath -Path 'D:\Sources\claude-docker')
+Assert-Eq 'forward slashes are left alone' 'D:/Sources/claude-docker' `
+    (ConvertTo-ComparablePath -Path 'D:/Sources/claude-docker')
+Assert-Eq 'a trailing separator is dropped' 'D:/Sources/claude-docker' `
+    (ConvertTo-ComparablePath -Path 'D:\Sources\claude-docker\')
+Assert-Eq 'a POSIX path survives unchanged' '/home/u/project' `
+    (ConvertTo-ComparablePath -Path '/home/u/project')
+
+# Trimming a root would turn "C:/" into "C:" and "/" into "", neither of which
+# is a path. No worktree is ever a root, so the guard just has to not corrupt
+# them if one is passed.
+Assert-Eq 'a drive root is not trimmed away' 'C:/' (ConvertTo-ComparablePath -Path 'C:\')
+Assert-Eq 'the POSIX root is not trimmed away' '/' (ConvertTo-ComparablePath -Path '/')
+Assert-Eq 'an empty path stays empty' '' (ConvertTo-ComparablePath -Path '')
+
+Write-Host '== Select-RemovableWorktree: the #342 regression =='
+
+# The exact shape the two removers see on Windows: git porcelain output in
+# forward-slash form, the current directory in backslash form. Before the fix
+# this returned the main worktree, and remove.ps1 went on to delete it.
+$porcelain = @(
+    'D:/Sources/claude-docker',
+    'D:/Sources/.codex/worktrees/claude-docker-a',
+    'D:/Sources/.codex/worktrees/claude-docker-b'
+)
+Assert-Set 'main tree in forward-slash form is excluded from a backslash cwd' `
+    @('D:/Sources/.codex/worktrees/claude-docker-a', 'D:/Sources/.codex/worktrees/claude-docker-b') `
+    (Select-RemovableWorktree -WorktreePath $porcelain -CurrentPath 'D:\Sources\claude-docker')
+
+# The single-worktree install is the default one, and it is the case where a
+# wrong answer costs the user their repository.
+Assert-Set 'a repository with no linked worktrees yields an empty set' `
+    @() `
+    (Select-RemovableWorktree -WorktreePath @('D:/Sources/claude-docker') `
+        -CurrentPath 'D:\Sources\claude-docker')
+
+Assert-Set 'no worktrees at all yields an empty set' `
+    @() (Select-RemovableWorktree -WorktreePath @() -CurrentPath 'D:\Sources\claude-docker')
+
+Assert-Set 'a null listing yields an empty set' `
+    @() (Select-RemovableWorktree -WorktreePath $null -CurrentPath 'D:\Sources\claude-docker')
+
+Write-Host '== Select-RemovableWorktree: standing in a linked worktree =='
+
+# This is the case that destroyed a repository. git lists the main working
+# tree first even when invoked from a linked one, so the caller's own path
+# does not identify what is at risk -- the ordering guard does.
+Assert-Set 'the main tree is dropped even when the caller is elsewhere' `
+    @('D:/Sources/.codex/worktrees/claude-docker-b') `
+    (Select-RemovableWorktree -WorktreePath $porcelain `
+        -CurrentPath 'D:\Sources\.codex\worktrees\claude-docker-a')
+
+Write-Host '== Select-RemovableWorktree: spelling variance =='
+
+Assert-Set 'a trailing separator on the cwd still matches' `
+    @('D:/Sources/.codex/worktrees/claude-docker-a', 'D:/Sources/.codex/worktrees/claude-docker-b') `
+    (Select-RemovableWorktree -WorktreePath $porcelain -CurrentPath 'D:\Sources\claude-docker\')
+
+# Windows paths are case-insensitive, and a drive letter reaches these scripts
+# in either case depending on how the user typed it into the installer.
+Assert-Set 'a case difference still matches' `
+    @('D:/Sources/.codex/worktrees/claude-docker-a', 'D:/Sources/.codex/worktrees/claude-docker-b') `
+    (Select-RemovableWorktree -WorktreePath $porcelain -CurrentPath 'd:\sources\CLAUDE-DOCKER')
+
+# A prefix must not be mistaken for the same tree, or a sibling worktree whose
+# name extends the repository's would silently survive removal.
+Assert-Set 'a path that merely shares a prefix is still removable' `
+    @('D:/Sources/claude-docker-extra') `
+    (Select-RemovableWorktree -WorktreePath @('D:/Sources/claude-docker', 'D:/Sources/claude-docker-extra') `
+        -CurrentPath 'D:\Sources\claude-docker')
+
+Write-Host '== both removers route through the shared selector =='
+
+# The point of the shared function is that one fix covers both scripts. If
+# either grows its own copy of the loop again, everything above keeps passing
+# while the defect comes back, so the call site is asserted too.
+foreach ($name in 'remove.ps1', 'cleanup.ps1') {
+    $source = Get-Content -LiteralPath (Join-Path $ScriptsDir $name) -Raw
+    Assert-Eq "$name calls Select-RemovableWorktree" $true `
+        ($source -like '*Select-RemovableWorktree*')
+    Assert-Eq "$name no longer compares against a raw `$currentDir" $false `
+        ($source -like '*-ne $currentDir*')
+}
+
+Write-Host ''
+Write-Host ("== Summary: PASS={0} FAIL={1} ==" -f $script:Pass, $script:Fail)
+if ($script:Fail -gt 0) { exit 1 }


### PR DESCRIPTION
Closes #342

## What

`remove.ps1` and `cleanup.ps1` excluded the tree they were standing in by comparing `git worktree list --porcelain` output against `(Get-Location).Path`. On Windows those two operands cannot be equal:

| Operand | Producer | Observed |
|---|---|---|
| `$wtPath` | `git worktree list --porcelain` | `D:/Sources/claude-docker` |
| `$currentDir` | `(Get-Location).Path` | `D:\Sources\claude-docker` |

So every listed worktree entered the removal branch, and in `remove.ps1` a failed `git worktree remove` escalated to `Remove-Item -Recurse -Force` with `-ErrorAction SilentlyContinue`.

Measured against a real worktree pair before this change (scratchpad repository, PowerShell 7.6):

```
cwd (Get-Location) : C:\Users\...\wt342-.../main
porcelain[0]       : C:/Users/.../wt342-.../main
raw -ne comparison : True   <- the main tree was selected for removal
```

The comparison returns `True` from the main tree *and* from a linked one. From the main tree the process' own cwd lock happens to make `Remove-Item` refuse; from a linked worktree nothing does, and the first loop iteration takes the main repository with it.

## Why

This is a Windows-port regression. `remove.sh` carries the same `rm -rf` escalation but neither defect that makes it reachable: its repository gate is `[[ -d "$project_dir/.git" ]]` (a **directory**, so a linked worktree is refused) and both sides of its comparison are forward-slash. The port kept the shape of each guard and lost the property it was relying on -- neither loss is visible from reading the PowerShell alone.

## How

The decision moved into `Select-RemovableWorktree` in `ClaudeDocker.psm1`, so the two removers share one copy instead of two that drifted. It applies two independent guards:

1. **Drop the first porcelain entry unconditionally.** git documents the main working tree as listed first, and it stays first even when the command runs from a linked worktree -- which is exactly the case where the caller's own path does not identify the repository at risk.
2. **Drop anything folding to the caller's own path.** `ConvertTo-ComparablePath` folds both separators to `/` and trims a trailing one. Pure string work, so it behaves identically on the Linux runner and on Windows.

Three further guards in `remove.ps1`:

- The `PROJECT_DIR` gate now requires `.git` to be a **directory**, matching `remove.sh:169`. A linked worktree is refused with a message that says so rather than the generic "not a git repository".
- The recursive fallback fires only for workspaces recorded in `.env` under `PROJECT_DIR_<X>` / `ISOLATED_WORKSPACE_<X>` -- the paths this tool created. Anything else logs a warning and is left alone.
- A failed delete is reported instead of swallowed, and the closing summary lists what was left behind rather than asserting unconditionally that nothing outside the repository was touched.

### Verification

- `tests/test_worktree_path_guard.ps1` (new, 19 assertions, added to the `pwsh-tests` matrix) -- `PASS=19 FAIL=0`. It pins the mixed-separator case, the linked-worktree case, trailing-separator and case variance, and the prefix-collision case; it also asserts both scripts still route through the shared selector, so a reinlined loop fails the test rather than passing silently.
- `tests/test_isolation_modes.ps1` -- `PASS=48 FAIL=0` (no regression in the other consumer of this module).
- `tests/test_parse_env.ps1` -- `PASS=20 FAIL=0`.
- End-to-end shape check against a real `git worktree add` pair: from both the main tree and the linked one, the selector returns 0 entries pointing at the main tree.
- PSScriptAnalyzer was **not** run locally (module not installed on this host); the `psanalyzer` job covers it.
- No removal script was executed against a real installation.

## Where

- `scripts/ClaudeDocker.psm1` -- `ConvertTo-ComparablePath`, `Select-RemovableWorktree`, exports
- `scripts/remove.ps1` -- `Remove-Worktrees`, `Get-ManagedWorktreePath`, `Show-RemovalSummary`
- `scripts/cleanup.ps1` -- worktree cleanup block
- `tests/test_worktree_path_guard.ps1` -- new
- `.github/workflows/ci.yml` -- registers the new test

## Notes for the reviewer

`cleanup.ps1` keeps `Test-Path (Join-Path $RepoDir '.git')` without `-PathType`, unlike `remove.ps1`. That is deliberate: `-RepoDir` is an explicit argument naming a repository to clean, and with both guards above a linked worktree passed there is now preserved rather than deleted. Tightening it to a directory would turn a supported invocation into a refusal, which belongs in #344 with the rest of the `remove.sh` / `cleanup.sh` confirmation work rather than here.
