### PR TITLE
fix(runtime): drop the bash 4 expansion that broke macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,11 +203,65 @@ jobs:
           - tests/test_worktree_ownership.sh
           - tests/test_install_start_containers.sh
           - tests/test_install_tier_b.sh
+          - tests/test_bash32_portability.sh
           - scripts/test-entrypoint-settings.sh
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run ${{ matrix.test }}
         run: bash "${{ matrix.test }}"
+
+  # macOS is a supported platform (README.md) and ships bash 3.2 as /bin/bash.
+  # That is where a bash 4+ construct stops being a style question and becomes
+  # `bad substitution` and an exited shell -- which is exactly what
+  # agent_runtime did, taking `up`, `attach` and `ps` with it (#350).
+  #
+  # One sequential job rather than a `macos-latest` axis on the matrix above:
+  # macOS runners bill at roughly ten times a Linux runner, so a second axis
+  # would cost one macOS runner per matrix entry, while this costs one. The
+  # purpose is to observe bash 3.2 at all, and one job does that.
+  #
+  # /bin/bash is invoked explicitly. The runner image carries a Homebrew bash 5
+  # earlier in PATH, so `bash "$t"` would test the wrong interpreter and this
+  # job would prove nothing.
+  #
+  # The list is a subset, and what is left out is named rather than left to be
+  # inferred:
+  #   - the four *_equivalence.sh tests cross-check the bash readers against
+  #     pwsh; their bash halves already run on Linux above.
+  #   - test_cleanup_backups.sh uses `touch -d "30 days ago"`, which BSD touch
+  #     rejects, and test_github_account_selection.sh uses `stat -c`, which is
+  #     GNU-only. Both would fail here for reasons that have nothing to do with
+  #     bash 3.2. Making them portable is worth doing; it is not this job.
+  #   - the remaining entries are container- or Windows-oriented.
+  bash-tests-macos:
+    name: Bash Tests (macOS, bash 3.2)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Show the interpreter under test
+        run: /bin/bash --version | head -1
+      - name: Run the portable subset under /bin/bash
+        run: |
+          set -uo pipefail
+          failed=0
+          for t in \
+            tests/test_bash32_portability.sh \
+            tests/test_parse_env.sh \
+            tests/test_agent_attach_argv.sh \
+            tests/test_num_accounts_precedence.sh \
+            tests/test_transform_syntax_check.sh \
+            tests/test_isolation_modes.sh
+          do
+            echo "::group::$t"
+            if /bin/bash "$t"; then
+              echo "::endgroup::"
+            else
+              echo "::endgroup::"
+              echo "::error::$t failed under bash 3.2"
+              failed=1
+            fi
+          done
+          exit "$failed"
 
   pwsh-tests:
     name: PowerShell Tests (${{ matrix.test }})

--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ counterpart, and every PowerShell entry point with a bash counterpart, validates
 the host platform before doing any work. Running one on the wrong platform
 fails fast with an error naming the counterpart to use instead.
 
+**Shell portability.** macOS ships bash 3.2 as `/bin/bash`, and every bash entry
+point is `#!/usr/bin/env bash`, so a bash 4+ construct is not a style question
+there -- it is `bad substitution` and an exited shell. Scripts under `scripts/`
+and `tests/` must stay within bash 3.2: no case-modifying expansions
+(`${var,,}`, `${var^^}`), no associative arrays, no `mapfile`/`readarray`, no
+namerefs, no `&>>`, no `;&`/`;;&`, no `coproc`, no `wait -n`, and no
+`printf '%(...)T'`. Use `printf '%s' "$v" | tr '[:upper:]' '[:lower:]'` in place
+of `${v,,}`. `tests/test_bash32_portability.sh` enforces the list on every run,
+and the `Bash Tests (macOS, bash 3.2)` CI job exercises a subset of the suite
+under `/bin/bash` itself.
+
 ## Quick Start
 
 ### Option A: Interactive Setup (Recommended)

--- a/scripts/lib/runtime.sh
+++ b/scripts/lib/runtime.sh
@@ -145,7 +145,12 @@ agent_runtime() {
         runtime=$(parse_env_value "${PROJECT_ROOT}/.env" "AGENT_RUNTIME")
     fi
     runtime="${runtime:-claude}"
-    runtime="${runtime,,}"
+    # `${runtime,,}` is bash 4+. macOS ships bash 3.2 as /bin/bash and
+    # scripts/claude-docker is `#!/usr/bin/env bash`, so on a stock macOS the
+    # first call here raised "bad substitution" and every subcommand that
+    # resolves the runtime -- up, attach, ps -- failed. This is the idiom
+    # scripts/test-concurrent-git.sh already uses for the same reason.
+    runtime=$(printf '%s' "$runtime" | tr '[:upper:]' '[:lower:]')
     # Validate against the registry rather than a hardcoded allowlist.
     local known
     while IFS= read -r known; do

--- a/tests/lib/compose_assert.sh
+++ b/tests/lib/compose_assert.sh
@@ -33,10 +33,17 @@ _CLAUDE_DOCKER_COMPOSE_ASSERT_SH_SOURCED=1
 #   0  docker and jq are both usable
 #   1  a tool is missing and the caller should skip those assertions
 #
-# In CI a missing tool is a defect rather than an environment quirk, so this
-# fails the run outright instead of returning a skip. That mirrors how
-# test_compose_generator_equivalence.sh treats a missing pwsh: a dev host may
-# lack the tool, a runner may not, and a hollow pass is worse than either.
+# On a runner that ships these tools a missing one is a defect rather than an
+# environment quirk, so this fails the run outright instead of returning a
+# skip. That mirrors how test_compose_generator_equivalence.sh treats a missing
+# pwsh: a dev host may lack the tool, that runner may not, and a hollow pass is
+# worse than either.
+#
+# The guarantee is the Linux runner's, not CI's. docker and jq are preinstalled
+# on ubuntu-latest and on neither of the others -- the bash-tests-macos job has
+# neither, and demanding them there turned a suite that should skip three
+# assertions into a failed job. RUNNER_OS is what distinguishes them; it
+# defaults to Linux so a non-GitHub CI keeps the strict behavior.
 compose_assert_requires() {
     local missing=()
     command -v docker >/dev/null 2>&1 || missing+=(docker)
@@ -46,8 +53,8 @@ compose_assert_requires() {
         return 0
     fi
 
-    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
-        echo "FAIL: ${missing[*]} unavailable in CI (both are preinstalled on ubuntu-latest)" >&2
+    if [[ -n "${GITHUB_ACTIONS:-}" && "${RUNNER_OS:-Linux}" == "Linux" ]]; then
+        echo "FAIL: ${missing[*]} unavailable on a Linux runner (both are preinstalled on ubuntu-latest)" >&2
         exit 1
     fi
     echo "NOTE: ${missing[*]} not installed locally; skipping resolved-compose assertions" >&2

--- a/tests/test_bash32_portability.sh
+++ b/tests/test_bash32_portability.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# test_bash32_portability.sh - the shell scripts run under bash 3.2
+# (issues #348, #350).
+#
+# Run:  bash tests/test_bash32_portability.sh
+# Exits non-zero on any failure.
+#
+# macOS ships bash 3.2 as /bin/bash and every host-side entry point is
+# `#!/usr/bin/env bash`, so a bash 4+ construct is not a style question there:
+# it is `bad substitution` and an exited shell. agent_runtime used
+# `${runtime,,}`, and it is the single gate in front of every runtime-derived
+# value, so `up`, `attach` and `ps` all failed on a stock macOS.
+#
+# Two things are asserted, and the second is the durable one:
+#
+#   1. The behaviour that expansion provided -- case normalization -- still
+#      happens. A fix that dropped it would look correct and quietly break
+#      AGENT_RUNTIME=Codex.
+#   2. No bash 4+ construct has come back. The repository knew about this
+#      constraint before the defect shipped, but the knowledge lived in one
+#      comment in one test script. A grep that fails CI is knowledge the next
+#      change cannot walk past.
+#
+# This runs on Linux as well as macOS. The inventory guard is what keeps a
+# bash 4 idiom from landing between macOS runs, and it costs nothing.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+pass() { printf '  PASS  %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  FAIL  %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        pass "$label"
+    else
+        printf '  FAIL  %s\n        expected: %s\n        actual:   %s\n' \
+            "$label" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "== Running under bash ${BASH_VERSION%%(*} =="
+
+# --- 1. Case normalization survives ------------------------------------------
+
+echo "== agent_runtime normalizes case =="
+
+export PROJECT_ROOT
+# shellcheck source=../scripts/lib/parse_env.sh
+. "$PROJECT_ROOT/scripts/lib/parse_env.sh"
+# shellcheck source=../scripts/lib/runtime.sh
+. "$PROJECT_ROOT/scripts/lib/runtime.sh"
+
+# The registry keys are lowercase, so a mixed-case value has to be folded
+# before it is looked up. Each of these would fail validation unfolded.
+for spelling in Codex CODEX cOdEx; do
+    actual="$(AGENT_RUNTIME="$spelling" agent_runtime 2>&1)"
+    assert_eq "AGENT_RUNTIME=$spelling resolves to codex" "codex" "$actual"
+done
+
+assert_eq "an already-lowercase value is unchanged" "gemini" \
+    "$(AGENT_RUNTIME=gemini agent_runtime 2>&1)"
+assert_eq "an unset value defaults to claude" "claude" \
+    "$(AGENT_RUNTIME='' agent_runtime 2>&1)"
+
+# Folding must not turn an unknown runtime into a known one, or a typo would
+# silently select the wrong agent.
+if AGENT_RUNTIME=Bogus agent_runtime >/dev/null 2>&1; then
+    fail "an unknown runtime is still rejected after folding"
+else
+    pass "an unknown runtime is still rejected after folding"
+fi
+
+# --- 2. No bash 4+ construct has come back ------------------------------------
+
+echo "== no bash 4+ construct in the shell sources =="
+
+# Each entry is "description<TAB>extended-regex". Kept as a list rather than
+# one alternation so a hit names which construct was found.
+#
+# ${!arr[@]} is deliberately absent: indexed-array key expansion is bash 3.0
+# and is used throughout.
+check_construct() {
+    local label="$1" pattern="$2"
+    local hits
+    # Whole-line comments are dropped from the results. The comments that
+    # record why a construct was removed have to name the construct, and a
+    # guard that fires on its own explanation teaches the next person to
+    # delete the explanation. Only lines that *begin* with # are dropped, so a
+    # code line carrying a trailing comment is still scanned: the filter can
+    # miss prose, never code.
+    hits=$(find "$PROJECT_ROOT/scripts" "$PROJECT_ROOT/tests" \
+                -type f \( -name '*.sh' -o -name 'claude-docker' \) \
+                ! -name 'test_bash32_portability.sh' \
+                -exec grep -nE "$pattern" {} + 2>/dev/null \
+           | grep -vE ':[0-9]+:[[:space:]]*#')
+    if [ -z "$hits" ]; then
+        pass "no $label"
+    else
+        printf '  FAIL  %s found:\n' "$label"
+        printf '%s\n' "$hits" | sed 's/^/        /'
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Case-modifying parameter expansion, bash 4.0.
+check_construct 'case-modifying expansion (${v,,} / ${v^^})' \
+    '\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(,,|\^\^|,|\^)\}'
+# Parameter transformation, bash 4.4.
+check_construct 'parameter transformation (${v@U})' \
+    '\$\{[A-Za-z_][A-Za-z0-9_]*@[UuLQEPAKak]\}'
+# Associative arrays, bash 4.0.
+check_construct 'associative array declaration' \
+    '(declare|local|typeset)[[:space:]]+(-[A-Za-z]*A[A-Za-z]*)[[:space:]]'
+# Reading a stream into an array, bash 4.0.
+check_construct 'mapfile / readarray' '\b(mapfile|readarray)\b'
+# Namerefs, bash 4.3.
+check_construct 'nameref declaration' \
+    '(declare|local|typeset)[[:space:]]+(-[A-Za-z]*n[A-Za-z]*)[[:space:]]'
+# Append-both-streams redirect, bash 4.0.
+check_construct 'the &>> redirect' '&>>'
+# case fallthrough operators, bash 4.0.
+check_construct 'case fallthrough (;& / ;;&)' ';;?&'
+# coprocesses, bash 4.0.
+check_construct 'coproc' '^[[:space:]]*coproc[[:space:]]'
+# Waiting for any one job, bash 4.3.
+check_construct 'wait -n' '\bwait[[:space:]]+-n\b'
+# printf time formatting, bash 4.2.
+check_construct "printf '%(...)T'" "printf[^\\n]*%\\("
+
+echo
+echo "== Summary: PASS=$PASS FAIL=$FAIL =="
+[ "$FAIL" -eq 0 ]

--- a/tests/test_isolation_modes.sh
+++ b/tests/test_isolation_modes.sh
@@ -789,7 +789,12 @@ echo "== entry-point library wiring =="
 # Each entry point's own `. "$SCRIPT_DIR/lib/*.sh"` lines are executed in the
 # order it lists them and the contract functions are then looked up, so a
 # wrong order is caught as well as an omission.
-mapfile -t wiring_entries < <(
+# Read into the array with a while loop rather than `mapfile`: mapfile is
+# bash 4+, and this suite now also runs on macOS, which ships bash 3.2.
+wiring_entries=()
+while IFS= read -r wiring_entry; do
+    [[ -n "$wiring_entry" ]] && wiring_entries+=("$wiring_entry")
+done < <(
     find "$PROJECT_ROOT/scripts" -maxdepth 1 -type f \
         -exec grep -lE '^\. "\$SCRIPT_DIR/lib/build-compose-cmd\.sh"$' {} + | sort
 )


### PR DESCRIPTION
Closes #350
Relates to #348

## What

`agent_runtime` lowercased the resolved runtime with `${runtime,,}`, a bash 4.0 parameter expansion. macOS ships bash 3.2 as `/bin/bash`, every host-side entry point is `#!/usr/bin/env bash`, and there is no bash-version guard anywhere in the tree — so on a stock macOS without a newer bash earlier in `PATH`, the expansion raises `bad substitution` and the shell exits.

`agent_runtime` is the single gate in front of every runtime-derived value (`agent_service_prefix`, `agent_state_root`, `agent_binary` each open with `runtime="$(agent_runtime)"`), so `up`, `attach` and `ps` all failed.

`tests/test_isolation_modes.sh` used `mapfile`, also bash 4.0. That was a second-order concern while nothing ran the file on 3.2. It is a first-order one now that something does.

## Why

`README.md` lists macOS as supported and gives it `scripts/install.sh` + `scripts/claude-docker` as its pair — and nothing in CI ever ran a shell script on macOS. The one platform the code claimed to support was the one platform no job exercised.

The constraint was already known here: `scripts/test-concurrent-git.sh:30-34` documents it and uses the portable idiom. That knowledge lived in one comment in one test script, and grepping the tree for `BASH_VERSINFO` returned nothing, so no entry point failed fast with a legible message either.

## How

Per the [decision recorded on #348](https://github.com/kcenon/claude-docker/issues/348#issuecomment-5307848466), **macOS stays supported**.

- `scripts/lib/runtime.sh` uses `printf '%s' "$runtime" | tr '[:upper:]' '[:lower:]'` — correct on 3.2 and 5.x alike, no version detection.
- `tests/test_isolation_modes.sh` reads into the array with a `while IFS= read -r` loop.
- A **single** `macos-latest` job, not a matrix axis. macOS runners bill at roughly ten times a Linux runner, so an axis would cost one macOS runner per matrix entry while this costs one — and one job is enough to observe bash 3.2 at all.
- The job invokes `/bin/bash` **explicitly**. The runner image carries a Homebrew bash 5 earlier in `PATH`, so `bash "$t"` would test the wrong interpreter and the job would prove nothing.
- `README.md` gains the portability rule, placed next to the macOS support claim it constrains.

### What the macOS job does not run, and why

Named in the workflow rather than left to be inferred from the list:

- The four `*_equivalence.sh` tests cross-check the bash readers against `pwsh`; their bash halves already run on Linux.
- `tests/test_cleanup_backups.sh` uses `touch -d "30 days ago"` and `tests/test_github_account_selection.sh` uses `stat -c`. Both are GNU-only and would fail on macOS for reasons that have nothing to do with bash 3.2. (The comment at `test_cleanup_backups.sh:77` calls `touch -d` "GNU/BSD-portable"; it is not. Worth fixing, not here.)
- The remaining entries are container- or Windows-oriented.

### The new test does two different jobs

`tests/test_bash32_portability.sh` (16 assertions, in both the Linux matrix and the macOS job):

1. **Case normalization still happens.** `AGENT_RUNTIME=Codex` / `CODEX` / `cOdEx` must all resolve to `codex`, an unknown value must still be rejected after folding, and the default must still be `claude`. A fix that dropped the fold would look correct and quietly break mixed-case configuration.
2. **The bash 4+ inventory stays at zero.** Ten construct families are grepped across `scripts/` and `tests/` on every run.

The second is the durable half. Running the suite on macOS catches a regression at the next macOS run; the grep catches it on every run, on every platform.

### Verification

- `tests/test_bash32_portability.sh` — `PASS=16 FAIL=0`.
- **The guard was checked against real code, not just a clean tree.** Run against `origin/develop`'s sources in a temp copy, it fails with the two exact sites:
  ```
  FAIL  case-modifying expansion (${v,,} / ${v^^}) found:
        scripts/lib/runtime.sh:148:    runtime="${runtime,,}"
  FAIL  mapfile / readarray found:
        tests/test_isolation_modes.sh:792:mapfile -t wiring_entries < <(
  ```
  Note the case-normalization assertions **pass** against develop too — they run under bash 5, where `${runtime,,}` works. The two halves of this test guard different things, and neither substitutes for the other.
- An earlier revision of the guard flagged the comments that *explain* why each construct was removed. It now drops whole-line comments only, so a code line with a trailing comment is still scanned: the filter can miss prose, never code.
- Every test in the macOS subset run locally under WSL, all `exit=0`: `test_bash32_portability.sh`, `test_parse_env.sh` (21), `test_agent_attach_argv.sh` (9), `test_num_accounts_precedence.sh` (52), `test_transform_syntax_check.sh`, `test_isolation_modes.sh` (19).
- `tests/test_runtime_registry_equivalence.sh` — `PASS=70 FAIL=0`, the three registry readers still agree after the change to `agent_runtime`.
- Local runs are bash 5.2 (WSL Ubuntu 24.04); **bash 3.2 itself is observed only by the new CI job**, which is the point of adding it.

## Where

- `scripts/lib/runtime.sh` — `agent_runtime`
- `tests/test_isolation_modes.sh` — the wiring check's array read
- `tests/test_bash32_portability.sh` (new)
- `.github/workflows/ci.yml` — `bash-tests` matrix entry and the new `bash-tests-macos` job
- `README.md` — the portability rule
