### PR TITLE
fix(cleanup): gate backup deletion behind a confirmation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,7 @@ jobs:
           - tests/test_container_memory.ps1
           - tests/test_powershell_platform_guard.ps1
           - tests/test_worktree_path_guard.ps1
+          - tests/test_cleanup_gate.ps1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run ${{ matrix.test }}

--- a/scripts/ClaudeDocker.psm1
+++ b/scripts/ClaudeDocker.psm1
@@ -1186,6 +1186,75 @@ function Test-OwnedWorktreePath {
     return $false
 }
 
+# --- Cleanup Policy -----------------------------------------------------------
+
+function Get-CleanupDecision {
+    <#
+    .SYNOPSIS
+    Decide whether a destructive cleanup step may proceed.
+    .DESCRIPTION
+    cleanup.ps1 has two destructive steps and used to have two different
+    policies for them: state-directory removal was gated on
+    -Force / -SkipState / a prompt / a refusal on a non-interactive host, and
+    backup removal simply ran. Both now route through this function, so the
+    two cannot drift apart again, and the policy can be tested without a
+    Windows host to run cleanup.ps1 on.
+
+    Returns one of:
+      remove  proceed without asking (-Force)
+      skip    do nothing (-SkipState)
+      refuse  abort; no answer is available and guessing would delete files
+      ask     prompt the operator
+
+    'refuse' rather than 'skip' on a non-interactive host is deliberate and
+    mirrors cleanup.sh: a pipeline that meant to clean up and silently did
+    not is its own failure, so the caller is told to pass a switch.
+    .PARAMETER Interactive
+    Whether a real console can answer. Passed in rather than detected here so
+    the decision stays pure.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][bool]$Force,
+        [Parameter(Mandatory)][bool]$Skip,
+        [Parameter(Mandatory)][bool]$Interactive
+    )
+
+    if ($Force) { return 'remove' }
+    if ($Skip) { return 'skip' }
+    if (-not $Interactive) { return 'refuse' }
+    return 'ask'
+}
+
+function Test-FileAgeExceedsDays {
+    <#
+    .SYNOPSIS
+    Whether a file is older than -Days, using find(1)'s whole-day rule.
+    .DESCRIPTION
+    cleanup.sh selects backups with `find -mtime +N`, which truncates a
+    file's age to whole days before comparing: a 7.5-day-old file reports 7,
+    so `-mtime +7` does not match it. cleanup.ps1 compared against an exact
+    `(Get-Date).AddDays(-N)` instant and did match it -- same flag, same
+    value, opposite outcome.
+
+    Truncation is the documented reading of "--backup-age-days N" and is what
+    the existing bash fixture assumes, so PowerShell moves to bash rather
+    than the other way round.
+    .PARAMETER Now
+    The reference instant. A parameter rather than Get-Date so a test can pin
+    the comparison instead of racing the clock.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][datetime]$LastWriteTime,
+        [Parameter(Mandatory)][datetime]$Now,
+        [Parameter(Mandatory)][int]$Days
+    )
+
+    $ageDays = [math]::Floor(($Now - $LastWriteTime).TotalDays)
+    return $ageDays -gt $Days
+}
+
 # --- Exports -----------------------------------------------------------------
 
 Export-ModuleMember -Function @(
@@ -1199,6 +1268,8 @@ Export-ModuleMember -Function @(
     'Protect-EnvFile',
     # Worktrees
     'Select-RemovableWorktree', 'Test-OwnedWorktreePath',
+    # Cleanup policy
+    'Get-CleanupDecision', 'Test-FileAgeExceedsDays',
     # Accounts
     'Get-NumAccounts', 'Get-AgentRuntime', 'Get-ServicePrefix',
     'Get-PrimaryService', 'Get-AgentStateRoot', 'Get-ServiceNames',

--- a/scripts/cleanup.ps1
+++ b/scripts/cleanup.ps1
@@ -28,6 +28,12 @@ param(
     [Alias('Yes')][switch]$Force,
     [Alias('No')][switch]$SkipState,
     [Alias('B')][switch]$Backups,
+    # Bounded so a negative value cannot put the cutoff in the future and
+    # sweep every backup. 0 is allowed and means the same as `find -mtime +0`:
+    # anything at least a whole day old. Validation runs at parameter binding,
+    # before the platform guard below, so a rejected value never reaches the
+    # deletion path on any host.
+    [ValidateRange(0, 3650)]
     [int]$BackupAgeDays = 7
 )
 
@@ -51,16 +57,62 @@ Import-Module "$PSScriptRoot\ClaudeDocker.psm1" -Force
 $ProjectRoot = Split-Path $PSScriptRoot -Parent
 Push-Location $ProjectRoot
 
+# Interactive-only paths need a real host that can accept input. Detected once
+# here so both destructive steps below judge it the same way; a redirected
+# stdin or a remoting host cannot answer a prompt, and hanging CI on one is
+# what the check prevents.
+$script:Interactive = ($Host.Name -ne 'ServerRemoteHost') -and (-not [Console]::IsInputRedirected)
+
+# Resolve-Step turns the switches into an answer for one destructive step, or
+# aborts when there is no answer to be had. Both steps call it, which is the
+# point: this script used to gate state-directory removal and not gate backup
+# removal, so one script carried two policies for two destructive actions.
+function Resolve-Step {
+    param([Parameter(Mandatory)][string]$Question)
+
+    $decision = Get-CleanupDecision -Force:$Force.IsPresent -Skip:$SkipState.IsPresent `
+                                    -Interactive:$script:Interactive
+    switch ($decision) {
+        'remove' { return $true }
+        'skip' { return $false }
+        'ask' { return (Read-Confirmation -Question $Question) }
+        'refuse' {
+            Write-Error '  stdin is not interactive. Pass -Force to proceed non-interactively, or -SkipState to skip.'
+            exit 1
+        }
+        default {
+            # Fail closed. An unrecognized decision reaching a delete is worse
+            # than an aborted cleanup, and `default` silently prompting would
+            # hide the mismatch on an interactive host.
+            Write-Error "  Unexpected cleanup decision '$decision'."
+            exit 1
+        }
+    }
+}
+
 try {
     if ($Backups) {
         Write-Host "=== Removing stale .env backup files (>$BackupAgeDays days) ===" -ForegroundColor Cyan
-        $cutoff = (Get-Date).AddDays(-$BackupAgeDays)
-        Get-ChildItem -Path $ProjectRoot -Filter '.env.backup.*' -File -ErrorAction SilentlyContinue |
-            Where-Object { $_.LastWriteTime -lt $cutoff } |
-            Remove-Item -Force
-        Get-ChildItem -Path $ProjectRoot -Filter '.env.bak' -File -ErrorAction SilentlyContinue |
-            Where-Object { $_.LastWriteTime -lt $cutoff } |
-            Remove-Item -Force
+        # These files are the only recovery point for a .env holding API keys
+        # and GH tokens (install.ps1 rotates them and keeps three), which is
+        # why cleanup.sh has always asked before deleting them and why
+        # remove.ps1 sweeps them only after its own confirmation.
+        if (Resolve-Step -Question "Remove stale .env.backup.* and .env.bak files older than $BackupAgeDays days?") {
+            # `find -mtime +N` truncates the age to whole days; matching that
+            # here is what keeps the same flag and value from producing
+            # opposite outcomes on the two platforms.
+            $now = Get-Date
+            Get-ChildItem -Path $ProjectRoot -Filter '.env.backup.*' -File -ErrorAction SilentlyContinue |
+                Where-Object { Test-FileAgeExceedsDays -LastWriteTime $_.LastWriteTime -Now $now -Days $BackupAgeDays } |
+                Remove-Item -Force
+            Get-ChildItem -Path $ProjectRoot -Filter '.env.bak' -File -ErrorAction SilentlyContinue |
+                Where-Object { Test-FileAgeExceedsDays -LastWriteTime $_.LastWriteTime -Now $now -Days $BackupAgeDays } |
+                Remove-Item -Force
+            Write-Host '  Stale backups removed.'
+        }
+        else {
+            Write-Host '  Skipped.'
+        }
     }
 
     Write-Host '=== Stopping containers ===' -ForegroundColor Cyan
@@ -115,24 +167,9 @@ try {
     }
 
     Write-Host '=== Removing state directories ===' -ForegroundColor Cyan
-    $shouldRemove = $false
-    if ($Force) {
-        $shouldRemove = $true
-    } elseif ($SkipState) {
-        $shouldRemove = $false
-    } else {
-        # Interactive-only path: detect a real host that can accept input.
-        # Read-Confirmation throws on non-interactive hosts (ServerRemoteHost,
-        # redirected stdin) which prevents CI hangs.
-        $interactive = ($Host.Name -ne 'ServerRemoteHost') -and (-not [Console]::IsInputRedirected)
-        if (-not $interactive) {
-            Write-Error '  stdin is not interactive. Pass -Force to remove state non-interactively, or -SkipState to skip.'
-            exit 1
-        }
-        $shouldRemove = Read-Confirmation -Question "Remove every runtime's state directory (~/.*-state)?"
-    }
-
-    if ($shouldRemove) {
+    # Same gate as the backup step above. This block is where the pattern came
+    # from; it now shares the implementation instead of being the only copy.
+    if (Resolve-Step -Question "Remove every runtime's state directory (~/.*-state)?") {
         # Remove every registered runtime's state directory, not just
         # Claude's, so a codex/gemini install is fully cleaned up (see #273).
         foreach ($runtime in Get-RuntimeList -ProjectRoot $ProjectRoot) {

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -49,6 +49,20 @@ BACKUP_AGE_DAYS=7
 expect_age_days=0
 for arg in "$@"; do
     if [ "$expect_age_days" = "1" ]; then
+        # Validate before assigning. Unchecked, this branch swallowed whatever
+        # token followed the flag: `--backups --backup-age-days --yes` set the
+        # age to "--yes" and left CONFIRM unset, so the prompt read "older than
+        # --yes days?" and the find that followed failed silently.
+        case "$arg" in
+            ''|*[!0-9]*)
+                echo "Invalid --backup-age-days value: $arg (expected a non-negative integer)" >&2
+                exit 2
+                ;;
+        esac
+        if [ "$arg" -gt 3650 ]; then
+            echo "Invalid --backup-age-days value: $arg (maximum 3650)" >&2
+            exit 2
+        fi
         BACKUP_AGE_DAYS="$arg"
         expect_age_days=0
         continue
@@ -96,11 +110,17 @@ if [ "$RUN_BACKUPS" = "1" ]; then
         fi
     fi
     if [ "$BACKUP_CONFIRM" = "yes" ]; then
-        find "$PROJECT_ROOT" -maxdepth 1 \
-            \( -name ".env.backup.*" -o -name ".env.bak" \) \
-            -mtime +"${BACKUP_AGE_DAYS}" \
-            -print -delete 2>/dev/null || true
-        echo "  Stale backups removed."
+        # Branch on find's status. `|| true` plus an unconditional success
+        # message reported a sweep that never ran as a sweep that succeeded.
+        if find "$PROJECT_ROOT" -maxdepth 1 \
+                \( -name ".env.backup.*" -o -name ".env.bak" \) \
+                -mtime +"${BACKUP_AGE_DAYS}" \
+                -print -delete 2>/dev/null; then
+            echo "  Stale backups removed."
+        else
+            echo "  Error: find failed while sweeping backups; nothing was reported as removed." >&2
+            exit 1
+        fi
     else
         echo "  Skipped."
     fi

--- a/tests/test_cleanup_backups.sh
+++ b/tests/test_cleanup_backups.sh
@@ -59,16 +59,24 @@ ENV_EXAMPLE="$TMPDIR_FAKE_ROOT/.env.example"
 OLD_BACKUP="$TMPDIR_FAKE_ROOT/.env.backup.1234567890"
 RECENT_BACKUP="$TMPDIR_FAKE_ROOT/.env.backup.9999999999"
 OLD_BAK="$TMPDIR_FAKE_ROOT/.env.bak"
+# 7.5 days old, tested against --backup-age-days 7. `find -mtime +7` truncates
+# the age to whole days, so this reports 7 and is kept. The PowerShell port
+# used to compare against an exact now-minus-7d instant and delete it: same
+# flag, same value, opposite outcome. Test-FileAgeExceedsDays is pinned to the
+# same verdict in tests/test_cleanup_gate.ps1.
+HALF_DAY_BACKUP="$TMPDIR_FAKE_ROOT/.env.backup.7500000000"
 
 printf 'KEY=value\n' > "$ENV_FILE"
 printf 'KEY=example\n' > "$ENV_EXAMPLE"
 printf 'KEY=old\n' > "$OLD_BACKUP"
 printf 'KEY=fresh\n' > "$RECENT_BACKUP"
 printf 'KEY=oldbak\n' > "$OLD_BAK"
+printf 'KEY=sevenandahalf\n' > "$HALF_DAY_BACKUP"
 
 # Mark old files 30 days in the past, leave fresh backup at current mtime.
 # Use `touch -d` (GNU/BSD-portable form).
 touch -d "30 days ago" "$OLD_BACKUP" "$OLD_BAK"
+touch -d "180 hours ago" "$HALF_DAY_BACKUP"
 
 echo "== Pre-check: fixture layout =="
 assert_present ".env exists"               "$ENV_FILE"
@@ -76,6 +84,35 @@ assert_present ".env.example exists"       "$ENV_EXAMPLE"
 assert_present "old .env.backup.* exists"  "$OLD_BACKUP"
 assert_present "fresh .env.backup.* exists" "$RECENT_BACKUP"
 assert_present ".env.bak exists"           "$OLD_BAK"
+assert_present "7.5-day backup exists"     "$HALF_DAY_BACKUP"
+
+echo "== Argument validation =="
+# The flag used to consume whatever token followed it, so
+# `--backups --backup-age-days --yes` set the age to "--yes" and left CONFIRM
+# unset. Off a TTY that exited 1 for the wrong reason; on a TTY it prompted
+# "older than --yes days?" and then ran a find that could not succeed.
+run_cleanup_expect_status() {
+    local label="$1" want="$2"; shift 2
+    local home status=0
+    home="$(mktemp -d)"
+    HOME="$home" PROJECT_ROOT_OVERRIDE="$TMPDIR_FAKE_ROOT" \
+        bash "$CLEANUP" "$@" >/dev/null 2>&1 </dev/null || status=$?
+    rm -rf "$home"
+    assert_eq "$label" "$want" "$status"
+}
+
+run_cleanup_expect_status "a flag as the age value exits 2" 2 \
+    --backups --backup-age-days --yes
+run_cleanup_expect_status "a non-integer age exits 2" 2 \
+    --backups --backup-age-days seven --yes
+run_cleanup_expect_status "a negative age exits 2" 2 \
+    --backups --backup-age-days -5 --yes
+run_cleanup_expect_status "an out-of-range age exits 2" 2 \
+    --backups --backup-age-days 4000 --yes
+
+# Validation must run before anything is deleted, not after.
+assert_present "old backup survives a rejected age value" "$OLD_BACKUP"
+assert_present ".env survives a rejected age value"       "$ENV_FILE"
 
 echo "== Running: cleanup.sh --backups --yes --backup-age-days 7 =="
 # --yes accepts both backup deletion and state-directory removal without
@@ -94,6 +131,8 @@ assert_missing "old .env.bak deleted"      "$OLD_BAK"
 assert_present "fresh .env.backup.* kept"  "$RECENT_BACKUP"
 assert_present ".env preserved"            "$ENV_FILE"
 assert_present ".env.example preserved"    "$ENV_EXAMPLE"
+# The whole-day truncation, asserted against real find(1) rather than assumed.
+assert_present "7.5-day backup kept at --backup-age-days 7" "$HALF_DAY_BACKUP"
 
 # Content sanity check on preserved files.
 assert_eq ".env content unchanged"         "KEY=value"   "$(cat "$ENV_FILE")"

--- a/tests/test_cleanup_gate.ps1
+++ b/tests/test_cleanup_gate.ps1
@@ -1,0 +1,154 @@
+# test_cleanup_gate.ps1 - the confirmation gate and age rule cleanup.ps1
+# applies before deleting .env backups (issue #345).
+#
+# Run:  pwsh -NoProfile -File tests/test_cleanup_gate.ps1
+# Exits non-zero on any failure.
+#
+# `cleanup.ps1 -Backups` used to delete .env.backup.* and .env.bak the moment
+# the switch was passed, while cleanup.sh refused to touch the same files
+# without an explicit answer. Those files are the only recovery point for a
+# .env carrying API keys and GitHub tokens.
+#
+# The policy and the age rule are asserted through the two module functions
+# both scripts route through, not by running cleanup.ps1: that script stops
+# containers, removes volumes and deletes state directories, so invoking it
+# from a test would operate on the checkout it lives in. The one thing that
+# can only be observed on the file itself -- the ValidateRange bound, which
+# fires at parameter binding rather than in any function -- is read out of the
+# script's syntax tree instead.
+#
+# Every value here is a placeholder; no test writes or prints a credential.
+
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent $ScriptDir
+$ScriptsDir = Join-Path $ProjectRoot 'scripts'
+
+Import-Module (Join-Path $ScriptsDir 'ClaudeDocker.psm1') -Force
+
+$script:Pass = 0
+$script:Fail = 0
+
+function Assert-Eq {
+    param(
+        [Parameter(Mandatory)][string]$Label,
+        [Parameter(Mandatory)][AllowEmptyString()][AllowNull()][object]$Expected,
+        [Parameter(Mandatory)][AllowEmptyString()][AllowNull()][object]$Actual
+    )
+    if ([string]$Expected -eq [string]$Actual) {
+        Write-Host ("  PASS  {0}" -f $Label)
+        $script:Pass++
+    } else {
+        Write-Host ("  FAIL  {0}`n        expected: {1}`n        actual:   {2}" -f `
+            $Label, ([string]$Expected), ([string]$Actual))
+        $script:Fail++
+    }
+}
+
+Write-Host '== Get-CleanupDecision =='
+
+# -Force wins over everything, including a host that could have been asked:
+# it is the explicit non-interactive answer.
+Assert-Eq 'Force removes, interactive' 'remove' `
+    (Get-CleanupDecision -Force $true -Skip $false -Interactive $true)
+Assert-Eq 'Force removes, non-interactive' 'remove' `
+    (Get-CleanupDecision -Force $true -Skip $false -Interactive $false)
+
+Assert-Eq 'Skip skips, interactive' 'skip' `
+    (Get-CleanupDecision -Force $false -Skip $true -Interactive $true)
+Assert-Eq 'Skip skips, non-interactive' 'skip' `
+    (Get-CleanupDecision -Force $false -Skip $true -Interactive $false)
+
+Assert-Eq 'neither switch on a console asks' 'ask' `
+    (Get-CleanupDecision -Force $false -Skip $false -Interactive $true)
+
+# Refusing rather than skipping is the point: a pipeline that meant to clean
+# up and quietly did not is its own failure, so the caller is told to choose.
+# Defaulting the other way -- proceeding -- would delete the backups.
+Assert-Eq 'neither switch off a console refuses' 'refuse' `
+    (Get-CleanupDecision -Force $false -Skip $false -Interactive $false)
+
+Write-Host '== Test-FileAgeExceedsDays: parity with find -mtime +N =='
+
+$now = [datetime]'2026-08-16T12:00:00'
+
+# The case the two implementations used to disagree on. `find -mtime +7`
+# truncates the age to whole days, so 7.5 days reports 7 and is kept; the old
+# PowerShell comparison against an exact now-minus-7d instant deleted it.
+# tests/test_cleanup_backups.sh pins the same verdict against real find(1).
+Assert-Eq '7.5 days is not older than 7' $false `
+    (Test-FileAgeExceedsDays -LastWriteTime $now.AddHours(-180) -Now $now -Days 7)
+Assert-Eq '8 days is older than 7' $true `
+    (Test-FileAgeExceedsDays -LastWriteTime $now.AddDays(-8) -Now $now -Days 7)
+
+# Exactly N days is not "more than N", matching find.
+Assert-Eq 'exactly 7 days is not older than 7' $false `
+    (Test-FileAgeExceedsDays -LastWriteTime $now.AddDays(-7) -Now $now -Days 7)
+Assert-Eq '7 days plus a second is still not older than 7' $false `
+    (Test-FileAgeExceedsDays -LastWriteTime $now.AddDays(-7).AddSeconds(-1) -Now $now -Days 7)
+
+Assert-Eq 'a fresh file is never stale' $false `
+    (Test-FileAgeExceedsDays -LastWriteTime $now.AddMinutes(-1) -Now $now -Days 7)
+Assert-Eq '30 days is older than 7' $true `
+    (Test-FileAgeExceedsDays -LastWriteTime $now.AddDays(-30) -Now $now -Days 7)
+
+# Days = 0 means the same as `find -mtime +0`: at least a whole day old. It is
+# an accepted value on both sides, so the two must agree on it.
+Assert-Eq 'Days=0 keeps a file younger than a day' $false `
+    (Test-FileAgeExceedsDays -LastWriteTime $now.AddHours(-23) -Now $now -Days 0)
+Assert-Eq 'Days=0 removes a file older than a day' $true `
+    (Test-FileAgeExceedsDays -LastWriteTime $now.AddHours(-25) -Now $now -Days 0)
+
+# A future mtime yields a negative age, which must not read as stale.
+Assert-Eq 'a future timestamp is not stale' $false `
+    (Test-FileAgeExceedsDays -LastWriteTime $now.AddDays(1) -Now $now -Days 7)
+
+Write-Host '== cleanup.ps1: the bound on -BackupAgeDays =='
+
+# Read from the syntax tree rather than by invoking the script. ValidateRange
+# fires at parameter binding, so observing it means starting cleanup.ps1 --
+# which on a Windows host would go on to stop containers and remove volumes in
+# whatever checkout the test runs from.
+$cleanupPath = Join-Path $ScriptsDir 'cleanup.ps1'
+$parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    $cleanupPath, [ref]$null, [ref]$parseErrors)
+Assert-Eq 'cleanup.ps1 parses' 0 (@($parseErrors).Count)
+
+$ageParam = $ast.ParamBlock.Parameters |
+    Where-Object { $_.Name.VariablePath.UserPath -eq 'BackupAgeDays' }
+Assert-Eq 'BackupAgeDays is declared' 1 (@($ageParam).Count)
+
+$range = @($ageParam.Attributes | Where-Object { $_.TypeName.Name -eq 'ValidateRange' })
+Assert-Eq 'BackupAgeDays carries ValidateRange' 1 $range.Count
+
+if ($range.Count -eq 1) {
+    $bounds = @($range[0].PositionalArguments | ForEach-Object { $_.Value })
+    # A negative value would put the cutoff in the future and sweep every
+    # backup; the upper bound matches the one cleanup.sh now enforces.
+    Assert-Eq 'lower bound is 0'    0    $bounds[0]
+    Assert-Eq 'upper bound is 3650' 3650 $bounds[1]
+}
+
+Write-Host '== cleanup.ps1: one gate, both destructive steps =='
+
+# The defect was one script carrying two policies: state-directory removal was
+# gated, backup removal was not. Both now call the same helper, so a future
+# edit that reintroduces a private copy fails here.
+$source = Get-Content -LiteralPath $cleanupPath -Raw
+$gateCalls = ([regex]::Matches($source, 'Resolve-Step -Question')).Count
+Assert-Eq 'both destructive steps call the shared gate' 2 $gateCalls
+Assert-Eq 'the gate delegates to Get-CleanupDecision' $true `
+    ($source -like '*Get-CleanupDecision*')
+Assert-Eq 'the backup sweep uses the shared age rule' $true `
+    ($source -like '*Test-FileAgeExceedsDays*')
+# The exact-instant cutoff this replaces must be gone, not merely unused.
+Assert-Eq 'the exact-instant cutoff is gone' $false `
+    ($source -like '*AddDays(-$BackupAgeDays)*')
+
+Write-Host ''
+Write-Host ("== Summary: PASS={0} FAIL={1} ==" -f $script:Pass, $script:Fail)
+if ($script:Fail -gt 0) { exit 1 }


### PR DESCRIPTION
Closes #345
Relates to #342, #344

## What

`cleanup.ps1` deleted `.env.backup.*` and `.env.bak` the moment `-Backups` was passed. `cleanup.sh` has always refused to touch the same files without an explicit answer.

| Behavior | `cleanup.sh` | `cleanup.ps1` (before) |
|---|---|---|
| Confirm before deleting backups | `--yes` / `--no` / TTY prompt / `exit 1` | none |
| `BackupAgeDays` range | unvalidated | unvalidated |
| Age comparison | `find -mtime +N`, whole-day truncation | exact `(Get-Date).AddDays(-N)` instant |

The age difference is observable and silent: `find -mtime +7` truncates a file's age to whole days, so a 7.5-day-old backup reports 7 and is **kept**; PowerShell computed `now - 7d` and **deleted** it. Same flag, same value, opposite outcome.

`-BackupAgeDays -30` put the cutoff 30 days in the future and swept every backup.

On the bash side, `--backup-age-days` consumed whatever token followed it before the option `case` ran, so `--backups --backup-age-days --yes` set the age to `"--yes"` and left `CONFIRM="ask"`. Off a TTY that exited 1 for the wrong reason; on a TTY it prompted `... older than --yes days?` and then ran a `find` that could not succeed — while `Stale backups removed.` printed unconditionally.

## Why

What the block deletes is the reason the gate exists. `install.ps1` copies `.env` to `.env.backup.<timestamp>` immediately before overwriting it and keeps only three, so those files are the sole recovery point for a `.env` carrying `CLAUDE_API_KEY_*`, `CODEX_API_KEY_*`, `GEMINI_API_KEY_*` and `GH_TOKEN*`. `remove.ps1` treats them accordingly — its rotated-backup sweep runs only after a confirmation.

The gate pattern was already in `cleanup.ps1`, one block further down: state-directory removal implements `-Force` / `-SkipState` / prompt / refuse. The `-Backups` block was added *ahead* of it and did not pick up the structure, so one script ended up with two policies for two destructive actions.

## How

- `Get-CleanupDecision` (new, in `ClaudeDocker.psm1`) is the whole policy: `remove` / `skip` / `refuse` / `ask`. Both destructive steps in `cleanup.ps1` call it through a local `Resolve-Step`, so the two cannot drift apart again. `refuse` rather than `skip` on a non-interactive host mirrors `cleanup.sh`: a pipeline that meant to clean up and silently did not is its own failure.
- `Test-FileAgeExceedsDays` (new) replicates `find`'s whole-day truncation. PowerShell moves to bash rather than the other way round: truncation is the documented reading of `--backup-age-days N` and what the existing bash fixture assumes.
- `[ValidateRange(0, 3650)]` on `-BackupAgeDays`. It binds **before** the platform guard, so a rejected value never reaches the deletion path on any host.
- `cleanup.sh` validates the `--backup-age-days` value before assigning it (`exit 2`, matching the other argument errors) and branches on `find`'s exit status.

### One acceptance criterion deliberately not implemented

The issue lists `-BackupAgeDays 0` among the values to reject. That item was premised on the exact-instant comparison, where `0` put the cutoff at `Get-Date` and swept everything written before that moment. With the truncation fix, `0` means exactly what `find -mtime +0` means — at least a whole day old — and `cleanup.sh` accepts it. Rejecting it on the PowerShell side would replace one divergence with another, so the bound is `(0, 3650)` as the issue's own **How** section specifies. `Test-FileAgeExceedsDays` carries both `Days=0` cases so the meaning is pinned rather than assumed.

### Verification

- `tests/test_cleanup_gate.ps1` (new, 24 assertions, added to the `pwsh-tests` matrix) — `PASS=24 FAIL=0`.
- `tests/test_cleanup_backups.sh` extended to 21 assertions (from 13) — `PASS=21 FAIL=0` under WSL. It now covers the four argument-validation cases, asserts nothing was deleted by a rejected run, and pins the 7.5-day file against **real** `find(1)`.
- The 7.5-day verdict is asserted on both sides — bash against real `find`, PowerShell against `Test-FileAgeExceedsDays` — so the parity claim is measured rather than reasoned.
- `tests/test_worktree_path_guard.ps1` — `PASS=34 FAIL=0` (the other consumer of the module).
- `bash -n scripts/cleanup.sh`; PowerShell `Parser::ParseFile` on all three modified `.ps1`/`.psm1` files.
- PSScriptAnalyzer over `scripts/ -Recurse -Severity Warning` with the CI job's exact exclusion list — **clean**. It was not installed on this host when #361/#362/#363 were opened; it is now, and the whole tree including those merged changes passes.
- shellcheck was **not** run locally (not installed on this host); the `Shellcheck` job covers it.

### Why the PowerShell test does not run cleanup.ps1

`cleanup.ps1` stops containers, removes volumes and deletes state directories, so invoking it from a test would operate on the checkout the test lives in — and on Linux the platform guard exits before any of it, which would make the test vacuous rather than safe. The policy and the age rule are therefore asserted through the two module functions both scripts route through. The one thing that can only be observed on the file itself — the `ValidateRange` bound, which fires at parameter binding rather than inside any function — is read out of the script's syntax tree.

## Where

- `scripts/ClaudeDocker.psm1` — `Get-CleanupDecision`, `Test-FileAgeExceedsDays`
- `scripts/cleanup.ps1` — `param` block, `Resolve-Step`, both destructive blocks
- `scripts/cleanup.sh` — argument loop, backup block
- `tests/test_cleanup_gate.ps1` (new), `tests/test_cleanup_backups.sh`, `.github/workflows/ci.yml`
