### PR TITLE
fix(remove): delete only worktrees this installer created

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,7 @@ jobs:
           - tests/test_transform_syntax_check.sh
           - tests/test_cleanup_backups.sh
           - tests/test_windows_platform_guard.sh
+          - tests/test_worktree_ownership.sh
           - scripts/test-entrypoint-settings.sh
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/scripts/ClaudeDocker.psm1
+++ b/scripts/ClaudeDocker.psm1
@@ -1123,6 +1123,69 @@ function Select-RemovableWorktree {
         Where-Object { (ConvertTo-ComparablePath -Path $_) -ne $current })
 }
 
+function Test-OwnedWorktreePath {
+    <#
+    .SYNOPSIS
+    Report whether a worktree is one this installer created.
+    .DESCRIPTION
+    Not being the current tree is not the same as being ours. A user who runs
+    `git worktree add ..\proj-hotfix` in the project repository has a worktree
+    that the removers used to delete with --force, and then with a recursive
+    delete when git declined.
+
+    Ownership has exactly two sources, both written by this installer, and
+    both are needed:
+
+    1. PROJECT_DIR_<X> / ISOLATED_WORKSPACE_<X> in .env -- the paths
+       setup-worktrees and setup-isolated record.
+    2. The "<project>-<letter>" naming those scripts produce, for installs
+       predating those keys and for the window in remove.ps1 where .env has
+       already been deleted.
+
+    Mirrors worktree_is_owned in scripts/lib/worktrees.sh. Matching is the
+    case-insensitive default, which is correct on the only platform these
+    scripts run on: there, two spellings that differ in case are one directory.
+    .PARAMETER EnvData
+    Parsed .env contents. Omit when .env is gone; source 2 still applies.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$ProjectDir,
+        [hashtable]$EnvData
+    )
+
+    $candidate = ConvertTo-ComparablePath -Path $Path
+
+    if ($EnvData) {
+        foreach ($key in $EnvData.Keys) {
+            if ($key -notmatch '^(PROJECT_DIR|ISOLATED_WORKSPACE)_[A-Z]+$') { continue }
+            if (-not $EnvData[$key]) { continue }
+            if ((ConvertTo-ComparablePath -Path $EnvData[$key]) -eq $candidate) {
+                return $true
+            }
+        }
+    }
+
+    if ($ProjectDir) {
+        $prefix = ConvertTo-ComparablePath -Path $ProjectDir
+        # StartsWith and a separate suffix test rather than one regex: a
+        # project path containing regex metacharacters would otherwise widen
+        # the pattern.
+        if ($candidate.StartsWith("$prefix-", [System.StringComparison]::OrdinalIgnoreCase)) {
+            $suffix = $candidate.Substring($prefix.Length + 1)
+            # Two characters is exactly what the generator can emit: the
+            # account count is capped at 702 and index 702 is "zz". A looser
+            # [A-Za-z]+ would claim any sibling named after a word --
+            # "<project>-clone", "<project>-hotfix" -- which are the
+            # user-created worktrees this check exists to spare.
+            if ($suffix -match '^[A-Za-z]{1,2}$') { return $true }
+        }
+    }
+
+    return $false
+}
+
 # --- Exports -----------------------------------------------------------------
 
 Export-ModuleMember -Function @(
@@ -1135,7 +1198,7 @@ Export-ModuleMember -Function @(
     'Test-Command', 'ConvertTo-ForwardSlash', 'ConvertTo-ComparablePath',
     'Protect-EnvFile',
     # Worktrees
-    'Select-RemovableWorktree',
+    'Select-RemovableWorktree', 'Test-OwnedWorktreePath',
     # Accounts
     'Get-NumAccounts', 'Get-AgentRuntime', 'Get-ServicePrefix',
     'Get-PrimaryService', 'Get-AgentStateRoot', 'Get-ServiceNames',

--- a/scripts/cleanup.ps1
+++ b/scripts/cleanup.ps1
@@ -72,6 +72,12 @@ try {
 
     Write-Host '=== Removing worktrees (if Tier B) ===' -ForegroundColor Cyan
     if ($RepoDir -and (Test-Path (Join-Path $RepoDir '.git'))) {
+        # .env names the workspaces the installer created. Read before the
+        # Push-Location so the path stays relative to the project root.
+        $envData = $null
+        $envFile = Join-Path $ProjectRoot '.env'
+        if (Test-Path $envFile) { $envData = Read-EnvFile -Path $envFile }
+
         Push-Location $RepoDir
         try {
             $listed = @(& git worktree list --porcelain 2>$null |
@@ -87,9 +93,20 @@ try {
             $removable = @(Select-RemovableWorktree -WorktreePath $listed `
                 -CurrentPath (Get-Location).Path)
 
+            # Ownership check and failure reporting kept in step with
+            # cleanup.sh: a worktree the user added themselves is not this
+            # tool's to delete, and a refusal that is swallowed reads as a
+            # successful removal.
             foreach ($wt in $removable) {
+                if (-not (Test-OwnedWorktreePath -Path $wt -ProjectDir $RepoDir -EnvData $envData)) {
+                    Write-Host "  Keeping worktree not created by claude-docker: $wt"
+                    continue
+                }
                 Write-Host "  Removing worktree: $wt"
                 & git worktree remove $wt --force 2>$null
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Warning "git declined to remove $wt - left in place."
+                }
             }
         }
         finally {

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -35,6 +35,12 @@ cd "$PROJECT_ROOT"
 # state cleanup covers every registered runtime, not just Claude (see #273).
 # shellcheck source=lib/runtime.sh
 . "$SCRIPT_DIR/lib/runtime.sh"
+# worktrees.sh decides which worktrees this installer owns, shared with
+# remove.sh so the two cannot disagree. It reads .env through parse_env.sh.
+# shellcheck source=lib/parse_env.sh
+. "$SCRIPT_DIR/lib/parse_env.sh"
+# shellcheck source=lib/worktrees.sh
+. "$SCRIPT_DIR/lib/worktrees.sh"
 
 REPO_DIR=""
 CONFIRM="ask"
@@ -109,12 +115,26 @@ docker compose down -v 2>/dev/null || true
 echo "=== Removing worktrees (if Tier B) ==="
 if [ -n "$REPO_DIR" ] && [ -d "$REPO_DIR/.git" ]; then
     cd "$REPO_DIR"
-    for wt in $(git worktree list --porcelain | grep "^worktree " | awk '{print $2}'); do
-        if [ "$wt" != "$(pwd)" ]; then
-            echo "  Removing worktree: $wt"
-            git worktree remove "$wt" --force 2>/dev/null || true
+    # The loop this replaces read the porcelain output through
+    # `awk '{print $2}'`, which truncates a path at its first space, and then
+    # word-split the unquoted substitution again. `git worktree remove` failed
+    # on the resulting non-existent path, `|| true` swallowed it, and the run
+    # printed "Removing worktree: /Users/me/My" as though it had succeeded --
+    # while the real worktree survived to collide with the next install.
+    #
+    # Ownership is checked for the same reason as in remove.sh: a worktree the
+    # user added themselves is not this tool's to delete.
+    while IFS= read -r wt; do
+        if ! worktree_is_owned "$wt" "$REPO_DIR" "$PROJECT_ROOT/.env"; then
+            echo "  Keeping worktree not created by claude-docker: $wt"
+            continue
         fi
-    done
+        echo "  Removing worktree: $wt"
+        if ! git worktree remove "$wt" --force 2>/dev/null; then
+            echo "  Warning: git declined to remove $wt - left in place." >&2
+        fi
+    done < <(worktree_selectable_paths "$(pwd)")
+    cd "$PROJECT_ROOT"
 fi
 
 echo "=== Removing state directories ==="

--- a/scripts/lib/worktrees.sh
+++ b/scripts/lib/worktrees.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# worktrees.sh — Which git worktrees the removal steps are allowed to delete.
+#
+# Library file meant to be `source`d, but the shebang serves as an
+# unambiguous shell directive for tooling (shellcheck SC2148).
+#
+# remove.sh and cleanup.sh both walk `git worktree list` and both used to
+# delete everything except the tree they were standing in. That set is not the
+# set this installer created: a user who runs `git worktree add ../proj-hotfix`
+# in the same repository loses it, with --force and then rm -rf. The rules live
+# here so the two scripts cannot drift apart again, and so they can be tested
+# without running either remover.
+#
+# Public functions:
+#   worktree_list_paths                       # paths git reports, in git order
+#   worktree_selectable_paths CURRENT_PATH    # minus the main tree and CURRENT
+#   worktree_is_owned PATH PROJECT_DIR [ENV]  # created by this installer?
+#
+# Ownership has exactly two sources, both of which the installer writes:
+#   1. PROJECT_DIR_<X> and ISOLATED_WORKSPACE_<X> in .env, the paths
+#      setup-worktrees and setup-isolated record.
+#   2. The "<project>-<letter>" naming setup-worktrees.sh:49 produces, for
+#      installations predating those keys or whose .env has been removed
+#      already (remove.sh deletes .env in a later step than the worktrees).
+#
+# Requires: scripts/lib/parse_env.sh sourced before this file.
+
+# Guard against double-sourcing.
+if [[ -n "${_CLAUDE_DOCKER_WORKTREES_SH_SOURCED:-}" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+_CLAUDE_DOCKER_WORKTREES_SH_SOURCED=1
+
+# _worktree_normalize PATH
+# Drop a trailing slash so "/a/b" and "/a/b/" compare equal. The root is left
+# alone; it is never a worktree, and trimming it would produce "".
+_worktree_normalize() {
+    local p="$1"
+    [[ "$p" != "/" ]] && p="${p%/}"
+    printf '%s' "$p"
+}
+
+# worktree_list_paths
+# Print the worktree paths git reports for the current directory, one per
+# line, in git's order — the main working tree first, including when this runs
+# from a linked worktree.
+#
+# The prefix is stripped with parameter expansion rather than `awk '{print $2}'`
+# because a path containing a space is one field to git and two to awk. That
+# truncation is why cleanup.sh printed "Removing worktree: /Users/me/My" and
+# left the real worktree in place.
+worktree_list_paths() {
+    local line
+    while IFS= read -r line; do
+        case "$line" in
+            "worktree "*) printf '%s\n' "${line#worktree }" ;;
+        esac
+    done < <(git worktree list --porcelain 2>/dev/null || true)
+}
+
+# worktree_selectable_paths CURRENT_PATH
+# Print the worktrees that are candidates for removal: everything git listed
+# except the main working tree and except CURRENT_PATH itself.
+#
+# Two independent guards, deliberately not one. Dropping the first entry works
+# even when the caller is standing in a linked worktree, which is the case
+# where its own path does not identify the repository at risk; comparing
+# against CURRENT_PATH covers the ordinary case. This mirrors
+# Select-RemovableWorktree in scripts/ClaudeDocker.psm1.
+worktree_selectable_paths() {
+    local current
+    current="$(_worktree_normalize "${1:-}")"
+
+    local first=1 path
+    while IFS= read -r path; do
+        if (( first )); then
+            first=0
+            continue
+        fi
+        [[ "$(_worktree_normalize "$path")" == "$current" ]] && continue
+        printf '%s\n' "$path"
+    done < <(worktree_list_paths)
+}
+
+# _worktree_env_keys ENV_FILE
+# Print the per-account workspace keys present in ENV_FILE. PROJECT_DIR on its
+# own does not match: the pattern requires a letter suffix.
+_worktree_env_keys() {
+    local env_file="$1"
+    [[ -r "$env_file" ]] || return 0
+    sed -n 's/^[[:space:]]*\(\(PROJECT_DIR\|ISOLATED_WORKSPACE\)_[A-Z][A-Z]*\)[[:space:]]*=.*/\1/p' \
+        "$env_file" | sort -u
+}
+
+# worktree_is_owned PATH PROJECT_DIR [ENV_FILE]
+# Return 0 when PATH is a workspace this installer created.
+worktree_is_owned() {
+    local path project_dir env_file
+    path="$(_worktree_normalize "$1")"
+    project_dir="$(_worktree_normalize "${2:-}")"
+    env_file="${3:-}"
+
+    # Source 1: the paths recorded in .env.
+    if [[ -n "$env_file" && -r "$env_file" ]]; then
+        local key value
+        while IFS= read -r key; do
+            [[ -z "$key" ]] && continue
+            value="$(parse_env_value "$env_file" "$key")"
+            [[ -z "$value" ]] && continue
+            if [[ "$(_worktree_normalize "$value")" == "$path" ]]; then
+                return 0
+            fi
+        done < <(_worktree_env_keys "$env_file")
+    fi
+
+    # Source 2: the "<project>-<letter>" naming setup-worktrees.sh produces.
+    #
+    # The suffix is bounded to two characters because that is exactly what the
+    # generator can emit: normalize_account_count caps the count at 702 and
+    # index_to_letter turns 702 into "zz". Accepting [a-z]+ instead would
+    # claim any sibling named after a lowercase word -- "<project>-clone",
+    # "<project>-hotfix", "<project>-wip" all match, and those are precisely
+    # the user-created worktrees this check exists to spare.
+    #
+    # The suffix is tested separately rather than interpolated into one
+    # regex, because a project directory containing regex metacharacters
+    # would otherwise widen the pattern.
+    if [[ -n "$project_dir" && "$path" == "$project_dir"-* ]]; then
+        local suffix="${path#"$project_dir"-}"
+        if [[ "$suffix" =~ ^[a-z]{1,2}$ ]]; then
+            return 0
+        fi
+    fi
+
+    return 1
+}

--- a/scripts/remove.ps1
+++ b/scripts/remove.ps1
@@ -116,41 +116,15 @@ function Remove-DockerImage {
     }
 }
 
-function Get-ManagedWorktreePath {
-    <#
-    .SYNOPSIS
-    Paths this installer created, folded for comparison.
-    .DESCRIPTION
-    setup-worktrees and setup-isolated record every workspace they create
-    under PROJECT_DIR_<X> / ISOLATED_WORKSPACE_<X>, so .env is the
-    authoritative list of what this tool owns. Anything outside it belongs to
-    the user and must never reach a recursive delete.
-
-    Read from .env rather than derived from NUM_ACCOUNTS: at removal time the
-    count may already have been lowered, and a workspace dropped from the
-    count is still one this tool created.
-    #>
-    param([Parameter(Mandatory)][hashtable]$EnvData)
-
-    $managed = @()
-    foreach ($key in $EnvData.Keys) {
-        if ($key -match '^(PROJECT_DIR|ISOLATED_WORKSPACE)_[A-Z]+$' -and $EnvData[$key]) {
-            $managed += (ConvertTo-ComparablePath -Path $EnvData[$key])
-        }
-    }
-    return $managed
-}
-
 function Remove-Worktrees {
     Write-LogStep 'Removing git worktrees'
 
     $projectDir = ''
-    $managedPaths = @()
+    $envData = $null
     $envFile = Join-Path $ProjectRoot '.env'
     if (Test-Path $envFile) {
         $envData = Read-EnvFile -Path $envFile
         $projectDir = $envData['PROJECT_DIR']
-        $managedPaths = @(Get-ManagedWorktreePath -EnvData $envData)
     }
 
     if (-not $projectDir) {
@@ -183,9 +157,39 @@ function Remove-Worktrees {
         $removable = @(Select-RemovableWorktree -WorktreePath $listed `
             -CurrentPath (Get-Location).Path)
 
+        # Not being the current tree is not the same as being ours. Ownership
+        # gates the target list, not just the fallback: a worktree the user
+        # added themselves in this repository was previously removed with
+        # --force before any fallback was reached.
+        $targets = @()
         foreach ($wtPath in $removable) {
             if (-not (Test-Path $wtPath)) { continue }
+            if (Test-OwnedWorktreePath -Path $wtPath -ProjectDir $projectDir -EnvData $envData) {
+                $targets += $wtPath
+            }
+            else {
+                Write-LogInfo "Keeping worktree not created by claude-docker: $wtPath"
+            }
+        }
 
+        if ($targets.Count -eq 0) {
+            Write-LogInfo 'No claude-docker worktrees found'
+            return
+        }
+
+        # Every other destructive step here prompts for itself. This one did
+        # not, and the run-level "Proceed with removal?" never names what is
+        # about to go.
+        Write-Host ''
+        Write-Host 'Worktrees to remove:' -ForegroundColor White
+        foreach ($wtPath in $targets) { Write-Host "  - $wtPath" }
+        Write-Host ''
+        if (-not (Read-Confirmation -Question "Remove the $($targets.Count) worktree(s) listed above?")) {
+            Write-LogInfo 'Worktrees kept'
+            return
+        }
+
+        foreach ($wtPath in $targets) {
             Write-LogInfo "Removing worktree: $wtPath"
             & git worktree remove $wtPath --force 2>$null
             if ($LASTEXITCODE -eq 0) {
@@ -193,29 +197,13 @@ function Remove-Worktrees {
                 continue
             }
 
-            # git refused. Before escalating to a recursive delete, require the
-            # path to be one this tool created -- git's refusal is often the
-            # last thing standing between the fallback and a directory that was
-            # never ours.
-            if ($managedPaths -notcontains (ConvertTo-ComparablePath -Path $wtPath)) {
-                Write-LogWarn "git refused to remove $wtPath, and it is not a workspace this installer created - left in place."
-                $script:WorktreesLeftBehind += $wtPath
-                continue
-            }
-
-            Write-LogWarn "Force removing: $wtPath"
-            try {
-                Remove-Item -LiteralPath $wtPath -Recurse -Force -ErrorAction Stop
-                & git worktree prune 2>$null
-                $worktreeCount++
-            }
-            catch {
-                # Swallowing this is what reduced a destroyed repository to one
-                # log line; a delete that fails at uninstall time is something
-                # the user has to be told about.
-                Write-LogError "Could not remove $($wtPath): $($_.Exception.Message)"
-                $script:WorktreesLeftBehind += $wtPath
-            }
+            # No recursive-delete fallback. git declining to remove a worktree
+            # it created is information -- the path is locked, or it is not the
+            # tree we think it is. Escalating past that refusal is what turned
+            # a wrong path into data loss.
+            Write-LogWarn "git declined to remove $wtPath - left in place."
+            Write-LogWarn '  Inspect it and remove it manually if it is no longer needed.'
+            $script:WorktreesLeftBehind += $wtPath
         }
     }
     finally {

--- a/scripts/remove.sh
+++ b/scripts/remove.sh
@@ -26,6 +26,10 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 . "$SCRIPT_DIR/lib/parse_env.sh"
 # shellcheck source=lib/runtime.sh
 . "$SCRIPT_DIR/lib/runtime.sh"
+# worktrees.sh decides which worktrees this installer owns; sourced after
+# parse_env.sh, which it reads .env through.
+# shellcheck source=lib/worktrees.sh
+. "$SCRIPT_DIR/lib/worktrees.sh"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -156,9 +160,10 @@ remove_worktrees() {
     log_step "Removing git worktrees"
 
     # Read PROJECT_DIR from .env if it exists
+    local env_file="$PROJECT_ROOT/.env"
     local project_dir=""
-    if [[ -f "$PROJECT_ROOT/.env" ]]; then
-        project_dir=$(parse_env_value "$PROJECT_ROOT/.env" "PROJECT_DIR")
+    if [[ -f "$env_file" ]]; then
+        project_dir=$(parse_env_value "$env_file" "PROJECT_DIR")
     fi
 
     if [[ -z "$project_dir" ]]; then
@@ -171,24 +176,69 @@ remove_worktrees() {
         return 0
     fi
 
-    # Find worktrees created by setup-worktrees.sh (named {project}-a, {project}-b)
-    local worktree_count=0
+    # Partition what git reports into worktrees this installer created and
+    # worktrees the user made themselves. The loop this replaces took
+    # "not the current directory" as the whole test, so a `git worktree add
+    # ../proj-hotfix` in the same repository was removed with --force and then
+    # rm -rf. The comment claimed to be looking for setup-worktrees.sh's
+    # names; now it actually is (scripts/lib/worktrees.sh).
+    local targets=() skipped=() wt_path
     cd "$project_dir"
-    while IFS= read -r wt_line; do
-        local wt_path="${wt_line#worktree }"
-        if [[ "$wt_path" != "$(pwd)" ]] && [[ -d "$wt_path" ]]; then
-            log_info "Removing worktree: $wt_path"
-            git worktree remove "$wt_path" --force 2>/dev/null || {
-                log_warn "Force removing: $wt_path"
-                rm -rf "$wt_path" 2>/dev/null || true
-                git worktree prune 2>/dev/null || true
-            }
-            worktree_count=$((worktree_count + 1))
+    while IFS= read -r wt_path; do
+        [[ -d "$wt_path" ]] || continue
+        if worktree_is_owned "$wt_path" "$project_dir" "$env_file"; then
+            targets+=("$wt_path")
+        else
+            skipped+=("$wt_path")
         fi
-    done < <(git worktree list --porcelain 2>/dev/null | grep "^worktree " || true)
+    done < <(worktree_selectable_paths "$(pwd)")
+
+    # Guarded by the count rather than expanding the array directly: bash 3.2
+    # (still what macOS ships) errors on "${arr[@]}" for an empty array under
+    # `set -u`.
+    if [[ ${#skipped[@]} -gt 0 ]]; then
+        for wt_path in "${skipped[@]}"; do
+            log_info "Keeping worktree not created by claude-docker: $wt_path"
+        done
+    fi
+
+    if [[ ${#targets[@]} -eq 0 ]]; then
+        log_info "No claude-docker worktrees found"
+        return 0
+    fi
+
+    # Every other destructive step in this script prompts for itself
+    # (remove_docker_image, remove_state_directories, remove_env_file). This
+    # one did not, and the single "Proceed with removal?" at the top never
+    # names what is about to go, so the user could not see the list.
+    echo ""
+    echo -e "${BOLD}Worktrees to remove:${NC}"
+    for wt_path in "${targets[@]}"; do
+        echo "  - $wt_path"
+    done
+    echo ""
+    if ! prompt_confirm "Remove the ${#targets[@]} worktree(s) listed above?"; then
+        log_info "Worktrees kept"
+        return 0
+    fi
+
+    local worktree_count=0
+    for wt_path in "${targets[@]}"; do
+        log_info "Removing worktree: $wt_path"
+        if git worktree remove "$wt_path" --force 2>/dev/null; then
+            worktree_count=$((worktree_count + 1))
+            continue
+        fi
+        # No rm -rf fallback. git refusing to remove a worktree it created is
+        # information, not an obstacle: the path is locked, or it is not the
+        # tree we think it is. Escalating past that refusal is what turned a
+        # wrong path into data loss.
+        log_warn "git declined to remove $wt_path — left in place"
+        log_warn "  Inspect it and remove it manually if it is no longer needed."
+    done
 
     if [[ $worktree_count -eq 0 ]]; then
-        log_info "No worktrees found"
+        log_info "No worktrees removed"
     else
         log_success "$worktree_count worktree(s) removed"
     fi

--- a/tests/test_worktree_ownership.sh
+++ b/tests/test_worktree_ownership.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# test_worktree_ownership.sh - which worktrees the removal steps may delete
+# (issue #344).
+#
+# Run:  bash tests/test_worktree_ownership.sh
+# Exits non-zero on any failure.
+#
+# remove.sh and cleanup.sh took "not the current directory" as the whole test,
+# so a worktree the user added themselves was removed with --force and then
+# rm -rf. cleanup.sh additionally read the porcelain output through
+# `awk '{print $2}'`, truncating any path containing a space and then
+# reporting the truncated path as removed.
+#
+# The subject is scripts/lib/worktrees.sh, which both scripts now route
+# through, exercised against real `git worktree add` output rather than a
+# fixture -- the space-truncation defect only exists in how git's real output
+# is parsed. What is deliberately not covered here is the surrounding scripts:
+# running remove.sh end to end needs docker, a populated .env and a HOME to
+# clobber. The decision under test is the partition, and that is what runs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=../scripts/lib/parse_env.sh
+. "$PROJECT_ROOT/scripts/lib/parse_env.sh"
+# shellcheck source=../scripts/lib/worktrees.sh
+. "$PROJECT_ROOT/scripts/lib/worktrees.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  PASS  $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL  $label"
+        echo "        expected: $expected"
+        echo "        actual:   $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_dir_exists() {
+    local label="$1" dir="$2"
+    if [[ -d "$dir" ]]; then
+        echo "  PASS  $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL  $label ($dir is gone)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- Fixture ------------------------------------------------------------------
+# A project repository with three linked worktrees:
+#   proj-a          installer-named ({project}-<letter>), and in .env
+#   proj-clone      installer-created, recorded only as ISOLATED_WORKSPACE_A
+#   my hotfix       user-added, path contains a space
+#
+# The space is in a *user* worktree on purpose: a parser that truncates at the
+# first space would produce "$WORK/my" for it, which matches nothing, so the
+# entry would be silently misclassified rather than obviously wrong.
+
+PROJECT="$WORK/proj"
+USER_WT="$WORK/my hotfix"
+CLONE_WT="$WORK/proj-clone"
+
+mkdir -p "$PROJECT"
+git -C "$PROJECT" init -q
+git -C "$PROJECT" -c user.email=t@e -c user.name=t commit -q --allow-empty -m init
+git -C "$PROJECT" worktree add -q -b wt-a "$PROJECT-a"
+git -C "$PROJECT" worktree add -q -b clone "$CLONE_WT"
+git -C "$PROJECT" worktree add -q -b hotfix "$USER_WT"
+
+ENV_FILE="$WORK/.env"
+cat > "$ENV_FILE" <<EOF
+PROJECT_DIR=$PROJECT
+PROJECT_DIR_A=$PROJECT-a
+ISOLATED_WORKSPACE_A=$CLONE_WT
+EOF
+
+# --- worktree_list_paths ------------------------------------------------------
+
+echo "== worktree_list_paths =="
+
+cd "$PROJECT"
+listed_count=$(worktree_list_paths | wc -l | tr -d ' ')
+assert_eq "reports every worktree (main + 3 linked)" "4" "$listed_count"
+
+# The regression the awk parser caused: the path is emitted whole.
+assert_eq "a path containing a space survives intact" \
+    "$USER_WT" \
+    "$(worktree_list_paths | grep 'hotfix')"
+
+assert_eq "the main working tree is listed first" \
+    "$PROJECT" \
+    "$(worktree_list_paths | head -n 1)"
+
+# --- worktree_selectable_paths ------------------------------------------------
+
+echo "== worktree_selectable_paths =="
+
+selectable=$(worktree_selectable_paths "$(pwd)")
+assert_eq "the main tree is not selectable from itself" "" \
+    "$(printf '%s\n' "$selectable" | grep -x -F "$PROJECT" || true)"
+assert_eq "the three linked worktrees are selectable" "3" \
+    "$(printf '%s\n' "$selectable" | grep -c . )"
+
+# Standing in a linked worktree is the case where the caller's own path does
+# not identify the repository at risk; the ordering guard is what covers it.
+cd "$USER_WT"
+from_linked=$(worktree_selectable_paths "$(pwd)")
+assert_eq "the main tree is not selectable from a linked worktree" "" \
+    "$(printf '%s\n' "$from_linked" | grep -x -F "$PROJECT" || true)"
+assert_eq "the caller's own worktree excludes itself" "" \
+    "$(printf '%s\n' "$from_linked" | grep -x -F "$USER_WT" || true)"
+cd "$PROJECT"
+
+# --- worktree_is_owned --------------------------------------------------------
+
+echo "== worktree_is_owned =="
+
+owned_or_not() {
+    if worktree_is_owned "$1" "$PROJECT" "$ENV_FILE"; then echo "owned"; else echo "foreign"; fi
+}
+
+assert_eq "the {project}-<letter> worktree is ours" "owned"   "$(owned_or_not "$PROJECT-a")"
+assert_eq "an ISOLATED_WORKSPACE path is ours"      "owned"   "$(owned_or_not "$CLONE_WT")"
+assert_eq "a user-added worktree is not ours"       "foreign" "$(owned_or_not "$USER_WT")"
+
+# A trailing slash is a spelling, not a different directory.
+assert_eq "a trailing slash still matches" "owned" "$(owned_or_not "$PROJECT-a/")"
+
+# remove.sh deletes .env in a later step than the worktrees, and installs
+# predating the keys never had them, so the naming pattern has to stand alone.
+if worktree_is_owned "$PROJECT-a" "$PROJECT" ""; then
+    assert_eq "the naming pattern works without .env" "owned" "owned"
+else
+    assert_eq "the naming pattern works without .env" "owned" "foreign"
+fi
+if worktree_is_owned "$CLONE_WT" "$PROJECT" ""; then
+    assert_eq "a clone path is not guessable without .env" "foreign" "owned"
+else
+    assert_eq "a clone path is not guessable without .env" "foreign" "foreign"
+fi
+
+# The suffix must be a letter run. "proj-2" and "proj-a-b" are not names this
+# installer produces, and treating them as ours would widen the delete set.
+assert_eq "a numeric suffix is not the naming pattern" "foreign" "$(owned_or_not "$PROJECT-2")"
+assert_eq "a nested suffix is not the naming pattern"  "foreign" "$(owned_or_not "$PROJECT-a/sub")"
+
+# The pattern must cover exactly what index_to_letter can emit and no more.
+# normalize_account_count caps the count at 702 and index 702 is "zz", so two
+# characters is the ceiling. A looser [a-z]+ claims "<project>-clone" and
+# "<project>-hotfix" -- the user-created siblings this check exists to spare.
+assert_eq "two letters (the generator's ceiling) are ours" "owned" \
+    "$(owned_or_not "$PROJECT-zz")"
+assert_eq "three letters exceed the generator's range" "foreign" \
+    "$(owned_or_not "$PROJECT-abc")"
+assert_eq "a word suffix is not the naming pattern" "foreign" \
+    "$(owned_or_not "$PROJECT-hotfix")"
+
+# --- The removal step, run over the partition ---------------------------------
+
+echo "== removal over the partition =="
+
+# Exactly what remove.sh now does, minus the prompt: partition, then remove
+# only the owned side.
+targets=()
+skipped=()
+while IFS= read -r wt; do
+    [[ -d "$wt" ]] || continue
+    if worktree_is_owned "$wt" "$PROJECT" "$ENV_FILE"; then
+        targets+=("$wt")
+    else
+        skipped+=("$wt")
+    fi
+done < <(worktree_selectable_paths "$(pwd)")
+
+assert_eq "two worktrees are targeted" "2" "${#targets[@]}"
+assert_eq "one worktree is skipped"    "1" "${#skipped[@]}"
+assert_eq "the skipped one is the user's" "$USER_WT" "${skipped[0]}"
+
+for wt in "${targets[@]}"; do
+    git worktree remove "$wt" --force 2>/dev/null || true
+done
+
+assert_dir_exists "the user's worktree survives"      "$USER_WT"
+assert_dir_exists "the main repository survives"      "$PROJECT"
+assert_dir_exists "the main repository keeps its .git" "$PROJECT/.git"
+assert_eq "the installer worktree is gone" "absent" \
+    "$([[ -d "$PROJECT-a" ]] && echo present || echo absent)"
+assert_eq "the clone worktree is gone" "absent" \
+    "$([[ -d "$CLONE_WT" ]] && echo present || echo absent)"
+
+# --- Summary ------------------------------------------------------------------
+
+echo ""
+echo "== Summary: PASS=$PASS FAIL=$FAIL =="
+[[ $FAIL -eq 0 ]]

--- a/tests/test_worktree_path_guard.ps1
+++ b/tests/test_worktree_path_guard.ps1
@@ -131,18 +131,74 @@ Assert-Set 'a path that merely shares a prefix is still removable' `
     (Select-RemovableWorktree -WorktreePath @('D:/Sources/claude-docker', 'D:/Sources/claude-docker-extra') `
         -CurrentPath 'D:\Sources\claude-docker')
 
-Write-Host '== both removers route through the shared selector =='
+Write-Host '== Test-OwnedWorktreePath: ownership (issue #344) =='
 
-# The point of the shared function is that one fix covers both scripts. If
+# Not being the current tree is not the same as being ours. This is the second
+# axis: a worktree the user added themselves in the project repository was
+# previously removed with --force before any other guard was consulted.
+# Mirrors worktree_is_owned in scripts/lib/worktrees.sh; the bash side is
+# exercised against real git output by tests/test_worktree_ownership.sh.
+
+$project = 'D:\Sources\myapp'
+$envData = @{
+    'PROJECT_DIR'          = 'D:/Sources/myapp'
+    'PROJECT_DIR_A'        = 'D:/Sources/myapp-a'
+    'ISOLATED_WORKSPACE_A' = 'D:/Sources/clones/myapp-iso-a'
+    'GH_TOKEN'             = 'placeholder-not-a-path'
+}
+function Test-Owned {
+    param([string]$Path, [hashtable]$Data = $envData)
+    return (Test-OwnedWorktreePath -Path $Path -ProjectDir $project -EnvData $Data)
+}
+
+Assert-Eq 'a PROJECT_DIR_<X> path is ours' $true (Test-Owned 'D:\Sources\myapp-a')
+Assert-Eq 'an ISOLATED_WORKSPACE_<X> path is ours' $true (Test-Owned 'D:/Sources/clones/myapp-iso-a')
+Assert-Eq 'a user-added worktree is not ours' $false (Test-Owned 'D:\Sources\myapp-hotfix')
+Assert-Eq 'an unrelated directory is not ours' $false (Test-Owned 'D:\Work\somethingelse')
+
+# PROJECT_DIR itself has no letter suffix and must not be read as a workspace
+# key, or the project repository would qualify as its own removable worktree.
+Assert-Eq 'PROJECT_DIR is not a per-account key' $false (Test-Owned 'D:\Sources\myapp')
+
+# remove.ps1 deletes .env in a later step than the worktrees, and installs
+# predating the keys never had them, so the naming pattern must stand alone.
+Assert-Eq 'the naming pattern works with no .env' $true (Test-Owned 'D:\Sources\myapp-b' $null)
+Assert-Eq 'a clone path is not guessable with no .env' $false `
+    (Test-Owned 'D:/Sources/clones/myapp-iso-a' $null)
+
+# The pattern must accept exactly what the generator emits. The account count
+# is capped at 702 and index 702 is "zz", so two characters is the ceiling; a
+# looser [A-Za-z]+ would claim "<project>-clone" and "<project>-hotfix".
+Assert-Eq 'two letters (the ceiling) are ours' $true (Test-Owned 'D:\Sources\myapp-zz')
+Assert-Eq 'three letters exceed the range' $false (Test-Owned 'D:\Sources\myapp-abc')
+Assert-Eq 'a numeric suffix is not the pattern' $false (Test-Owned 'D:\Sources\myapp-2')
+
+# Separator form must not decide ownership, for the same reason it must not
+# decide self-exclusion.
+Assert-Eq 'a forward-slash spelling still matches .env' $true (Test-Owned 'D:/Sources/myapp-a')
+Assert-Eq 'a trailing separator still matches' $true (Test-Owned 'D:\Sources\myapp-a\')
+
+Write-Host '== both removers route through the shared helpers =='
+
+# The point of the shared functions is that one fix covers both scripts. If
 # either grows its own copy of the loop again, everything above keeps passing
-# while the defect comes back, so the call site is asserted too.
+# while the defect comes back, so the call sites are asserted too.
 foreach ($name in 'remove.ps1', 'cleanup.ps1') {
     $source = Get-Content -LiteralPath (Join-Path $ScriptsDir $name) -Raw
     Assert-Eq "$name calls Select-RemovableWorktree" $true `
         ($source -like '*Select-RemovableWorktree*')
+    Assert-Eq "$name checks ownership before removing" $true `
+        ($source -like '*Test-OwnedWorktreePath*')
     Assert-Eq "$name no longer compares against a raw `$currentDir" $false `
         ($source -like '*-ne $currentDir*')
 }
+
+# The recursive-delete fallback is gone from remove.ps1. git declining to
+# remove a worktree it created is information; escalating past that refusal is
+# what turned a wrong path into data loss.
+$removeSource = Get-Content -LiteralPath (Join-Path $ScriptsDir 'remove.ps1') -Raw
+Assert-Eq 'remove.ps1 has no recursive worktree delete' $false `
+    ($removeSource -like '*Remove-Item -LiteralPath $wtPath -Recurse*')
 
 Write-Host ''
 Write-Host ("== Summary: PASS={0} FAIL={1} ==" -f $script:Pass, $script:Fail)


### PR DESCRIPTION
Closes #344
Relates to #342, #345

## What

`remove_worktrees` in `scripts/remove.sh` force-removed every worktree attached to `PROJECT_DIR`, with no name filter and no per-step confirmation. The comment said it was looking for the worktrees `setup-worktrees.sh` creates; the code checked only "not the current directory" and "is a directory".

```bash
if [[ "$wt_path" != "$(pwd)" ]] && [[ -d "$wt_path" ]]; then
    git worktree remove "$wt_path" --force 2>/dev/null || {
        rm -rf "$wt_path" 2>/dev/null || true
```

So `git worktree add ../proj-hotfix`, `.claude/worktrees/feature-x`, or an editor's worktree pool all matched. It was also the only destructive step in the script without its own prompt - `remove_docker_image`, `remove_state_directories` and `remove_env_file` each have one, and the run-level `Proceed with removal?` never names the worktrees.

**Companion defect in `cleanup.sh`:**

```bash
for wt in $(git worktree list --porcelain | grep "^worktree " | awk '{print $2}'); do
```

`awk '{print $2}'` truncates `/Users/me/My Projects/repo-a` at the first space and the unquoted `$(...)` splits it again. `git worktree remove` then fails on a path that does not exist, `2>/dev/null || true` swallows it, and the run prints `Removing worktree: /Users/me/My` as if it had succeeded. The real worktree survives to collide with the next `git worktree add`.

## Why

`remove.sh` predates the assumption it encodes. When Tier B worktrees were the only worktrees a user was expected to have under `PROJECT_DIR`, "every worktree except the current one" and "the ones we created" were the same set, and the comment recorded the intent rather than the filter. Isolated mode (#335) added a second naming source without narrowing the loop.

This is a different axis from #342. That one was self-exclusion (the main tree was never excluded on Windows); this one is ownership. A correctly self-excluding loop still deletes every unrelated worktree the user owns.

## How

Ownership has exactly two sources, both written by this installer:

1. `PROJECT_DIR_<X>` / `ISOLATED_WORKSPACE_<X>` in `.env`.
2. The `<project>-<letter>` naming `setup-worktrees.sh:49` produces - needed because `remove.sh` deletes `.env` in a *later* step than the worktrees, and installs predating those keys never had them.

The rules live in `scripts/lib/worktrees.sh` (`worktree_list_paths`, `worktree_selectable_paths`, `worktree_is_owned`) and `Test-OwnedWorktreePath` in `ClaudeDocker.psm1`, so the four scripts cannot drift apart again. All four now:

- filter to owned worktrees and report the rest as kept,
- list targets and prompt before deleting (`remove.sh` / `remove.ps1`),
- report a `git worktree remove` refusal instead of swallowing or escalating it.

The `rm -rf` / `Remove-Item -Recurse -Force` fallback is **gone**. git declining to remove a worktree it created is information - the path is locked, or it is not the tree we think it is. Escalating past that refusal is what turned a wrong path into data loss.

`cleanup.sh` now reads the list the way `remove.sh` always did (`while IFS= read -r` plus `${line#worktree }`), so a path containing a space survives intact.

### A real finding from the new test

The first version of the ownership pattern accepted `[a-z]+` as the letter suffix. The test fixture happened to include a clone at `<project>-clone`, and it was classified as **ours** - `clone` is a lowercase letter run. So would `<project>-hotfix` and `<project>-wip`, which are exactly the sibling worktrees this check exists to spare.

The bound is now two characters, which is precisely what the generator can emit: `normalize_account_count` caps the count at 702 and `index_to_letter` turns 702 into `zz`. The pattern accepts the generator's output domain and nothing wider. Both implementations and both test suites carry the case.

### Verification

- `tests/test_worktree_ownership.sh` (new, 26 assertions, added to the `bash-tests` matrix) - `PASS=26 FAIL=0` under WSL. It builds a real repository with three linked worktrees (installer-named, an `ISOLATED_WORKSPACE` clone, and a user-added one whose path contains a space), drives the partition over **real** `git worktree list --porcelain` output, then performs the removal and asserts the user's worktree, the main repository and its `.git` all survive.
- `tests/test_worktree_path_guard.ps1` extended to 34 assertions (from 19) - `PASS=34 FAIL=0`. It also asserts both `.ps1` removers still route through the shared helpers and that the recursive fallback is gone, so a reinlined loop fails the test rather than passing silently.
- `tests/test_cleanup_backups.sh` - `PASS=13 FAIL=0` (the other consumer of `cleanup.sh`).
- `tests/test_isolation_modes.ps1` - `PASS=48 FAIL=0` (the other consumer of the module).
- `bash -n` on all four modified shell files; PowerShell `Parser::ParseFile` on all three modified `.ps1`/`.psm1` files - these are not executed by any test, so a syntax error would first surface on a user's uninstall.
- Verified under **WSL**, not Git Bash: on Git Bash `git` reports `C:/...` while the shell reports `/tmp/...`, so path comparisons fail for reasons that have nothing to do with this change. That is the environment the CI runner matches.
- shellcheck and PSScriptAnalyzer were **not** run locally (neither is installed on this host); the `Shellcheck` and `PSScriptAnalyzer` jobs cover them.
- No removal script was executed against a real installation.

## Where

- `scripts/lib/worktrees.sh` - new shared library
- `scripts/remove.sh` - `remove_worktrees`
- `scripts/cleanup.sh` - worktree block
- `scripts/ClaudeDocker.psm1` - `Test-OwnedWorktreePath`
- `scripts/remove.ps1` - `Remove-Worktrees` (the local `Get-ManagedWorktreePath` moved into the module as a predicate)
- `scripts/cleanup.ps1` - worktree block
- `tests/test_worktree_ownership.sh`, `tests/test_worktree_path_guard.ps1`, `.github/workflows/ci.yml`

## Notes for the reviewer

`cleanup.ps1` reads `.env` from `$ProjectRoot` while `-RepoDir` names the repository being cleaned. That is deliberate: the `.env` that records the workspaces belongs to the claude-docker checkout, not to the user's project repository.

A remaining known limit of source 2: a user-created sibling named `<project>-ui` or `<project>-v2` would still be classified as ours when `.env` is absent. Narrowing further means dropping the pattern entirely and relying on `.env`, which would break uninstall for installs predating those keys. The two-character bound is where the trade-off currently sits, and it is stated in both implementations.
