### PR TITLE
fix(install): generate compose after the worktrees exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,7 @@ jobs:
           - tests/test_windows_platform_guard.sh
           - tests/test_worktree_ownership.sh
           - tests/test_install_start_containers.sh
+          - tests/test_install_tier_b.sh
           - scripts/test-entrypoint-settings.sh
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -600,9 +600,33 @@ function New-EnvFile {
 
     Write-LogSuccess ".env generated at $envFile"
 
-    # Generate compose files from .env
+    # Handed to Invoke-ComposeGeneration, which now runs as its own step after
+    # the worktrees exist.
+    $Script:ImageTag = $imageTag
+}
+
+# --- Compose Generation --------------------------------------------------------
+
+# Invoke-ComposeGeneration runs the compose generator against the finished
+# .env.
+#
+# This used to be the last thing New-EnvFile did, which put it before
+# Invoke-WorktreeSetup in the step list. For Tier B that meant handing the
+# generator a .env declaring ISOLATION_MODE=worktree with empty PROJECT_DIR_*
+# placeholders, and Get-SupportedIsolationMode throws on that by design (it
+# does not distinguish empty from unset). With $ErrorActionPreference = 'Stop'
+# the throw aborted the install. The ordering was structural, not a race.
+#
+# The generator is not wrong -- tests/test_isolation_modes.sh pins that exact
+# refusal as a contract. The installer was violating it, so the installer
+# moved.
+#
+# Invoke-ImageBuild still runs before this, on the committed
+# docker-compose.yml. That is deliberate and safe: the image does not depend on
+# the account count, the runtime or the isolation mode.
+function Invoke-ComposeGeneration {
     Write-LogInfo "Generating compose files for $($Script:NumAccounts) account(s)..."
-    & "$PSScriptRoot\generate-compose.ps1" -NumAccounts $Script:NumAccounts -ImageTag $imageTag
+    & "$PSScriptRoot\generate-compose.ps1" -NumAccounts $Script:NumAccounts -ImageTag $Script:ImageTag
 }
 
 # --- Directory Creation -------------------------------------------------------
@@ -781,10 +805,14 @@ function Invoke-WorktreeSetup {
                 $content = [System.IO.File]::ReadAllText($envFile)
                 $content = $content -replace '(?m)^# ==== Tier B:.*\r?\n', ''
                 $content = $content -replace '(?m)^# \(populated after.*\r?\n', ''
-                $content = $content -replace '(?m)^PROJECT_DIR_A=.*\r?\n', ''
-                $content = $content -replace '(?m)^PROJECT_DIR_B=.*\r?\n', ''
-                $content = $content -replace '(?m)^CONTAINER_PROJECT_DIR_A=.*\r?\n', ''
-                $content = $content -replace '(?m)^CONTAINER_PROJECT_DIR_B=.*\r?\n', ''
+                # Over the same range New-EnvFile wrote, not the literals A and
+                # B: a 4-account install used to leave PROJECT_DIR_C= and
+                # PROJECT_DIR_D= behind.
+                for ($j = 1; $j -le $Script:NumAccounts; $j++) {
+                    $u = Get-AccountLetterUpper -Index $j
+                    $content = $content -replace "(?m)^PROJECT_DIR_${u}=.*\r?\n", ''
+                    $content = $content -replace "(?m)^CONTAINER_PROJECT_DIR_${u}=.*\r?\n", ''
+                }
                 Write-EnvContent -Path $envFile -Content $content
                 Set-EnvValue -Path $envFile -Key 'ISOLATION_MODE' -Value 'shared'
             }
@@ -810,25 +838,38 @@ function Invoke-WorktreeSetup {
         Write-LogInfo "Project directory updated: $newDir"
     }
 
-    $branchA = Read-Input -Question 'Branch name for Container A' -Default 'worktree-a'
-    $branchB = Read-Input -Question 'Branch name for Container B' -Default 'worktree-b'
+    # Driven by NumAccounts, matching the placeholders New-EnvFile writes.
+    # This used to prompt for exactly two branches and write back exactly
+    # PROJECT_DIR_A and PROJECT_DIR_B, so a Tier B install with more than two
+    # accounts left the rest empty. setup-worktrees.ps1 already takes a
+    # [string[]]; only the caller was fixed at two.
+    $branches = @()
+    $letters = @()
+    for ($i = 1; $i -le $Script:NumAccounts; $i++) {
+        $lower = Get-AccountLetter -Index $i
+        $upper = Get-AccountLetterUpper -Index $i
+        $letters += $lower
+        $branches += (Read-Input -Question "Branch name for Container $upper" -Default "worktree-$lower")
+    }
 
     Write-LogInfo 'Creating worktrees...'
-    & "$PSScriptRoot\setup-worktrees.ps1" -RepoDir $Script:SourceDir -Branches @($branchA, $branchB)
+    # One invocation with the whole array: setup-worktrees.ps1 derives each
+    # worktree's letter from the branch's position, so splitting the call
+    # would restart the numbering at "a".
+    & "$PSScriptRoot\setup-worktrees.ps1" -RepoDir $Script:SourceDir -Branches $branches
 
-    $worktreeA = "$($Script:SourceDir.TrimEnd('\', '/'))-a"
-    $worktreeB = "$($Script:SourceDir.TrimEnd('\', '/'))-b"
-
-    # Update .env with worktree paths (forward slashes for Docker)
     $envFile = Join-Path $ProjectRoot '.env'
-    $wtA = ConvertTo-ForwardSlash -Path $worktreeA
-    $wtB = ConvertTo-ForwardSlash -Path $worktreeB
-    Set-EnvValue -Path $envFile -Key 'PROJECT_DIR_A' -Value $wtA
-    Set-EnvValue -Path $envFile -Key 'PROJECT_DIR_B' -Value $wtB
-
+    $base = $Script:SourceDir.TrimEnd('\', '/')
     Write-LogSuccess 'Worktrees created:'
-    Write-LogInfo "  A: $worktreeA (branch: $branchA)"
-    Write-LogInfo "  B: $worktreeB (branch: $branchB)"
+    for ($i = 0; $i -lt $letters.Count; $i++) {
+        $lower = $letters[$i]
+        $upper = $lower.ToUpperInvariant()
+        $worktree = "$base-$lower"
+        # Forward slashes for Docker.
+        Set-EnvValue -Path $envFile -Key "PROJECT_DIR_$upper" `
+            -Value (ConvertTo-ForwardSlash -Path $worktree)
+        Write-LogInfo "  ${upper}: $worktree (branch: $($branches[$i]))"
+    }
 }
 
 # --- Container Startup --------------------------------------------------------
@@ -1058,6 +1099,9 @@ Invoke-ImageBuild
 Invoke-TUIBuild
 Invoke-AuthSetup
 Invoke-WorktreeSetup
+# After Invoke-WorktreeSetup, so a Tier B .env has its PROJECT_DIR_* populated
+# before the generator validates the mode it declares.
+Invoke-ComposeGeneration
 Start-Containers
 Install-Dependencies
 Invoke-Verification

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -802,8 +802,29 @@ generate_env() {
 
     chmod 600 "$env_file"
     log_success ".env generated at $env_file (permissions: 600)"
+}
 
-    # Generate compose files from .env
+# --- Compose Generation --------------------------------------------------------
+
+# generate_compose_files runs the compose generator against the finished .env.
+#
+# This used to be the last thing generate_env did, which put it before
+# setup_worktrees in main(). For Tier B that meant handing the generator a .env
+# declaring ISOLATION_MODE=worktree with empty PROJECT_DIR_* placeholders, and
+# require_supported_isolation_mode refuses that by design (it does not
+# distinguish empty from unset). Under `set -euo pipefail` the refusal ended
+# the install. The ordering was structural, not a race: main() runs the two
+# steps five apart, so there was no value that could have been present.
+#
+# The generator is not wrong -- tests/test_isolation_modes.sh pins that exact
+# refusal as a contract. The installer was violating it, so the installer
+# moved.
+#
+# build_image still runs before this, on the committed docker-compose.yml. That
+# is deliberate and safe: the image does not depend on the account count, the
+# runtime or the isolation mode -- every service builds the one
+# claude-code-base image, and the only build argument is CLAUDE_CODE_VERSION.
+generate_compose_files() {
     log_info "Generating compose files for $NUM_ACCOUNTS account(s)..."
     "$SCRIPT_DIR/generate-compose.sh"
 }
@@ -988,7 +1009,18 @@ setup_worktrees() {
             # mode requires have just been deleted.
             local env_file="$PROJECT_ROOT/.env"
             if [[ -f "$env_file" ]]; then
-                perl -i -ne 'print unless /^# ==== Tier B:/ || /^# \(populated after/ || /^PROJECT_DIR_A=/ || /^PROJECT_DIR_B=/ || /^CONTAINER_PROJECT_DIR_A=/ || /^CONTAINER_PROJECT_DIR_B=/' "$env_file"
+                # Built over the same range generate_env wrote, not the
+                # literals A and B: a 4-account install used to leave
+                # PROJECT_DIR_C= and PROJECT_DIR_D= behind. Every fragment
+                # comes from index_to_letter, so nothing user-supplied reaches
+                # the pattern.
+                local drop='^# ==== Tier B:|^# \(populated after'
+                local j upper_j
+                for j in $(seq 1 "$NUM_ACCOUNTS"); do
+                    upper_j=$(index_to_letter "$j" | tr '[:lower:]' '[:upper:]')
+                    drop="${drop}|^PROJECT_DIR_${upper_j}=|^CONTAINER_PROJECT_DIR_${upper_j}="
+                done
+                perl -i -ne "print unless /$drop/" "$env_file"
                 set_env_value "$env_file" "ISOLATION_MODE" "shared"
             fi
 
@@ -1014,25 +1046,35 @@ setup_worktrees() {
         log_info "Project directory updated: $new_dir"
     done
 
-    local branch_a
-    local branch_b
-    branch_a=$(prompt_input "Branch name for Container A" "worktree-a")
-    branch_b=$(prompt_input "Branch name for Container B" "worktree-b")
+    # Driven by NUM_ACCOUNTS, matching the placeholders generate_env writes.
+    # This used to prompt for exactly two branches and write back exactly
+    # PROJECT_DIR_A and PROJECT_DIR_B, so a Tier B install with more than two
+    # accounts left the rest empty. Both callees already accept N --
+    # setup-worktrees.sh takes "$@" -- only the caller was fixed at two.
+    local branches=() letters=()
+    local i letter upper
+    for i in $(seq 1 "$NUM_ACCOUNTS"); do
+        letter=$(index_to_letter "$i")
+        upper=$(printf '%s' "$letter" | tr '[:lower:]' '[:upper:]')
+        letters+=("$letter")
+        branches+=("$(prompt_input "Branch name for Container ${upper}" "worktree-${letter}")")
+    done
 
     log_info "Creating worktrees..."
-    "$SCRIPT_DIR/setup-worktrees.sh" "$SOURCE_DIR" "$branch_a" "$branch_b"
+    # One invocation with the whole array: setup-worktrees.sh derives each
+    # worktree's letter from the branch's position, so splitting the call
+    # would restart the numbering at "a".
+    "$SCRIPT_DIR/setup-worktrees.sh" "$SOURCE_DIR" "${branches[@]}"
 
-    local worktree_a="${SOURCE_DIR%/}-a"
-    local worktree_b="${SOURCE_DIR%/}-b"
-
-    # Update .env with worktree paths
     local env_file="$PROJECT_ROOT/.env"
-    set_env_value "$env_file" "PROJECT_DIR_A" "$worktree_a"
-    set_env_value "$env_file" "PROJECT_DIR_B" "$worktree_b"
-
     log_success "Worktrees created:"
-    log_info "  A: $worktree_a (branch: $branch_a)"
-    log_info "  B: $worktree_b (branch: $branch_b)"
+    for i in "${!letters[@]}"; do
+        letter="${letters[$i]}"
+        upper=$(printf '%s' "$letter" | tr '[:lower:]' '[:upper:]')
+        local worktree="${SOURCE_DIR%/}-${letter}"
+        set_env_value "$env_file" "PROJECT_DIR_${upper}" "$worktree"
+        log_info "  ${upper}: $worktree (branch: ${branches[$i]})"
+    done
 }
 
 # --- Compose Command Builder --------------------------------------------------
@@ -1288,6 +1330,9 @@ main() {
     build_tui
     run_authentication
     setup_worktrees
+    # After setup_worktrees, so a Tier B .env has its PROJECT_DIR_* populated
+    # before the generator validates the mode it declares.
+    generate_compose_files
     start_containers
     install_dependencies
     run_verification

--- a/scripts/setup-worktrees.ps1
+++ b/scripts/setup-worktrees.ps1
@@ -31,6 +31,14 @@ if ($PSVersionTable.PSEdition -eq 'Core' -and $PSVersionTable.OS -and $PSVersion
     exit 1
 }
 
+# Excel-style account letters, shared with the generators and the installer.
+# The arithmetic this replaces -- [char](96 + $idx) -- was correct only for
+# the first 26 accounts and produced punctuation past 'z'. That was unreachable
+# while install.ps1 passed exactly two branches; it is reachable now that the
+# installer drives this from NUM_ACCOUNTS, whose validator allows up to 702.
+# Nested two-argument Join-Path: the three-argument form is PowerShell 7+.
+. (Join-Path (Join-Path $PSScriptRoot 'lib') 'index.ps1')
+
 $RepoDir = $RepoDir.TrimEnd('\', '/')
 
 # Validate
@@ -46,8 +54,8 @@ try {
     for ($i = 0; $i -lt $Branches.Count; $i++) {
         $idx = $i + 1
         $branch = $Branches[$i]
-        $letter = [char](96 + $idx)  # a, b, c, ...
-        $upper  = [char](64 + $idx)  # A, B, C, ...
+        $letter = Get-AccountLetter -Index $idx
+        $upper  = Get-AccountLetterUpper -Index $idx
         $worktree = "${RepoDir}-${letter}"
 
         & git branch $branch 2>$null
@@ -64,7 +72,7 @@ Write-Host ''
 Write-Host 'Add to .env:'
 for ($i = 0; $i -lt $Branches.Count; $i++) {
     $idx = $i + 1
-    $letter = [char](96 + $idx)
-    $upper  = [char](64 + $idx)
+    $letter = Get-AccountLetter -Index $idx
+    $upper  = Get-AccountLetterUpper -Index $idx
     Write-Host "  PROJECT_DIR_${upper}=${RepoDir}-${letter}"
 }

--- a/tests/test_install_tier_b.sh
+++ b/tests/test_install_tier_b.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# test_install_tier_b.sh - the Tier B installer-to-generator seam (issue #347).
+#
+# Run:  bash tests/test_install_tier_b.sh
+# Exits non-zero on any failure.
+#
+# generate_env wrote ISOLATION_MODE=worktree with empty PROJECT_DIR_*
+# placeholders and then called the compose generator from inside the same
+# function, 72 lines later. require_supported_isolation_mode refuses that by
+# design -- it does not distinguish empty from unset -- so under
+# `set -euo pipefail` a Tier B install died before create_state_dirs.
+#
+# Nothing in tests/ covered this seam. The one test that calls generate_env at
+# all (test_installer_github_equivalence.sh) sets TIER=A, which never emits the
+# placeholders, so CI stayed green while every Tier B install aborted.
+#
+# The generator and setup-worktrees are stubbed. What is under test is the
+# ordering and the account count the installer drives them with, not what they
+# then do; the generator's refusal itself is pinned by
+# tests/test_isolation_modes.sh and must keep passing unchanged.
+#
+# NUM_ACCOUNTS is 4 rather than 2 so the second defect is covered too: the
+# worktree step prompted for exactly two branches and wrote back exactly
+# PROJECT_DIR_A and PROJECT_DIR_B regardless of the count.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        printf '  PASS  %s\n' "$label"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL  %s\n        expected: %s\n        actual:   %s\n' \
+            "$label" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+FAKE_ROOT="$WORK/root"        # stands in for PROJECT_ROOT; receives .env
+FAKE_SCRIPTS="$WORK/scripts"  # stands in for SCRIPT_DIR; holds the stubs
+SOURCE_REPO="$WORK/myapp"     # the user's project repository
+mkdir -p "$FAKE_ROOT" "$FAKE_SCRIPTS" "$SOURCE_REPO"
+
+git -C "$SOURCE_REPO" init -q
+git -C "$SOURCE_REPO" -c user.email=t@e -c user.name=t commit -q --allow-empty -m init
+
+# The generator stub records its argv and, more importantly, a snapshot of the
+# .env exactly as it stood when it was invoked. That snapshot is the subject:
+# the defect is not that the generator misbehaves, it is what the installer
+# hands it.
+cat > "$FAKE_SCRIPTS/generate-compose.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "invoked" >> "$GEN_LOG"
+cp "$SNAPSHOT_SOURCE" "$SNAPSHOT_DEST"
+STUB
+
+# The worktree stub records the argv it was handed, which is how "all N
+# branches in one invocation" is observed.
+cat > "$FAKE_SCRIPTS/setup-worktrees.sh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$#" > "$WT_ARGC"
+printf '%s\n' "$@" > "$WT_ARGV"
+STUB
+
+chmod +x "$FAKE_SCRIPTS/generate-compose.sh" "$FAKE_SCRIPTS/setup-worktrees.sh"
+
+status=0
+(
+    export CLAUDE_DOCKER_INSTALL_LIBRARY_ONLY=1
+    export HOME="$WORK/home"
+    mkdir -p "$HOME"
+    export GEN_LOG="$WORK/gen.log"
+    export SNAPSHOT_SOURCE="$FAKE_ROOT/.env"
+    export SNAPSHOT_DEST="$WORK/env-at-generation"
+    export WT_ARGC="$WORK/wt.argc"
+    export WT_ARGV="$WORK/wt.argv"
+
+    # shellcheck source=../scripts/install.sh
+    . "$REPO_ROOT/scripts/install.sh"
+
+    # Redirect the installer at the sandbox. SCRIPT_DIR is what selects the
+    # stubs; PROJECT_ROOT is where .env lands.
+    SCRIPT_DIR="$FAKE_SCRIPTS"
+    PROJECT_ROOT="$FAKE_ROOT"
+
+    # shellcheck disable=SC2034
+    PLATFORM=linux
+    # shellcheck disable=SC2034
+    TIER=B
+    # shellcheck disable=SC2034
+    AUTH_PATH=A
+    # shellcheck disable=SC2034
+    NUM_ACCOUNTS=4
+    # shellcheck disable=SC2034
+    SOURCE_DIR="$SOURCE_REPO"
+    # shellcheck disable=SC2034
+    RUNTIME=claude
+
+    # The real prompt reads from /dev/tty, which a test run does not have.
+    # Returning the default is what an operator pressing enter would do.
+    prompt_input() { printf '%s' "${2:-}"; }
+
+    generate_env
+    setup_worktrees
+    generate_compose_files
+) > "$WORK/out.log" 2>&1 || status=$?
+
+echo "== A Tier B install reaches the generator =="
+
+assert_eq "the install steps complete" "0" "$status"
+if [[ "$status" -ne 0 ]]; then
+    echo "  --- captured output ---"
+    sed 's/^/  /' "$WORK/out.log"
+fi
+
+gen_runs=0
+[[ -f "$WORK/gen.log" ]] && gen_runs=$(grep -c invoked "$WORK/gen.log")
+assert_eq "the generator ran exactly once" "1" "$gen_runs"
+
+echo "== What .env declared at the moment the generator ran =="
+
+snapshot="$WORK/env-at-generation"
+if [[ ! -f "$snapshot" ]]; then
+    assert_eq "a snapshot was taken" "taken" "missing"
+else
+    mode=$(grep '^ISOLATION_MODE=' "$snapshot" | tail -1 | cut -d= -f2-)
+    assert_eq "the declared mode is worktree" "worktree" "$mode"
+
+    # The contract: worktree may only be declared once every path it requires
+    # is populated. An empty value is what the generator refuses.
+    empty=$(grep -cE '^(PROJECT_DIR|ISOLATED_WORKSPACE)_[A-Z]+=$' "$snapshot" || true)
+    assert_eq "no per-account path is empty" "0" "$empty"
+
+    for letter in A B C D; do
+        value=$(grep "^PROJECT_DIR_${letter}=" "$snapshot" | tail -1 | cut -d= -f2-)
+        assert_eq "PROJECT_DIR_${letter} is populated" \
+            "$SOURCE_REPO-$(printf '%s' "$letter" | tr '[:upper:]' '[:lower:]')" "$value"
+    done
+fi
+
+echo "== All accounts reach setup-worktrees in one invocation =="
+
+if [[ -f "$WORK/wt.argc" ]]; then
+    # repo dir plus four branch names.
+    assert_eq "setup-worktrees.sh got 5 arguments" "5" "$(cat "$WORK/wt.argc")"
+    assert_eq "the branches are the four defaults" \
+        "worktree-a worktree-b worktree-c worktree-d" \
+        "$(tail -n +2 "$WORK/wt.argv" | tr '\n' ' ' | sed 's/ $//')"
+else
+    assert_eq "setup-worktrees.sh was invoked" "invoked" "not invoked"
+fi
+
+echo
+echo "== Summary: PASS=$PASS FAIL=$FAIL =="
+[[ $FAIL -eq 0 ]]

--- a/tests/test_installer_github_equivalence.sh
+++ b/tests/test_installer_github_equivalence.sh
@@ -105,6 +105,95 @@ else
     pass 'installer output never includes token values'
 fi
 
+# --- Tier B, four accounts (issue #347) ---------------------------------------
+#
+# Everything above is Tier A, which is why nothing here ever exercised the
+# worktree placeholder block. Two things make this case worth its own pair of
+# runs:
+#
+#   * A Tier B .env can be produced at all. generate_env / New-EnvFile used to
+#     call the compose generator before returning, and the generator refuses a
+#     .env declaring ISOLATION_MODE=worktree with empty PROJECT_DIR_*. This
+#     block would have exited 1 on both sides.
+#   * The placeholders are written for NUM_ACCOUNTS, so four accounts is what
+#     distinguishes a generalized writer from one hard-wired to A and B.
+
+bash_b_dir="$(make_sandbox bash-tier-b)"
+pwsh_b_dir="$(make_sandbox pwsh-tier-b)"
+
+# shellcheck disable=SC2034
+(
+    export CLAUDE_DOCKER_INSTALL_LIBRARY_ONLY=1
+    export HOME="$WORK/bash-b-home"
+    # shellcheck source=../scripts/install.sh
+    . "$bash_b_dir/scripts/install.sh"
+    PLATFORM=linux
+    AUTH_PATH=A
+    TIER=B
+    SOURCE_DIR="$WORK/project"
+    CLAUDE_VERSION=""
+    RUNTIME=claude
+    NUM_ACCOUNTS=4
+    GH_AUTH_MODE=per-account
+    GH_USERS=(fixture-user-a fixture-user-b fixture-user-c fixture-user-d)
+    GH_TOKENS=(fixture-token-a fixture-token-b fixture-token-c fixture-token-d)
+    generate_env
+) >"$bash_b_dir/install.log" 2>&1
+
+PWSH_B_COMMAND='& {
+    $PSVersionTable.OS = "Microsoft Windows"
+    $env:CLAUDE_DOCKER_INSTALL_LIBRARY_ONLY = "1"
+    . $env:CLAUDE_DOCKER_INSTALL_ENTRYPOINT
+    $Script:AuthPath = "A"
+    $Script:Tier = "B"
+    $Script:SourceDir = $env:CLAUDE_DOCKER_TEST_PROJECT
+    $Script:ClaudeVersion = ""
+    $Script:Runtime = "claude"
+    $Script:NumAccounts = 4
+    $Script:GhAuthMode = "per-account"
+    $Script:GhUsers = @("fixture-user-a", "fixture-user-b", "fixture-user-c", "fixture-user-d")
+    $Script:GhTokens = @("fixture-token-a", "fixture-token-b", "fixture-token-c", "fixture-token-d")
+    New-EnvFile
+}'
+CLAUDE_DOCKER_INSTALL_ENTRYPOINT="$pwsh_b_dir/scripts/install.ps1" \
+CLAUDE_DOCKER_TEST_PROJECT="$WORK/project" \
+USERPROFILE="$WORK/pwsh-b-home" APPDATA="$WORK/pwsh-b-appdata" \
+pwsh -NoProfile -Command "$PWSH_B_COMMAND" >"$pwsh_b_dir/install.log" 2>&1
+
+if [[ -f "$bash_b_dir/.env" && -f "$pwsh_b_dir/.env" ]]; then
+    pass 'both installers produce a Tier B .env'
+else
+    fail 'both installers produce a Tier B .env'
+    sed 's/^/    bash: /' "$bash_b_dir/install.log"
+    sed 's/^/    pwsh: /' "$pwsh_b_dir/install.log"
+fi
+
+tier_b_keys=(ISOLATION_MODE
+             CONTAINER_PROJECT_DIR_A CONTAINER_PROJECT_DIR_B
+             CONTAINER_PROJECT_DIR_C CONTAINER_PROJECT_DIR_D)
+for key in "${tier_b_keys[@]}"; do
+    bash_value="$(parse_env_value "$bash_b_dir/.env" "$key")"
+    pwsh_value="$(parse_env_value "$pwsh_b_dir/.env" "$key")"
+    if [[ -n "$bash_value" && "$bash_value" == "$pwsh_value" ]]; then
+        pass "Tier B: $key is equivalent"
+    else
+        fail "Tier B: $key is equivalent (bash=$bash_value pwsh=$pwsh_value)"
+    fi
+done
+
+# The PROJECT_DIR_* keys are the placeholders, so they are empty at this point
+# by design. parse_env_value cannot distinguish empty from absent, so the line
+# itself is what gets compared -- and the point is that all four exist on both
+# sides, not two.
+for letter in A B C D; do
+    if grep -qx "PROJECT_DIR_${letter}=" "$bash_b_dir/.env" &&
+       grep -qx "PROJECT_DIR_${letter}=" "$pwsh_b_dir/.env"; then
+        pass "Tier B: PROJECT_DIR_${letter} placeholder present on both sides"
+    else
+        fail "Tier B: PROJECT_DIR_${letter} placeholder present on both sides"
+    fi
+done
+
 echo
 printf '== Summary: PASS=%d FAIL=%d ==\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #347
Relates to #346, #349

## What

A Tier B install aborted with exit 1. `generate_env` wrote `ISOLATION_MODE=worktree` with empty `PROJECT_DIR_*` placeholders and then called the compose generator from inside the same function, 72 lines later. `require_supported_isolation_mode` refuses that by design — it does not distinguish empty from unset — and `set -euo pipefail` turned the refusal into the end of the install. `install.ps1` was identical, with `Get-SupportedIsolationMode` throwing under `$ErrorActionPreference = 'Stop'`.

The ordering was structural, not a race: `main` ran the two steps five apart, so there was no value that could have been present.

Reproduced by the test added here, run against `origin/develop`'s installer with the generator stubbed so the run continues far enough to be observed:

```
[1/0] Generating .env configuration
[INFO] Generating compose files for 4 account(s)...     <- before the worktrees
[2/0] Setting up git worktrees (Tier B)
  FAIL  no per-account path is empty      expected: 0   actual: 4
  FAIL  setup-worktrees.sh got 5 arguments  expected: 5   actual: 3
```

**Second defect**, reachable only once the install gets past `generate_env`: the worktree step prompted for exactly two branches and wrote back exactly `PROJECT_DIR_A`/`PROJECT_DIR_B`, while the `.env` placeholders were written for `NUM_ACCOUNTS`. A 4-account Tier B install left `PROJECT_DIR_C`/`D` empty. The Tier A fallback filter was hardcoded to A/B too, so a fallback left `PROJECT_DIR_C=` behind in `.env`.

## Why

`ISOLATION_MODE` did not exist before #336. Until then the `.env` the installer produced at that point carried no key the generator could reject, so the call at the end of `generate_env` passed. #336 added the key and the validator without moving the call, and the ordering became a hard failure.

CI stayed green because nothing exercised the installer-to-generator seam under Tier B: the one test that calls `generate_env` at all sets `TIER=A`, which never emits the placeholders.

The two-account limit predates the count generalization — the `.env` writer was taught `seq 1 $NUM_ACCOUNTS` and the worktree scripts were taught to take an array, but the callers kept their two literal prompts.

## How

**Ordering.** The generator call is now its own step — `generate_compose_files` / `Invoke-ComposeGeneration` — placed after `setup_worktrees` and before `start_containers`. This is the issue's preferred option: it removes the window in which `.env` declares a mode whose inputs are absent, rather than shrinking it. The generator's refusal stays exactly as it is; the installer stopped violating it.

`build_image` still runs *before* generation, on the committed `docker-compose.yml`. That is deliberate and safe: the image does not depend on the account count, the runtime or the isolation mode — every service builds the one `claude-code-base` image and the only build argument is `CLAUDE_CODE_VERSION`. The reasoning is recorded in a comment at the new step so a later reader does not "fix" the order back.

**Account count.** Both worktree setup functions are driven by `NUM_ACCOUNTS`, prompt for `worktree-<letter>` per account using the shared letter helpers, pass the whole array in **one** invocation (the callees derive each worktree's letter from position, so splitting would restart at `a`), and write back every `PROJECT_DIR_*`. The Tier A fallback filters over the same range instead of naming A and B.

**A consequence that had to be fixed with it.** `setup-worktrees.ps1` derived its letters with `[char](96 + $idx)` — correct for the first 26 accounts, punctuation past `z`. That was unreachable while `install.ps1` passed exactly two branches. Opening the caller to `NUM_ACCOUNTS` (validated up to 702) makes it reachable, and it would have produced a directory name that did not match the `PROJECT_DIR_AA` key written beside it. It now uses `Get-AccountLetter` from `lib/index.ps1`, the same helper the generators and the installer already use. The dot-source uses the nested two-argument `Join-Path` form so this does not add to #349's inventory.

### Verification

- `tests/test_install_tier_b.sh` (new, 10 assertions, added to the `bash-tests` matrix) — `PASS=10 FAIL=0`.
  - **Red first**: against `origin/develop`'s `install.sh` in a temp copy, `PASS=2 FAIL=8`, output quoted above.
  - It stubs the generator to snapshot `.env` *exactly as it stood when it was invoked* — the subject is not what the generator does but what the installer hands it — and stubs `setup-worktrees.sh` to record its argv.
  - `NUM_ACCOUNTS=4`, so the account-count defect is covered by the same run.
- `tests/test_installer_github_equivalence.sh` extended from 7 to 17 assertions — `PASS=17 FAIL=0`. The new Tier B case at four accounts **could not have existed before this change**: `generate_env` would have exited 1 on both sides. It confirms the bash and PowerShell `.env` still agree on `ISOLATION_MODE`, all four `CONTAINER_PROJECT_DIR_*`, and the presence of all four `PROJECT_DIR_*` placeholders.
- `tests/test_isolation_modes.sh` — `PASS=19 FAIL=0`, **unchanged**, including `worktree without paths: generator names the missing variable` and `worktree without paths: no compose file was written`. That contract is what the installer now respects.
- `tests/test_num_accounts_precedence.sh` (52 passed), `tests/test_compose_generator_equivalence.sh` (`PASS=23`), `tests/test_isolation_modes.ps1` (`PASS=48`), `tests/test_powershell_platform_guard.ps1` (24 passed).
- `bash -n scripts/install.sh`; PSScriptAnalyzer over `scripts/ -Recurse -Severity Warning` with the CI exclusion list — clean.
- The PowerShell half of the equivalence test really runs here: pwsh is now installed in the WSL Ubuntu 24.04 used for verification, which is the same distribution as `ubuntu-latest`.
- No installer was run against a real installation; every run is library-only sourcing into a temp sandbox with `PROJECT_ROOT` and `SCRIPT_DIR` redirected.

## Where

- `scripts/install.sh` — `generate_env`, new `generate_compose_files`, `setup_worktrees`, Tier A fallback, `main`
- `scripts/install.ps1` — `New-EnvFile`, new `Invoke-ComposeGeneration`, `Invoke-WorktreeSetup`, Tier A fallback, step list
- `scripts/setup-worktrees.ps1` — letter derivation
- `tests/test_install_tier_b.sh` (new), `tests/test_installer_github_equivalence.sh`, `.github/workflows/ci.yml`

## Notes for the reviewer

`build-compose-cmd.sh` calls `require_supported_isolation_mode` with no argument, which defaults the count to 1, and the PowerShell `Get-ComposeArgs` likewise relies on `AccountCount = 1`. So an empty `PROJECT_DIR_C` never surfaced as a validation error at start time — only as a Docker error on an empty bind source. That is unchanged here and is worth a separate look; this PR makes it unreachable from the installer rather than making the check stricter.
