### PR TITLE
fix(install): drop the readonly UID assignment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,7 @@ jobs:
           - tests/test_cleanup_backups.sh
           - tests/test_windows_platform_guard.sh
           - tests/test_worktree_ownership.sh
+          - tests/test_install_start_containers.sh
           - scripts/test-entrypoint-settings.sh
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1055,13 +1055,14 @@ start_containers() {
 
     cd "$PROJECT_ROOT"
 
+    # build_compose_cmd exports UID/GID itself when it selects the Linux
+    # overlay, using the readonly-safe `: "${UID:=$(id -u)}"` form. The block
+    # that used to be here duplicated that job with a plain `UID=$(id -u)`,
+    # which bash refuses because UID is a readonly special variable -- and
+    # under `set -euo pipefail` that ended the install one line before
+    # `docker compose up -d`, on native Linux only. install_dependencies has
+    # always relied on build_compose_cmd alone; this call site now matches it.
     build_compose_cmd
-
-    if [[ "$PLATFORM" == "linux" ]]; then
-        export UID GID
-        UID=$(id -u)
-        GID=$(id -g)
-    fi
 
     log_info "Compose command: ${COMPOSE_CMD[*]} up -d"
     "${COMPOSE_CMD[@]}" up -d 2>&1

--- a/tests/test_install_start_containers.sh
+++ b/tests/test_install_start_containers.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# test_install_start_containers.sh - start_containers on a native Linux host
+# (issue #346).
+#
+# Run:  bash tests/test_install_start_containers.sh
+# Exits non-zero on any failure.
+#
+# start_containers assigned to UID, which bash maintains as a readonly special
+# variable. Under `set -euo pipefail` that aborted install.sh between
+# build_compose_cmd and `docker compose up -d` -- after the image, the state
+# directories, the TUI, authentication and the worktrees had all been set up.
+# The user got "UID: readonly variable" and no containers.
+#
+# detect_platform returns wsl2 when /proc/version mentions microsoft, so macOS
+# and WSL2 never reached the block. Native Linux is the only platform that did,
+# and there it failed for every tier and every auth path -- which is also why
+# no existing test caught it: PLATFORM is set explicitly here rather than
+# detected.
+#
+# docker is stubbed. This test must never reach a daemon: the compose command
+# it builds points at the working tree it runs from.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        printf '  PASS  %s\n' "$label"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL  %s\n        expected: %s\n        actual:   %s\n' \
+            "$label" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        printf '  PASS  %s\n' "$label"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL  %s\n        missing: %s\n        in:      %s\n' \
+            "$label" "$needle" "$haystack"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "== No assignment to the readonly UID remains =="
+
+# The .env emission writes UID as text inside an echo, so it does not match
+# this pattern; a bare assignment at the start of a line does.
+uid_assignments=$(grep -cE '^[[:space:]]*(export )?(UID|GID)=' "$PROJECT_ROOT/scripts/install.sh" || true)
+assert_eq "install.sh assigns neither UID nor GID directly" "0" "$uid_assignments"
+
+echo "== start_containers reaches docker compose up -d =="
+
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/docker" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$DOCKER_LOG"
+exit 0
+STUB
+chmod +x "$WORK/bin/docker"
+
+status=0
+(
+    export CLAUDE_DOCKER_INSTALL_LIBRARY_ONLY=1
+    export PATH="$WORK/bin:$PATH"
+    export DOCKER_LOG="$WORK/docker.log"
+    export HOME="$WORK/home"
+    mkdir -p "$HOME"
+
+    # shellcheck source=../scripts/install.sh
+    . "$PROJECT_ROOT/scripts/install.sh"
+
+    # The value detect_platform would return on a native Linux host. Set
+    # explicitly because the runner may be WSL2, where the block never ran and
+    # the defect is invisible.
+    # shellcheck disable=SC2034
+    PLATFORM=linux
+
+    start_containers
+
+    # Recorded from inside the subshell: build_compose_cmd is what must have
+    # exported these, since nothing else does any more.
+    printf 'UID=%s\n' "${UID:-unset}" > "$WORK/ids"
+    printf 'GID=%s\n' "${GID:-unset}" >> "$WORK/ids"
+    export -p | grep -E '^(declare -x |export )GID' > "$WORK/gid-export" || true
+    printf '%s\n' "${COMPOSE_CMD[*]}" > "$WORK/compose-cmd"
+) > "$WORK/out.log" 2>&1 || status=$?
+
+assert_eq "start_containers exits 0 under set -euo pipefail" "0" "$status"
+
+if [[ "$status" -ne 0 ]]; then
+    echo "  --- captured output ---"
+    sed 's/^/  /' "$WORK/out.log"
+fi
+
+if [[ -f "$WORK/docker.log" ]]; then
+    assert_contains "docker was invoked with 'up -d'" "up -d" "$(cat "$WORK/docker.log")"
+else
+    assert_eq "docker was invoked" "invoked" "not invoked"
+fi
+
+echo "== build_compose_cmd still supplies UID/GID for the linux overlay =="
+
+if [[ -f "$WORK/ids" ]]; then
+    ids="$(cat "$WORK/ids")"
+    assert_eq "UID matches id -u" "UID=$(id -u)" "$(printf '%s\n' "$ids" | grep '^UID=')"
+    assert_eq "GID matches id -g" "GID=$(id -g)" "$(printf '%s\n' "$ids" | grep '^GID=')"
+else
+    assert_eq "ids were recorded" "recorded" "missing"
+fi
+
+# GID is not a bash special variable, so a child process seeing it proves the
+# export happened rather than the value merely existing.
+if [[ -s "$WORK/gid-export" ]]; then
+    assert_eq "GID is exported" "exported" "exported"
+else
+    assert_eq "GID is exported" "exported" "not exported"
+fi
+
+if [[ -f "$WORK/compose-cmd" ]]; then
+    assert_contains "the linux overlay is selected" "docker-compose.linux.yml" \
+        "$(cat "$WORK/compose-cmd")"
+fi
+
+echo
+echo "== Summary: PASS=$PASS FAIL=$FAIL =="
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Closes #346
Relates to #347

## What

`start_containers` assigned to `UID`, which bash maintains as a readonly special variable. Under `set -euo pipefail` that ended `install.sh` one line before `docker compose up -d`.

Reproduced against the unfixed script on Linux, by the test added here:

```
[1/0] Starting containers
/mnt/d/Sources/claude-docker/scripts/install.sh: line 1062: UID: readonly variable
  FAIL  start_containers exits 0 under set -euo pipefail
  FAIL  docker was invoked
```

Line 1061 (`export UID GID`) was never the problem — exporting a readonly variable is allowed, and `GID` is not special. Only `UID=$(id -u)` failed.

The failure landed *after* `run_prerequisite_checks`, `generate_env`, `create_state_dirs`, `build_image`, `build_tui`, `run_authentication` and `setup_worktrees`. The user was left with a built image, populated state directories, a built TUI, completed authentication, **no containers**, and one line of diagnosis.

`detect_platform` returns `wsl2` when `/proc/version` matches `microsoft`, so macOS and WSL2 skipped the block entirely. Native Linux was the only platform that reached it — and there it failed for every tier and every auth path.

## Why

The repository already knew this trap and already handled it correctly, one call earlier. `scripts/lib/build-compose-cmd.sh` uses the readonly-safe form:

```bash
: "${UID:=$(id -u)}"
: "${GID:=$(id -g)}"
export UID GID
```

`start_containers` calls `build_compose_cmd` immediately above the offending block, so `UID`/`GID` were already exported with the correct values by the time the duplicate ran. The block predates the shared helper and was not removed when the logic moved into the library — the safe form landed in the library only.

`generate_env` also writes `UID`/`GID` into `.env` on Linux, so compose interpolation has a second, independent source. Nothing about the overlay depended on the block.

## How

Deleted, with a comment recording why nothing replaces it. `install_dependencies` has always relied on `build_compose_cmd` alone and has no such block; the two call sites now match.

### Verification

- `tests/test_install_start_containers.sh` (new, 7 assertions, added to the `bash-tests` matrix).
  - **Red first**: against the unfixed script it reports `PASS=0 FAIL=5` with the `UID: readonly variable` line captured and `docker was invoked -> not invoked`.
  - **Green after**: `PASS=7 FAIL=0`.
  - It asserts exit 0 under `set -euo pipefail`, that `up -d` reached the (stubbed) docker, that `UID`/`GID` still match `id -u`/`id -g`, that **`GID` is exported** — `GID` is not a bash special variable, so a child seeing it proves the export rather than the value merely existing — and that the linux overlay is still selected.
  - It also greps `install.sh` for a bare `UID=`/`GID=` assignment, so re-adding one fails the test. The `.env` emission is inside `echo "UID=..."` and does not match.
- `PLATFORM` is set explicitly rather than detected: the runner may be WSL2, where the block never executed and the defect is invisible. That is the same reason no existing test caught this.
- `bash -n scripts/install.sh`.
- `tests/test_installer_github_equivalence.sh` (`PASS=7`), `tests/test_num_accounts_precedence.sh` (52 passed), `tests/test_parse_env.sh` (`PASS=21`) — no regression in the other consumers of `install.sh`.
- `docker` is stubbed and no daemon is reached; the compose command this builds points at the working tree the test runs from.
- shellcheck was not run locally (not installed on this host); the `Shellcheck` job covers it.

## Where

- `scripts/install.sh` — `start_containers`
- `scripts/lib/build-compose-cmd.sh` — the readonly-safe form already in place (unchanged)
- `tests/test_install_start_containers.sh` (new), `.github/workflows/ci.yml`
