### PR TITLE
fix(tui): select compose overlays from ISOLATION_MODE

### DIFF
--- a/tui/internal/config/env.go
+++ b/tui/internal/config/env.go
@@ -316,6 +316,33 @@ func (e *Env) IsolationMode() string {
 	return IsolationShared
 }
 
+// UnusedWorkspaceWarnings reports per-account workspace paths that are
+// configured but that the resolved mode does not consume.
+//
+// Mirrors warn_unused_workspace_paths in scripts/lib/isolation.sh, including
+// checking both families rather than stopping at the first: a user who tried
+// isolated, went back to worktree, and left the clone paths behind should be
+// told the clones are now inert. This reports a surprise and decides nothing,
+// which is why it returns messages rather than an error -- the case it exists
+// for is a stale PROJECT_DIR_A under ISOLATION_MODE=isolated, where the paths
+// are ignored but the configuration reads as though they are not.
+func (e *Env) UnusedWorkspaceWarnings() []string {
+	if e == nil {
+		return nil
+	}
+	mode := e.IsolationMode()
+	var out []string
+	if mode != IsolationWorktree && e.Get("PROJECT_DIR_A") != "" {
+		out = append(out, "PROJECT_DIR_A is set, but ISOLATION_MODE="+mode+
+			" ignores per-account worktree paths")
+	}
+	if mode != IsolationIsolated && e.Get("ISOLATED_WORKSPACE_A") != "" {
+		out = append(out, "ISOLATED_WORKSPACE_A is set, but ISOLATION_MODE="+mode+
+			" ignores per-account clone paths")
+	}
+	return out
+}
+
 // IsolationModeKnown reports whether a mode name is part of the contract.
 func IsolationModeKnown(mode string) bool {
 	switch mode {

--- a/tui/internal/docker/client.go
+++ b/tui/internal/docker/client.go
@@ -32,7 +32,11 @@ type ContainerInfo struct {
 
 // PS returns the list of containers for this compose project.
 func (c *Client) PS() ([]ContainerInfo, error) {
-	args := append(BuildComposeArgs(c.projectRoot, c.env), "ps", "--format", "json", "--all")
+	base, err := BuildComposeArgs(c.projectRoot, c.env)
+	if err != nil {
+		return nil, err
+	}
+	args := append(base, "ps", "--format", "json", "--all")
 	cmd := exec.Command("docker", args...)
 	out, err := cmd.Output()
 	if err != nil {
@@ -74,49 +78,76 @@ func parseComposePS(out string) ([]ContainerInfo, error) {
 
 // Up starts all services detached.
 func (c *Client) Up() error {
-	args := append(BuildComposeArgs(c.projectRoot, c.env), "up", "-d")
-	cmd := exec.Command("docker", args...)
+	base, err := BuildComposeArgs(c.projectRoot, c.env)
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command("docker", append(base, "up", "-d")...)
 	return cmd.Run()
 }
 
 // Down stops all services.
 func (c *Client) Down() error {
-	args := append(BuildComposeArgs(c.projectRoot, c.env), "down")
-	cmd := exec.Command("docker", args...)
+	base, err := BuildComposeArgs(c.projectRoot, c.env)
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command("docker", append(base, "down")...)
 	return cmd.Run()
 }
 
+// The *Args methods return (bin, args, error) rather than building a command.
+// The error is not decoration: the caller hands the result to tea.ExecProcess,
+// so a compose prefix that could not be resolved has to stop the caller before
+// a docker process is spawned. Returning args anyway and letting docker sort
+// it out is what started every account on the shared mount.
+
 // ExecArgs returns (bin, args) for running a command in a running service container.
 // Used with tea.ExecProcess for interactive terminal handoff.
-func (c *Client) ExecArgs(service string, cmd ...string) (string, []string) {
-	args := append(BuildComposeArgs(c.projectRoot, c.env), "exec", service)
+func (c *Client) ExecArgs(service string, cmd ...string) (string, []string, error) {
+	base, err := BuildComposeArgs(c.projectRoot, c.env)
+	if err != nil {
+		return "", nil, err
+	}
+	args := append(base, "exec", service)
 	args = append(args, cmd...)
-	return "docker", args
+	return "docker", args, nil
 }
 
 // BuildArgs returns (bin, args) for `docker compose build`.
 // When noCache is true, passes --no-cache to force a full rebuild.
-func (c *Client) BuildArgs(noCache bool) (string, []string) {
-	args := append(BuildComposeArgs(c.projectRoot, c.env), "build")
+func (c *Client) BuildArgs(noCache bool) (string, []string, error) {
+	base, err := BuildComposeArgs(c.projectRoot, c.env)
+	if err != nil {
+		return "", nil, err
+	}
+	args := append(base, "build")
 	if noCache {
 		args = append(args, "--no-cache")
 	}
-	return "docker", args
+	return "docker", args, nil
 }
 
 // UpRecreateArgs returns (bin, args) for `docker compose up -d --force-recreate`.
 // Used after image rebuild or .env change so containers pick up new config.
-func (c *Client) UpRecreateArgs(services ...string) (string, []string) {
-	args := append(BuildComposeArgs(c.projectRoot, c.env), "up", "-d", "--force-recreate")
+func (c *Client) UpRecreateArgs(services ...string) (string, []string, error) {
+	base, err := BuildComposeArgs(c.projectRoot, c.env)
+	if err != nil {
+		return "", nil, err
+	}
+	args := append(base, "up", "-d", "--force-recreate")
 	args = append(args, services...)
-	return "docker", args
+	return "docker", args, nil
 }
 
 // RestartArgs returns (bin, args) for restarting a single service.
 // service must be a name produced by ServiceNames() (e.g. "claude-a").
-func (c *Client) RestartArgs(service string) (string, []string) {
-	args := append(BuildComposeArgs(c.projectRoot, c.env), "restart", service)
-	return "docker", args
+func (c *Client) RestartArgs(service string) (string, []string, error) {
+	base, err := BuildComposeArgs(c.projectRoot, c.env)
+	if err != nil {
+		return "", nil, err
+	}
+	return "docker", append(base, "restart", service), nil
 }
 
 // HasRunningContainers returns true if any compose service is currently up.

--- a/tui/internal/docker/compose.go
+++ b/tui/internal/docker/compose.go
@@ -3,6 +3,7 @@ package docker
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -22,12 +23,39 @@ func fileExists(path string) bool {
 	return true
 }
 
-// BuildComposeArgs replicates the overlay logic from scripts/claude-docker.
-// Adds docker-compose.linux.yml on Linux only when the file exists, and
-// docker-compose.worktree.yml when PROJECT_DIR_A is set and the worktree
-// override file exists. The file-existence checks match the canonical bash
-// implementation in scripts/lib/build-compose-cmd.sh.
-func BuildComposeArgs(projectRoot string, env *config.Env) []string {
+// modeOverlay maps a resolved isolation mode to the compose overlay it selects.
+// An empty string means the mode adds no overlay.
+//
+// This is one half of a contract whose other half is the `case` block in
+// build_compose_cmd (scripts/lib/build-compose-cmd.sh). A mode added to one
+// side and not the other is what put this table out of step in the first
+// place, so TestOverlayTableMatchesBash reads that `case` and compares it
+// against this map rather than trusting a comment to keep them aligned.
+var modeOverlay = map[string]string{
+	config.IsolationShared:   "",
+	config.IsolationWorktree: "docker-compose.worktree.yml",
+	config.IsolationIsolated: "docker-compose.isolated.yml",
+}
+
+// BuildComposeArgs builds the `docker compose -f ...` prefix for the TUI,
+// following the same rules as build_compose_cmd in
+// scripts/lib/build-compose-cmd.sh:
+//
+//  1. docker-compose.yml is always included, and is not stat'd.
+//  2. docker-compose.linux.yml is added on Linux when the file exists. This
+//     one is genuinely "add when present" in bash too.
+//  3. The overlay named by the resolved ISOLATION_MODE is added. A mode that
+//     names an overlay which is not on disk is an error, not a silent
+//     omission -- dropping it would leave every account on the base stack's
+//     shared read-write /project mount, which is the exact fallback these
+//     modes exist to prevent. An unrecognized mode is likewise an error.
+//
+// Selection keys off env.IsolationMode(), not env.HasWorktrees(). Those agree
+// for a Tier B install predating the ISOLATION_MODE key, because
+// IsolationMode() still infers worktree from PROJECT_DIR_A; they disagree for
+// every isolated install, where the old branch picked the worktree overlay or
+// none at all.
+func BuildComposeArgs(projectRoot string, env *config.Env) ([]string, error) {
 	args := []string{"compose", "-f", filepath.Join(projectRoot, "docker-compose.yml")}
 	if runtime.GOOS == "linux" {
 		linuxOverlay := filepath.Join(projectRoot, "docker-compose.linux.yml")
@@ -35,11 +63,26 @@ func BuildComposeArgs(projectRoot string, env *config.Env) []string {
 			args = append(args, "-f", linuxOverlay)
 		}
 	}
-	if env != nil && env.HasWorktrees() {
-		worktreeOverlay := filepath.Join(projectRoot, "docker-compose.worktree.yml")
-		if fileExists(worktreeOverlay) {
-			args = append(args, "-f", worktreeOverlay)
-		}
+
+	// IsolationMode has a nil-receiver guard and answers "shared", which is
+	// the right answer for a TUI that could not load .env at all.
+	mode := env.IsolationMode()
+	overlay, known := modeOverlay[mode]
+	if !known {
+		return nil, fmt.Errorf(
+			"ISOLATION_MODE=%s is not one of shared, worktree, isolated; "+
+				"refusing to start on a weaker boundary than the one configured", mode)
 	}
-	return args
+	if overlay == "" {
+		return args, nil
+	}
+
+	overlayPath := filepath.Join(projectRoot, overlay)
+	if !fileExists(overlayPath) {
+		return nil, fmt.Errorf(
+			"ISOLATION_MODE=%s but %s is missing; "+
+				"regenerate it with scripts/generate-compose.sh before starting containers",
+			mode, overlay)
+	}
+	return append(args, "-f", overlayPath), nil
 }

--- a/tui/internal/docker/docker_test.go
+++ b/tui/internal/docker/docker_test.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -28,6 +29,29 @@ func writeFile(t *testing.T, path string) {
 	}
 }
 
+// mustArgs fails the test if BuildComposeArgs returns an error. Used by the
+// cases whose subject is the argument list rather than the refusal.
+func mustArgs(t *testing.T, root string, env *config.Env) []string {
+	t.Helper()
+	args, err := BuildComposeArgs(root, env)
+	if err != nil {
+		t.Fatalf("BuildComposeArgs: unexpected error: %v", err)
+	}
+	return args
+}
+
+// modeEnv returns an Env configured with ISOLATION_MODE and any extra keys.
+func modeEnv(mode string, kv ...string) *config.Env {
+	env := config.NewEmptyEnv("/tmp/.env")
+	if mode != "" {
+		env.Set("ISOLATION_MODE", mode)
+	}
+	for i := 0; i+1 < len(kv); i += 2 {
+		env.Set(kv[i], kv[i+1])
+	}
+	return env
+}
+
 // TestBuildComposeArgs verifies the base compose file is always present and
 // that the Linux overlay and worktree overlay are added under the right
 // conditions when the corresponding files exist on disk. CI runs on Linux so
@@ -38,6 +62,7 @@ func TestBuildComposeArgs(t *testing.T) {
 	baseFile := filepath.Join(root, "docker-compose.yml")
 	linuxFile := filepath.Join(root, "docker-compose.linux.yml")
 	worktreeFile := filepath.Join(root, "docker-compose.worktree.yml")
+	isolatedFile := filepath.Join(root, "docker-compose.isolated.yml")
 
 	// Pre-create the overlay files so the file-existence checks pass for the
 	// scenarios that exercise the "overlay should be added" path. The base
@@ -46,9 +71,10 @@ func TestBuildComposeArgs(t *testing.T) {
 	// canonical bash implementation.
 	writeFile(t, linuxFile)
 	writeFile(t, worktreeFile)
+	writeFile(t, isolatedFile)
 
 	t.Run("base only nil env", func(t *testing.T) {
-		args := BuildComposeArgs(root, nil)
+		args := mustArgs(t, root, nil)
 		if len(args) == 0 || args[0] != "compose" {
 			t.Fatalf("args = %v, want first element %q", args, "compose")
 		}
@@ -61,7 +87,7 @@ func TestBuildComposeArgs(t *testing.T) {
 	})
 
 	t.Run("os specific overlay", func(t *testing.T) {
-		args := BuildComposeArgs(root, nil)
+		args := mustArgs(t, root, nil)
 		hasLinux := containsArg(args, linuxFile)
 		if runtime.GOOS == "linux" && !hasLinux {
 			t.Errorf("linux: expected %q in args %v", linuxFile, args)
@@ -71,33 +97,77 @@ func TestBuildComposeArgs(t *testing.T) {
 		}
 	})
 
+	// PROJECT_DIR_A with no explicit mode is how Tier B installations
+	// predating the ISOLATION_MODE key are configured. IsolationMode() infers
+	// worktree from it, so switching selection to the mode must not move them.
 	t.Run("worktree overlay added when PROJECT_DIR_A set", func(t *testing.T) {
-		env := config.NewEmptyEnv("/tmp/.env")
-		env.Set("PROJECT_DIR_A", "/some/path")
-		args := BuildComposeArgs(root, env)
+		args := mustArgs(t, root, modeEnv("", "PROJECT_DIR_A", "/some/path"))
 		if !containsArg(args, worktreeFile) {
 			t.Errorf("worktree file %q missing in %v", worktreeFile, args)
 		}
 	})
+
+	t.Run("shared selects no mode overlay", func(t *testing.T) {
+		args := mustArgs(t, root, modeEnv(config.IsolationShared))
+		if containsArg(args, worktreeFile) || containsArg(args, isolatedFile) {
+			t.Errorf("shared must select no mode overlay (args=%v)", args)
+		}
+	})
+
+	// The defect this test exists for: ISOLATION_MODE was never read, so an
+	// isolated install started on the base stack -- with the base's shared
+	// read-write /project mount restored, because the overlay's `volumes:
+	// !override` never got applied.
+	t.Run("isolated selects the isolated overlay", func(t *testing.T) {
+		args := mustArgs(t, root, modeEnv(config.IsolationIsolated))
+		if !containsArg(args, isolatedFile) {
+			t.Errorf("isolated overlay %q missing in %v", isolatedFile, args)
+		}
+		if containsArg(args, worktreeFile) {
+			t.Errorf("isolated must not select the worktree overlay (args=%v)", args)
+		}
+	})
+
+	// A stale PROJECT_DIR_A left over from a worktree install must not drag an
+	// isolated configuration back onto the worktree overlay. Before the fix
+	// this selected the wrong overlay rather than none.
+	t.Run("stale PROJECT_DIR_A under isolated selects isolated", func(t *testing.T) {
+		env := modeEnv(config.IsolationIsolated, "PROJECT_DIR_A", "/stale/worktree")
+		args := mustArgs(t, root, env)
+		if !containsArg(args, isolatedFile) {
+			t.Errorf("isolated overlay %q missing in %v", isolatedFile, args)
+		}
+		if containsArg(args, worktreeFile) {
+			t.Errorf("stale PROJECT_DIR_A must not select the worktree overlay (args=%v)", args)
+		}
+		warnings := env.UnusedWorkspaceWarnings()
+		if len(warnings) != 1 || !strings.Contains(warnings[0], "PROJECT_DIR_A") {
+			t.Errorf("expected one PROJECT_DIR_A warning, got %v", warnings)
+		}
+	})
 }
 
-// TestBuildComposeArgs_FileMissing verifies the file-existence check: when
-// an overlay file is not present on disk, BuildComposeArgs must omit the
-// corresponding `-f` argument even if the host conditions (Linux / worktree
-// env) would otherwise select it. This matches the canonical bash logic
-// in scripts/lib/build-compose-cmd.sh.
+// TestBuildComposeArgs_FileMissing separates the two file-existence rules,
+// which are not the same rule in the canonical bash implementation:
+//
+//   - The Linux overlay is genuinely "add when present"
+//     (scripts/lib/build-compose-cmd.sh:45).
+//   - A mode overlay that is missing is an error and build_compose_cmd returns
+//     non-zero (:74-78), because omitting it leaves every account on the base
+//     stack's shared mount.
+//
+// This test previously asserted the second case fell back silently and
+// described that as matching bash. It did not.
 func TestBuildComposeArgs_FileMissing(t *testing.T) {
 	root := t.TempDir()
 	baseFile := filepath.Join(root, "docker-compose.yml")
 	linuxFile := filepath.Join(root, "docker-compose.linux.yml")
-	worktreeFile := filepath.Join(root, "docker-compose.worktree.yml")
-	// Deliberately do NOT create linuxFile or worktreeFile — only the empty
-	// temp dir exists. The base file is also absent; the bash canonical
-	// version does not stat the base file either, so neither does the Go
-	// port: the base path is unconditionally included.
+	// Deliberately do NOT create any overlay. The base file is also absent;
+	// the bash canonical version does not stat the base file either, so
+	// neither does the Go port: the base path is unconditionally included.
 
 	t.Run("linux overlay omitted when file missing", func(t *testing.T) {
-		args := BuildComposeArgs(root, nil)
+		args := mustArgs(t, root, nil)
 		if !containsArg(args, baseFile) {
 			t.Errorf("base file %q should always be present in %v", baseFile, args)
 		}
@@ -106,14 +176,117 @@ func TestBuildComposeArgs_FileMissing(t *testing.T) {
 		}
 	})
 
-	t.Run("worktree overlay omitted when file missing even with PROJECT_DIR_A", func(t *testing.T) {
-		env := config.NewEmptyEnv(filepath.Join(root, ".env"))
-		env.Set("PROJECT_DIR_A", "/some/path")
-		args := BuildComposeArgs(root, env)
-		if containsArg(args, worktreeFile) {
-			t.Errorf("worktree overlay %q must be omitted when file does not exist (args=%v)", worktreeFile, args)
+	for _, tc := range []struct {
+		name string
+		env  *config.Env
+		want string
+	}{
+		{"worktree", modeEnv("", "PROJECT_DIR_A", "/some/path"), "docker-compose.worktree.yml"},
+		{"isolated", modeEnv(config.IsolationIsolated), "docker-compose.isolated.yml"},
+	} {
+		t.Run(tc.name+" overlay missing is an error", func(t *testing.T) {
+			args, err := BuildComposeArgs(root, tc.env)
+			if err == nil {
+				t.Fatalf("expected an error for a missing %s overlay, got args=%v", tc.name, args)
+			}
+			if args != nil {
+				t.Errorf("args must be nil on error, got %v", args)
+			}
+			// The message has to name the file, because regenerating it is
+			// the fix and the user cannot act on "compose failed".
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not name %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildComposeArgs_UnknownMode pins the refusal that gives
+// config.IsolationModeKnown's contract a non-test consumer. An unrecognized
+// mode used to start on the base stack with no diagnostic at all.
+func TestBuildComposeArgs_UnknownMode(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "docker-compose.worktree.yml"))
+	writeFile(t, filepath.Join(root, "docker-compose.isolated.yml"))
+
+	for _, mode := range []string{"bogus", "per-account", "none", "worktrees"} {
+		t.Run(mode, func(t *testing.T) {
+			args, err := BuildComposeArgs(root, modeEnv(mode))
+			if err == nil {
+				t.Fatalf("ISOLATION_MODE=%s must be refused, got args=%v", mode, args)
+			}
+			if !strings.Contains(err.Error(), mode) {
+				t.Errorf("error %q does not name the configured mode %q", err.Error(), mode)
+			}
+		})
+	}
+
+	// Case folding happens in IsolationMode(), matching resolve_isolation_mode
+	// and Get-IsolationMode -- a mixed-case value is a spelling of a valid
+	// mode, not an unknown one. Asserted here so a future tightening of the
+	// refusal cannot silently start rejecting configurations the two shell
+	// layers accept.
+	t.Run("mixed case is a valid spelling, not an unknown mode", func(t *testing.T) {
+		args, err := BuildComposeArgs(root, modeEnv("IsoLated"))
+		if err != nil {
+			t.Fatalf("mixed-case isolated must resolve: %v", err)
+		}
+		if !containsArg(args, filepath.Join(root, "docker-compose.isolated.yml")) {
+			t.Errorf("isolated overlay missing in %v", args)
 		}
 	})
+}
+
+// TestOverlayTableMatchesBash reads the `case` block in build_compose_cmd and
+// compares it against the Go table.
+//
+// The two implementations drifted precisely because nothing connected them:
+// the isolated arm was added to bash in #335 and the Go side kept selecting
+// from PROJECT_DIR_A. A comment pointing at the other file would not have
+// caught that, so the bash source is parsed instead.
+func TestOverlayTableMatchesBash(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "scripts", "lib", "build-compose-cmd.sh")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	// Matches e.g. `        worktree) overlay="docker-compose.worktree.yml" ;;`
+	arm := regexp.MustCompile(`(?m)^\s*([A-Za-z*]+)\)\s*overlay="([^"]*)"`)
+	matches := arm.FindAllStringSubmatch(string(data), -1)
+	if len(matches) == 0 {
+		t.Fatalf("no `overlay=` case arms found in %s; the parser or the script changed shape", path)
+	}
+
+	bash := map[string]string{}
+	for _, m := range matches {
+		bash[m[1]] = m[2]
+	}
+	// The `*` arm is bash's default and corresponds to every Go mode mapping
+	// to an empty overlay; it has no name to compare against.
+	if got, ok := bash["*"]; !ok || got != "" {
+		t.Errorf("bash default arm = %q (present=%v), want an empty overlay", got, ok)
+	}
+	delete(bash, "*")
+
+	for mode, want := range bash {
+		got, ok := modeOverlay[mode]
+		if !ok {
+			t.Errorf("bash selects %q for mode %q, but the Go table has no such mode", want, mode)
+			continue
+		}
+		if got != want {
+			t.Errorf("mode %q: Go selects %q, bash selects %q", mode, got, want)
+		}
+	}
+	for mode, overlay := range modeOverlay {
+		if overlay == "" {
+			continue // falls into bash's `*` arm
+		}
+		if _, ok := bash[mode]; !ok {
+			t.Errorf("Go selects %q for mode %q, but bash has no arm for it", overlay, mode)
+		}
+	}
 }
 
 // TestExecArgs verifies the binary is "docker", the compose plumbing comes
@@ -121,7 +294,10 @@ func TestBuildComposeArgs_FileMissing(t *testing.T) {
 // command tokens follow the service name in order.
 func TestExecArgs(t *testing.T) {
 	c := NewClient("/tmp/proj", nil)
-	bin, args := c.ExecArgs("claude-a", "bash", "-lc", "ls")
+	bin, args, err := c.ExecArgs("claude-a", "bash", "-lc", "ls")
+	if err != nil {
+		t.Fatalf("ExecArgs: %v", err)
+	}
 
 	if bin != "docker" {
 		t.Errorf("bin = %q, want %q", bin, "docker")
@@ -202,7 +378,10 @@ func TestBuildArgs(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			bin, args := c.BuildArgs(tc.noCache)
+			bin, args, err := c.BuildArgs(tc.noCache)
+			if err != nil {
+				t.Fatalf("BuildArgs: %v", err)
+			}
 			if bin != "docker" {
 				t.Errorf("bin = %q, want %q", bin, "docker")
 			}
@@ -228,7 +407,10 @@ func TestBuildArgs(t *testing.T) {
 // "--force-recreate" so containers pick up new env/image content.
 func TestUpRecreateArgs(t *testing.T) {
 	c := NewClient("/tmp/proj", nil)
-	bin, args := c.UpRecreateArgs()
+	bin, args, err := c.UpRecreateArgs()
+	if err != nil {
+		t.Fatalf("UpRecreateArgs: %v", err)
+	}
 
 	if bin != "docker" {
 		t.Errorf("bin = %q, want %q", bin, "docker")
@@ -249,9 +431,78 @@ func TestUpRecreateArgs(t *testing.T) {
 
 func TestUpRecreateArgsSelectedService(t *testing.T) {
 	c := NewClient("/tmp/proj", nil)
-	_, args := c.UpRecreateArgs("claude-b")
+	_, args, err := c.UpRecreateArgs("claude-b")
+	if err != nil {
+		t.Fatalf("UpRecreateArgs: %v", err)
+	}
 	if got := args[len(args)-1]; got != "claude-b" {
 		t.Errorf("last arg = %q, want claude-b (args=%v)", got, args)
+	}
+}
+
+// TestClientPathsCarryIsolatedOverlay covers the seven client.go entry points
+// the dashboard reaches. Six of them create or replace containers, and none
+// sits behind a confirmation, so it is not enough for BuildComposeArgs alone
+// to be right -- every caller has to route through it.
+//
+// The three that shell out (PS, Up, Down) are asserted only on the refusal
+// path. That is deliberate and not a gap in coverage: the refusal is the case
+// with a security consequence, and asserting it also proves the short-circuit
+// happens before exec.Command, since a spawned docker would fail with some
+// other message.
+func TestClientPathsCarryIsolatedOverlay(t *testing.T) {
+	root := t.TempDir()
+	isolatedFile := filepath.Join(root, "docker-compose.isolated.yml")
+	writeFile(t, isolatedFile)
+	c := NewClient(root, modeEnv(config.IsolationIsolated))
+
+	argsCases := map[string]func() (string, []string, error){
+		"ExecArgs":       func() (string, []string, error) { return c.ExecArgs("claude-a", "bash") },
+		"BuildArgs":      func() (string, []string, error) { return c.BuildArgs(false) },
+		"UpRecreateArgs": func() (string, []string, error) { return c.UpRecreateArgs() },
+		"RestartArgs":    func() (string, []string, error) { return c.RestartArgs("claude-a") },
+	}
+	for name, call := range argsCases {
+		t.Run(name+" selects the isolated overlay", func(t *testing.T) {
+			_, args, err := call()
+			if err != nil {
+				t.Fatalf("%s: %v", name, err)
+			}
+			if !containsArg(args, isolatedFile) {
+				t.Errorf("%s: isolated overlay %q missing in %v", name, isolatedFile, args)
+			}
+		})
+	}
+
+	// Same client, overlay removed: nothing may proceed.
+	if err := os.Remove(isolatedFile); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	for name, call := range argsCases {
+		t.Run(name+" refuses a missing overlay", func(t *testing.T) {
+			_, args, err := call()
+			if err == nil {
+				t.Fatalf("%s: expected a refusal, got args=%v", name, args)
+			}
+		})
+	}
+
+	execCases := map[string]func() error{
+		"PS":   func() error { _, err := c.PS(); return err },
+		"Up":   c.Up,
+		"Down": c.Down,
+	}
+	for name, call := range execCases {
+		t.Run(name+" refuses a missing overlay before spawning docker", func(t *testing.T) {
+			err := call()
+			if err == nil {
+				t.Fatalf("%s: expected a refusal", name)
+			}
+			if !strings.Contains(err.Error(), "docker-compose.isolated.yml") {
+				t.Errorf("%s: error %q is not the compose refusal; docker may have been spawned",
+					name, err.Error())
+			}
+		})
 	}
 }
 
@@ -314,7 +565,10 @@ func TestExecArgs_GeminiAttach(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			bin, args := c.ExecArgs("gemini-a", env.RuntimeCommandArgs(tc.skipPermissions)...)
+			bin, args, err := c.ExecArgs("gemini-a", env.RuntimeCommandArgs(tc.skipPermissions)...)
+			if err != nil {
+				t.Fatalf("ExecArgs: %v", err)
+			}
 			if bin != "docker" {
 				t.Errorf("bin = %q, want %q", bin, "docker")
 			}

--- a/tui/internal/ui/dashboard/helpers.go
+++ b/tui/internal/ui/dashboard/helpers.go
@@ -67,6 +67,21 @@ func (m Model) startGHAuth() (Model, tea.Cmd) {
 	}
 }
 
+// composeErr reports a compose prefix that could not be resolved and returns
+// the dashboard to an idle state.
+//
+// BuildComposeArgs fails when ISOLATION_MODE names an overlay that is not on
+// disk, or names nothing recognizable. Both mean the containers this key would
+// start would not have the boundary the operator configured, so the operation
+// is abandoned here rather than handed to docker. Clearing busy matters as
+// much as the message: every caller sits on a key handler that has already
+// committed to an operation, and leaving the flag set wedges the dashboard.
+func (m Model) composeErr(op string, err error) (Model, tea.Cmd) {
+	m.busy = false
+	m = m.toast(op+": "+err.Error(), statusErr)
+	return m, m.toastExpireCmd()
+}
+
 // toast returns a copy of the model with a transient status message set.
 // Callers should chain toastExpireCmd() so the message auto-clears.
 func (m Model) toast(text string, level statusLevel) Model {

--- a/tui/internal/ui/dashboard/render.go
+++ b/tui/internal/ui/dashboard/render.go
@@ -37,7 +37,19 @@ func renderIsolationBanner(env *config.Env) string {
 	tagline := lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280")).
 		Render("  " + config.IsolationModeTagline(mode))
 
-	return label + tagline + "\n\n"
+	out := label + tagline
+
+	// Paths the mode ignores are reported here rather than as a toast: the
+	// condition is a property of .env, not of an operation, so it should stay
+	// visible for as long as it is true. The shell layers print the same thing
+	// on every invocation (warn_unused_workspace_paths); the dashboard has a
+	// place to put it that does not repeat.
+	warnStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#EAB308"))
+	for _, w := range env.UnusedWorkspaceWarnings() {
+		out += "\n" + warnStyle.Render("  Warning: "+w)
+	}
+
+	return out + "\n\n"
 }
 
 func renderAccountTable(accounts []account.Account, cursor int, width int) string {

--- a/tui/internal/ui/dashboard/render_test.go
+++ b/tui/internal/ui/dashboard/render_test.go
@@ -49,6 +49,68 @@ var geminiRenderCases = []struct {
 	{letter: "b", withOAuthFile: false, wantService: "gemini-b", wantAuthCell: "--"},
 }
 
+// TestRenderIsolationBannerWarnsAboutUnusedPaths pins the banner's report of
+// per-account paths the active mode ignores.
+//
+// The shell layers print this on every invocation
+// (warn_unused_workspace_paths, Write-UnusedWorkspacePathWarning); the TUI had
+// no equivalent, so the one configuration where the mode and the paths
+// disagree -- a stale PROJECT_DIR_A left behind by a move to isolated -- read
+// as if the worktrees were still mounted. Asserted on the stripped frame
+// because the colour is styling, not content.
+func TestRenderIsolationBannerWarnsAboutUnusedPaths(t *testing.T) {
+	cases := []struct {
+		name    string
+		env     map[string]string
+		want    []string
+		notWant []string
+	}{
+		{
+			name: "isolated with a stale worktree path",
+			env:  map[string]string{"ISOLATION_MODE": "isolated", "PROJECT_DIR_A": "/stale/wt"},
+			want: []string{"Isolation: isolated", "PROJECT_DIR_A is set"},
+		},
+		{
+			name:    "worktree consumes its own paths",
+			env:     map[string]string{"ISOLATION_MODE": "worktree", "PROJECT_DIR_A": "/wt/a"},
+			want:    []string{"Isolation: worktree"},
+			notWant: []string{"Warning:"},
+		},
+		{
+			name:    "worktree with leftover clone paths",
+			env:     map[string]string{"ISOLATION_MODE": "worktree", "PROJECT_DIR_A": "/wt/a", "ISOLATED_WORKSPACE_A": "/old/clone"},
+			want:    []string{"ISOLATED_WORKSPACE_A is set"},
+			notWant: []string{"PROJECT_DIR_A is set"},
+		},
+		{
+			name:    "shared with nothing configured",
+			env:     map[string]string{},
+			want:    []string{"Isolation: shared"},
+			notWant: []string{"Warning:"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := config.NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+			for k, v := range tc.env {
+				env.Set(k, v)
+			}
+			got := ansiEscape.ReplaceAllString(renderIsolationBanner(env), "")
+			for _, w := range tc.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("banner missing %q:\n%s", w, got)
+				}
+			}
+			for _, w := range tc.notWant {
+				if strings.Contains(got, w) {
+					t.Errorf("banner should not contain %q:\n%s", w, got)
+				}
+			}
+		})
+	}
+}
+
 // TestDashboardRendersGeminiAccounts drives the dashboard through a simulated
 // terminal and asserts that gemini accounts discovered from
 // $HOME/.gemini-state/account-* actually reach the rendered frame. This is the

--- a/tui/internal/ui/dashboard/update.go
+++ b/tui/internal/ui/dashboard/update.go
@@ -85,8 +85,11 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				return m, m.toastExpireCmd()
 			}
 			// Chain into recreate stage.
+			bin, args, err := m.client.UpRecreateArgs()
+			if err != nil {
+				return m.composeErr("Update (recreate)", err)
+			}
 			m.busy = true
-			bin, args := m.client.UpRecreateArgs()
 			cmd := exec.Command(bin, args...)
 			return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
 				return dockerOpDoneMsg{kind: opUpdateRecreate, err: err}
@@ -110,7 +113,10 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			return m, tea.Batch(m.Refresh(), m.toastExpireCmd())
 		}
 		// Containers are running — recreate them so the new GH_TOKEN takes effect.
-		bin, args := m.client.UpRecreateArgs(msg.services...)
+		bin, args, err := m.client.UpRecreateArgs(msg.services...)
+		if err != nil {
+			return m.composeErr("GitHub auth + recreate", err)
+		}
 		cmd := exec.Command(bin, args...)
 		return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
 			return dockerOpDoneMsg{kind: opGHAuthRecreate, err: err}
@@ -148,7 +154,10 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			if m.cursor < len(m.accounts) {
 				acct := m.accounts[m.cursor]
 				if acct.IsRunning() {
-					bin, args := m.client.ExecArgs(acct.ServiceName, m.env.RuntimeCommandArgs(m.skipPermissions)...)
+					bin, args, err := m.client.ExecArgs(acct.ServiceName, m.env.RuntimeCommandArgs(m.skipPermissions)...)
+					if err != nil {
+						return m.composeErr("Attach", err)
+					}
 					cmd := exec.Command(bin, args...)
 					return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
 						return sessionFinishedMsg{err: err}
@@ -181,16 +190,22 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			return m, m.Refresh()
 
 		case "b":
+			bin, args, err := m.client.BuildArgs(false)
+			if err != nil {
+				return m.composeErr("Build", err)
+			}
 			m.busy = true
-			bin, args := m.client.BuildArgs(false)
 			cmd := exec.Command(bin, args...)
 			return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
 				return dockerOpDoneMsg{kind: opBuild, err: err}
 			})
 
 		case "B":
+			bin, args, err := m.client.BuildArgs(true)
+			if err != nil {
+				return m.composeErr("Rebuild (no-cache)", err)
+			}
 			m.busy = true
-			bin, args := m.client.BuildArgs(true)
 			cmd := exec.Command(bin, args...)
 			return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
 				return dockerOpDoneMsg{kind: opBuildNoCache, err: err}
@@ -198,8 +213,11 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 		case "U":
 			// Two-stage chain: build --no-cache → up -d --force-recreate.
+			bin, args, err := m.client.BuildArgs(true)
+			if err != nil {
+				return m.composeErr("Update (build)", err)
+			}
 			m.busy = true
-			bin, args := m.client.BuildArgs(true)
 			cmd := exec.Command(bin, args...)
 			return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
 				return dockerOpDoneMsg{kind: opUpdateBuild, err: err}
@@ -210,8 +228,11 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				return m, nil
 			}
 			svc := m.accounts[m.cursor].ServiceName
+			bin, args, err := m.client.RestartArgs(svc)
+			if err != nil {
+				return m.composeErr("Restart", err)
+			}
 			m.busy = true
-			bin, args := m.client.RestartArgs(svc)
 			cmd := exec.Command(bin, args...)
 			return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
 				return dockerOpDoneMsg{kind: opRestart, err: err}


### PR DESCRIPTION
Closes #343
Relates to #353

## What

`BuildComposeArgs` selected compose overlays without ever reading `ISOLATION_MODE`. Its only mode-related branch was `env.HasWorktrees()` (`PROJECT_DIR_A != ""`), and neither `isolated` nor `ISOLATION_MODE` occurred anywhere in `tui/internal/docker`.

| `ISOLATION_MODE` | `PROJECT_DIR_A` | overlays appended (before) |
|---|---|---|
| `isolated` | unset | none - base only |
| `isolated` | set (stale) | `docker-compose.worktree.yml` - the wrong overlay |
| `shared` | unset | none |
| `totally-bogus` | unset | none - started without complaint |

Both `volumes:` blocks in `docker-compose.isolated.yml` carry `!override` precisely so the base list is replaced rather than merged. Dropping the overlay therefore does not merely skip hardening -- it restores the base stack's shared read-write `/project` mount, and loses `read_only`, `cap_drop: ALL`, `no-new-privileges`, the pids limit, the per-account bridge networks, and the `environment: !override` that keeps the base stack's `GH_TOKEN` out of an isolated container. The banner kept reading "isolated" the whole time.

Seven paths route through this function and six of them create or replace containers; none is behind a confirmation.

## Why

The hardened boundary from #335 landed on the CLI path only. `build_compose_cmd` has been mode-driven and fail-closed since then (`scripts/lib/build-compose-cmd.sh:63-80`), and the PowerShell port throws (`Get-ComposeArgs`). The Go port kept the pre-#335 shape, so **the trust boundary differed by entry point**: `claude-docker up` honored `isolated`, the dashboard's `u` key did not.

`config.IsolationMode()` already existed and already mirrored `resolve_isolation_mode`. Its only non-test caller was `renderIsolationBanner` - the dashboard read the mode to print it, and started containers as if the key did not exist. `config.IsolationModeKnown` had zero non-test callers.

## How

- Selection goes through `env.IsolationMode()`. That keeps Tier B installations predating the key on the same overlay, because the resolver still infers `worktree` from `PROJECT_DIR_A`.
- `BuildComposeArgs` returns `([]string, error)` and refuses when the resolved mode names an overlay that is not on disk, or names something unrecognized. `IsolationModeKnown`'s contract now has a real consumer via the `modeOverlay` table.
- The error is propagated through all seven `client.go` entry points. The four that hand argv to `tea.ExecProcess` return it so the caller stops **before** a docker process is spawned.
- The dashboard surfaces it through a new `composeErr` helper: error toast plus a `busy` reset, since every caller sits on a key handler that has already committed to an operation.
- Paths the active mode ignores are reported in the isolation banner, matching `warn_unused_workspace_paths`. This lives in the banner rather than a toast because the condition is a property of `.env`, not of an operation.
- The Linux overlay keeps its "add when present" semantics, which does match bash.

### On the test that pinned the defect

`TestBuildComposeArgs_FileMissing` asserted the fail-open path and described it as "matches the canonical bash logic in scripts/lib/build-compose-cmd.sh". Bash returns non-zero there. The same claim was in the `compose.go` doc comment. Both are corrected, and the mode half of that test now asserts the refusal.

To stop the two tables drifting again, `TestOverlayTableMatchesBash` parses the `case` block out of `build-compose-cmd.sh` and compares it against the Go map in both directions. A comment pointing at the other file would not have caught the original drift, which is why the bash source is read instead.

### Verification

- `go build ./...` and `go test ./...` -- all packages pass.
- `go test ./... -run '^$' -bench . -benchtime=1x` (the CI benchmark smoke) -- passes.
- `gofmt -l .` -- empty.
- **Mutation check on the new cross-check**: with `modeOverlay[isolated]` temporarily set to `docker-compose.MUTANT.yml`, `TestOverlayTableMatchesBash` fails with `mode "isolated": Go selects "docker-compose.MUTANT.yml", bash selects "docker-compose.isolated.yml"`. Reverted before commit. A guard that has never been observed failing is not yet a guard.
- New coverage: isolated overlay selected; stale `PROJECT_DIR_A` under isolated selects isolated and warns; missing worktree/isolated overlay is an error naming the file; unknown mode refused; mixed-case mode still accepted (parity with the two shell layers, which lowercase before validating); all seven `client.go` paths carry the overlay and all seven refuse without it.
- No container was started and no docker daemon was involved; the three shelling methods are asserted only on the refusal path, which also proves the short-circuit happens before `exec.Command`.

## Where

- `tui/internal/docker/compose.go` -- `modeOverlay`, `BuildComposeArgs`, corrected doc comment
- `tui/internal/docker/client.go` -- all seven entry points
- `tui/internal/config/env.go` -- `UnusedWorkspaceWarnings`
- `tui/internal/ui/dashboard/{helpers,update,render}.go` -- `composeErr`, seven call sites, banner
- `tui/internal/docker/docker_test.go`, `tui/internal/ui/dashboard/render_test.go`

## Not in scope

The real-container check that `ISOLATION_MODE=isolated` from the TUI produces a container with the isolated mount set is #353. This PR asserts the argv; it does not assert what docker then does with it.
