### PR TITLE
fix(powershell): require PowerShell 7 and say so everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,6 +276,7 @@ jobs:
           - tests/test_powershell_platform_guard.ps1
           - tests/test_worktree_path_guard.ps1
           - tests/test_cleanup_gate.ps1
+          - tests/test_powershell_version_floor.ps1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run ${{ matrix.test }}

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ per VM) by sharing a single Docker image and bind-mounting the project source.
 | Linux | UID/GID matching (`id -u`, `id -g`) |
 | macOS | Docker Desktop with VirtioFS (default) |
 | Windows (WSL2) | Source code on WSL2 filesystem (not `/mnt/c/`) |
-| Windows (Native) | Docker Desktop with WSL2 backend, PowerShell 5.1+ |
+| Windows (Native) | Docker Desktop with WSL2 backend, PowerShell 7 (`winget install --id Microsoft.PowerShell`) |
 
 ## Platform Support
 
@@ -42,7 +42,7 @@ installer and CLI wrapper that match your host platform:
 |----------|-----------|-------------|----------------|-------|
 | Linux (native) | `scripts/install.sh` | `scripts/claude-docker` | native Docker Engine | UID/GID auto-detected; uses `docker-compose.linux.yml` overlay |
 | macOS | `scripts/install.sh` | `scripts/claude-docker` | Docker Desktop (VirtioFS recommended) | OAuth tokens live in Keychain — see Troubleshooting |
-| Windows (native) | `scripts/install.ps1` | `scripts/claude-docker.ps1` or `.cmd` | Docker Desktop (WSL2 backend) | Run from PowerShell 5.1+ or PowerShell 7 |
+| Windows (native) | `scripts/install.ps1` | `scripts/claude-docker.ps1` or `.cmd` | Docker Desktop (WSL2 backend) | Requires PowerShell 7 (`pwsh`); Windows PowerShell 5.1 is not supported |
 | Windows (WSL2) | `scripts/install.sh` (**inside** WSL2) | `scripts/claude-docker` | Docker Desktop (WSL2 integration) | Keep project files inside the WSL2 filesystem for performance |
 
 **Do not cross platforms.** Every bash entry point with a PowerShell
@@ -81,7 +81,7 @@ git clone <repo-url> claude-docker
 cd claude-docker
 .\scripts\install.ps1
 # or from cmd.exe:
-powershell -ExecutionPolicy Bypass -File scripts\install.ps1
+pwsh -ExecutionPolicy Bypass -File scripts\install.ps1
 ```
 
 Same interactive Q&A as the bash version, adapted for Windows.

--- a/scripts/ClaudeDocker.psm1
+++ b/scripts/ClaudeDocker.psm1
@@ -1,8 +1,9 @@
 # ClaudeDocker.psm1 — Shared PowerShell module for claude-docker scripts
 # Provides logging, prompts, Docker Compose helpers, and utility functions.
-# Compatible with PowerShell 5.1+ and PowerShell 7+.
+# Requires PowerShell 7. Windows PowerShell 5.1 is not supported; see the
+# Platform Support section of README.md and the decision recorded on #348.
 
-#Requires -Version 5.1
+#Requires -Version 7.0
 
 # --- Logging -----------------------------------------------------------------
 

--- a/scripts/claude-docker.cmd
+++ b/scripts/claude-docker.cmd
@@ -1,5 +1,21 @@
 @echo off
-REM Batch wrapper for claude-docker.ps1 — allows cmd.exe users to run:
+REM Batch wrapper for claude-docker.ps1 - allows cmd.exe users to run:
 REM   scripts\claude-docker up
 REM   scripts\claude-docker claude
-powershell -ExecutionPolicy Bypass -File "%~dp0claude-docker.ps1" %*
+REM
+REM pwsh, not powershell. `powershell` is always Windows PowerShell 5.1, which
+REM this project no longer supports (see README.md, Platform Support, and the
+REM decision recorded on issue #348). Invoking 5.1 here surfaced as a parameter
+REM binder error from a library load rather than as anything a user could act
+REM on, because 5.1 has no -AdditionalChildPath on Join-Path.
+REM
+REM pwsh is not guaranteed present on Windows the way powershell is, so its
+REM absence is reported here rather than left to cmd's "not recognized".
+where /q pwsh
+if errorlevel 1 (
+    echo Error: PowerShell 7 ^(pwsh^) was not found on PATH.>&2
+    echo        claude-docker requires PowerShell 7; Windows PowerShell 5.1 is not supported.>&2
+    echo        Install it with:  winget install --id Microsoft.PowerShell>&2
+    exit /b 1
+)
+pwsh -ExecutionPolicy Bypass -File "%~dp0claude-docker.ps1" %*

--- a/scripts/claude-docker.ps1
+++ b/scripts/claude-docker.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+#Requires -Version 7.0
 <#
 .SYNOPSIS
     claude-docker — multi-account CLI wrapper (Windows PowerShell port)

--- a/scripts/cleanup.ps1
+++ b/scripts/cleanup.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+#Requires -Version 7.0
 <#
 .SYNOPSIS
     Cleanup containers, worktrees, and state directories.

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 case "$(uname -s)" in
     MINGW*|MSYS*|CYGWIN*)
         echo "Error: cleanup.sh is not supported on native Windows shells." >&2
-        echo "Use: powershell -ExecutionPolicy Bypass -File scripts\\cleanup.ps1" >&2
+        echo "Use: pwsh -ExecutionPolicy Bypass -File scripts\\cleanup.ps1" >&2
         exit 1 ;;
 esac
 

--- a/scripts/generate-compose.ps1
+++ b/scripts/generate-compose.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+#Requires -Version 7.0
 <#
 .SYNOPSIS
     Generate docker-compose files for N accounts.

--- a/scripts/generate-compose.sh
+++ b/scripts/generate-compose.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 case "$(uname -s)" in
     MINGW*|MSYS*|CYGWIN*)
         echo "Error: generate-compose.sh is not supported on native Windows shells." >&2
-        echo "Use: powershell -ExecutionPolicy Bypass -File scripts\\generate-compose.ps1" >&2
+        echo "Use: pwsh -ExecutionPolicy Bypass -File scripts\\generate-compose.ps1" >&2
         exit 1 ;;
 esac
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+#Requires -Version 7.0
 <#
 .SYNOPSIS
     Interactive setup script for claude-docker (Windows PowerShell port).
@@ -9,7 +9,7 @@
 .EXAMPLE
     .\scripts\install.ps1
     # or from cmd.exe:
-    powershell -ExecutionPolicy Bypass -File scripts\install.ps1
+    pwsh -ExecutionPolicy Bypass -File scripts\install.ps1
 #>
 [CmdletBinding()]
 param()

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 case "$(uname -s)" in
     MINGW*|MSYS*|CYGWIN*)
         echo "Error: install.sh is not supported on native Windows shells." >&2
-        echo "Use: powershell -ExecutionPolicy Bypass -File scripts\\install.ps1" >&2
+        echo "Use: pwsh -ExecutionPolicy Bypass -File scripts\\install.ps1" >&2
         exit 1 ;;
 esac
 

--- a/scripts/remove.ps1
+++ b/scripts/remove.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+#Requires -Version 7.0
 <#
 .SYNOPSIS
     Complete removal script for claude-docker (Windows PowerShell port).

--- a/scripts/remove.sh
+++ b/scripts/remove.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 case "$(uname -s)" in
     MINGW*|MSYS*|CYGWIN*)
         echo "Error: remove.sh is not supported on native Windows shells." >&2
-        echo "Use: powershell -ExecutionPolicy Bypass -File scripts\\remove.ps1" >&2
+        echo "Use: pwsh -ExecutionPolicy Bypass -File scripts\\remove.ps1" >&2
         exit 1 ;;
 esac
 

--- a/scripts/setup-isolated.ps1
+++ b/scripts/setup-isolated.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+#Requires -Version 7.0
 <#
 .SYNOPSIS
     Create independent per-account clones for ISOLATION_MODE=isolated.

--- a/scripts/setup-isolated.sh
+++ b/scripts/setup-isolated.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 case "$(uname -s)" in
     MINGW*|MSYS*|CYGWIN*)
         echo "Error: setup-isolated.sh is not supported on native Windows shells." >&2
-        echo "Use: powershell -ExecutionPolicy Bypass -File scripts\\setup-isolated.ps1" >&2
+        echo "Use: pwsh -ExecutionPolicy Bypass -File scripts\\setup-isolated.ps1" >&2
         exit 1 ;;
 esac
 

--- a/scripts/setup-worktrees.ps1
+++ b/scripts/setup-worktrees.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+#Requires -Version 7.0
 <#
 .SYNOPSIS
     Setup git worktrees for Tier B concurrent editing (supports N accounts).
@@ -36,7 +36,6 @@ if ($PSVersionTable.PSEdition -eq 'Core' -and $PSVersionTable.OS -and $PSVersion
 # the first 26 accounts and produced punctuation past 'z'. That was unreachable
 # while install.ps1 passed exactly two branches; it is reachable now that the
 # installer drives this from NUM_ACCOUNTS, whose validator allows up to 702.
-# Nested two-argument Join-Path: the three-argument form is PowerShell 7+.
 . (Join-Path (Join-Path $PSScriptRoot 'lib') 'index.ps1')
 
 $RepoDir = $RepoDir.TrimEnd('\', '/')

--- a/scripts/setup-worktrees.sh
+++ b/scripts/setup-worktrees.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 case "$(uname -s)" in
     MINGW*|MSYS*|CYGWIN*)
         echo "Error: setup-worktrees.sh is not supported on native Windows shells." >&2
-        echo "Use: powershell -ExecutionPolicy Bypass -File scripts\\setup-worktrees.ps1" >&2
+        echo "Use: pwsh -ExecutionPolicy Bypass -File scripts\\setup-worktrees.ps1" >&2
         exit 1 ;;
 esac
 

--- a/scripts/test-concurrent-git.ps1
+++ b/scripts/test-concurrent-git.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+#Requires -Version 7.0
 <#
 .SYNOPSIS
     E2E test: Tier B concurrent git safety (Windows PowerShell port).

--- a/scripts/test-concurrent-git.sh
+++ b/scripts/test-concurrent-git.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 case "$(uname -s)" in
     MINGW*|MSYS*|CYGWIN*)
         echo "Error: test-concurrent-git.sh is not supported on native Windows shells." >&2
-        echo "Use: powershell -ExecutionPolicy Bypass -File scripts\\test-concurrent-git.ps1" >&2
+        echo "Use: pwsh -ExecutionPolicy Bypass -File scripts\\test-concurrent-git.ps1" >&2
         exit 1 ;;
 esac
 

--- a/tests/test_powershell_version_floor.ps1
+++ b/tests/test_powershell_version_floor.ps1
@@ -1,0 +1,127 @@
+# test_powershell_version_floor.ps1 - the repository declares one PowerShell
+# floor and every entry point agrees with it (issues #348, #349).
+#
+# Run:  pwsh -NoProfile -File tests/test_powershell_version_floor.ps1
+# Exits non-zero on any failure.
+#
+# The tree used to say two things at once. Nine scripts carried
+# `#Requires -Version 5.1` and README advertised "PowerShell 5.1+", while four
+# dot-source lines passed three positional arguments to Join-Path -- binding to
+# -AdditionalChildPath, which exists only in PowerShell 6+. On 5.1 the binder
+# threw before the script did any work. Nothing caught it: every PowerShell CI
+# step invokes `pwsh`, so the declared floor was never the interpreter under
+# test.
+#
+# Per the decision recorded on #348, the floor is PowerShell 7 and 5.1 is not
+# supported. These assertions are static: they read the sources rather than
+# running the entry points, because running install.ps1 or cleanup.ps1 to
+# observe a #Requires header would mean running an installer or a remover.
+#
+# What this cannot check is the interpreter itself -- a CI job invoking `pwsh`
+# proves 7 works, not that 5.1 is refused. What it can check, and what actually
+# regressed here, is that no part of the tree quietly re-advertises 5.1.
+
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent $ScriptDir
+$ScriptsDir = Join-Path $ProjectRoot 'scripts'
+
+$script:Pass = 0
+$script:Fail = 0
+
+function Assert-Eq {
+    param(
+        [Parameter(Mandatory)][string]$Label,
+        [Parameter(Mandatory)][AllowEmptyString()][AllowNull()][object]$Expected,
+        [Parameter(Mandatory)][AllowEmptyString()][AllowNull()][object]$Actual
+    )
+    if ([string]$Expected -eq [string]$Actual) {
+        Write-Host ("  PASS  {0}" -f $Label)
+        $script:Pass++
+    } else {
+        Write-Host ("  FAIL  {0}`n        expected: {1}`n        actual:   {2}" -f `
+            $Label, ([string]$Expected), ([string]$Actual))
+        $script:Fail++
+    }
+}
+
+$RequiredFloor = '7.0'
+
+Write-Host '== Every PowerShell source declares the same floor =='
+
+# -Recurse so a new script under scripts/lib/ is covered without editing a
+# list here. A file with no #Requires at all is reported rather than skipped:
+# an entry point that inherits nothing is how a 5.1 user reaches a parse error
+# instead of a version message.
+$psFiles = @(Get-ChildItem -Path $ScriptsDir -Recurse -File -Include '*.ps1', '*.psm1' |
+    Sort-Object FullName)
+
+Assert-Eq 'PowerShell sources were found' $true ($psFiles.Count -gt 0)
+
+$missing = @()
+$wrong = @()
+foreach ($f in $psFiles) {
+    $text = Get-Content -LiteralPath $f.FullName -Raw
+    $m = [regex]::Match($text, '(?m)^#Requires\s+-Version\s+(\S+)')
+    $rel = $f.FullName.Substring($ProjectRoot.Length + 1) -replace '\\', '/'
+    if (-not $m.Success) {
+        $missing += $rel
+    } elseif ($m.Groups[1].Value -ne $RequiredFloor) {
+        $wrong += ("{0} declares {1}" -f $rel, $m.Groups[1].Value)
+    }
+}
+
+Assert-Eq "no source declares a floor other than $RequiredFloor" '' ($wrong -join '; ')
+
+# lib/*.ps1 files are dot-sourced into a caller that already declared the
+# floor, so they are listed rather than failed -- but they are listed, so a
+# new *entry point* without a header is visible instead of silent.
+if ($missing.Count -gt 0) {
+    Write-Host ("  NOTE  no #Requires header (dot-sourced libraries): {0}" -f ($missing -join ', '))
+}
+
+Write-Host '== The cmd wrapper launches the supported interpreter =='
+
+# claude-docker.cmd is the one entry point that chooses an interpreter rather
+# than being run by one. `powershell` is always Windows PowerShell 5.1, so a
+# bare `powershell` here sends every cmd.exe user straight into the floor it
+# cannot meet.
+$cmdPath = Join-Path $ScriptsDir 'claude-docker.cmd'
+$cmdText = Get-Content -LiteralPath $cmdPath -Raw
+
+Assert-Eq 'claude-docker.cmd invokes pwsh' $true `
+    ($cmdText -match '(?m)^\s*pwsh\s')
+Assert-Eq 'claude-docker.cmd does not invoke powershell' $false `
+    ($cmdText -match '(?m)^\s*powershell(\.exe)?\s')
+# pwsh is not guaranteed present on Windows the way powershell is, so its
+# absence has to be reported rather than left to cmd's "not recognized".
+Assert-Eq 'claude-docker.cmd checks that pwsh exists' $true `
+    ($cmdText -match 'where\s+/q\s+pwsh')
+
+Write-Host '== Guidance never points at the unsupported interpreter =='
+
+# The bash platform guards tell a Windows user which PowerShell script to run
+# instead. Naming `powershell` there routes them into the interpreter the
+# #Requires headers now refuse -- a failure caused by the error message that
+# was meant to help.
+$guidance = @()
+foreach ($f in (Get-ChildItem -Path $ScriptsDir -Recurse -File -Include '*.sh', '*.ps1', '*.psm1', '*.cmd')) {
+    $text = Get-Content -LiteralPath $f.FullName -Raw
+    if ($text -match 'powershell\s+-ExecutionPolicy') {
+        $guidance += ($f.FullName.Substring($ProjectRoot.Length + 1) -replace '\\', '/')
+    }
+}
+Assert-Eq 'no script suggests `powershell -ExecutionPolicy`' '' ($guidance -join '; ')
+
+$readme = Get-Content -LiteralPath (Join-Path $ProjectRoot 'README.md') -Raw
+Assert-Eq 'README does not suggest `powershell -ExecutionPolicy`' $false `
+    ($readme -match 'powershell\s+-ExecutionPolicy')
+Assert-Eq 'README does not advertise a 5.1 floor' $false `
+    ($readme -match 'PowerShell 5\.1\+')
+
+Write-Host ''
+Write-Host ("== Summary: PASS={0} FAIL={1} ==" -f $script:Pass, $script:Fail)
+if ($script:Fail -gt 0) { exit 1 }

--- a/tests/test_worktree_path_guard.ps1
+++ b/tests/test_worktree_path_guard.ps1
@@ -23,8 +23,6 @@ $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ProjectRoot = Split-Path -Parent $ScriptDir
 $ScriptsDir = Join-Path $ProjectRoot 'scripts'
 
-# Two-argument Join-Path only: the three-argument form is PowerShell 7+, and
-# these scripts are also read by Windows PowerShell 5.1.
 Import-Module (Join-Path $ScriptsDir 'ClaudeDocker.psm1') -Force
 
 $script:Pass = 0


### PR DESCRIPTION
Closes #349
Relates to #348

## What

The tree said two things at once.

| Claim | Site |
|---|---|
| PowerShell 5.1 is supported | nine `#Requires -Version 5.1` headers, `README.md:34`, `README.md:45`, `ClaudeDocker.psm1:3` |
| PowerShell 6+ is required | four dot-source lines passing three positional arguments to `Join-Path` |

The third positional slot binds to `-AdditionalChildPath`, which exists only in PowerShell 6+. On Windows PowerShell 5.1 the binder throws before the script does any work:

```
PS> $PSVersionTable.PSVersion.ToString(); Join-Path 'a' 'b' 'c'
5.1.26100.9168
Join-Path : <positional parameter cannot be found that accepts argument 'c'>
    + FullyQualifiedErrorId : PositionalParameterNotFound,...JoinPathCommand
```

`scripts/claude-docker.cmd:5` made that reachable by design: it invoked `powershell`, which is always Windows PowerShell 5.1, never `pwsh`. `claude-docker scale N` dispatches to `Invoke-Scale`, which shells out to `generate-compose.ps1` — and that died at its line 36.

Nothing caught it. Every PowerShell CI step invokes `pwsh`, including `pwsh-windows-tests` (which is `runs-on: windows-latest` but still selects `pwsh`), so the declared floor was never the interpreter under test. The tests could not catch it either — they use the same construct.

## Why

The library headers document the broken call as the intended usage: `scripts/lib/index.ps1:5` and `scripts/lib/tui-release.ps1:5` both carry the three-argument form as their load example. So every new caller copied a PowerShell 7 idiom into a tree whose headers promised 5.1.

## How

Per the [decision recorded on #348](https://github.com/kcenon/claude-docker/issues/348#issuecomment-5307848466), **the floor is PowerShell 7 and 5.1 is withdrawn** (Branch B). Keeping 5.1 would bind every future PowerShell change to its syntax — no three-argument `Join-Path`, no ternary, no `??`, no `?.` — for a runtime that installs with one `winget` command.

- Nine `#Requires -Version 5.1` headers → `7.0`.
- `ClaudeDocker.psm1:3` said "Compatible with PowerShell 5.1+ and PowerShell 7+", contradicting its own `#Requires` two lines later.
- `README.md:34` and `:45`.
- `scripts/claude-docker.cmd` invokes `pwsh`, and **reports pwsh's absence** rather than leaving it to cmd's "not recognized". `powershell` is guaranteed present on Windows; `pwsh` is not, so replacing one with the other without a check trades a confusing error for a different confusing error.

### The change that was not in the issue's list

Nine `powershell -ExecutionPolicy Bypass -File` strings had to change, and **seven of them are the bash platform guards' own "use this instead" messages**:

```
Error: install.sh is not supported on native Windows shells.
Use: powershell -ExecutionPolicy Bypass -File scripts\install.ps1
```

Naming `powershell` there routes a Windows user straight into the interpreter the new headers refuse — the message written to help them would have caused their next failure. `install.ps1`'s own docstring and `README.md:73` had the same string.

### Verification

- `tests/test_powershell_version_floor.ps1` (new, 8 assertions, added to the `pwsh-tests` matrix) — `PASS=8 FAIL=0`.
  - **Red first**: against `origin/develop`'s sources in a temp copy it fails on all four axes — nine files declaring 5.1 (listed by name), the cmd wrapper invoking `powershell` with no pwsh check, the guidance strings, and both README claims. `PASS=1 FAIL=7`.
  - It reads the sources rather than running the entry points. Observing a `#Requires` header by *running* `install.ps1` would mean running an installer; observing `cleanup.ps1`'s would mean running a remover.
  - It scans `scripts/` recursively, so a new script is covered without editing a list. Files with no `#Requires` at all are reported as a NOTE rather than passed over silently — today that is `lib/index.ps1` and `lib/tui-release.ps1`, which are dot-sourced into callers that already declared the floor.
- Full `pwsh-tests` matrix under Linux pwsh 7.6.5 (the same distribution as `ubuntu-latest`): `test_parse_env.ps1` (20), `test_isolation_modes.ps1` (48), `test_container_memory.ps1` (47), `test_powershell_platform_guard.ps1` (24), `test_worktree_path_guard.ps1` (34), `test_cleanup_gate.ps1` (24), `test_powershell_version_floor.ps1` (8) — all zero failures.
- PSScriptAnalyzer with the CI exclusion list — clean.
- `bash -n` on all seven edited shell guards; `tests/test_windows_platform_guard.sh` — 34 passed, so the guards still fire and still name a counterpart.

### What this does not verify

A CI job invoking `pwsh` proves PowerShell 7 works; it does not prove 5.1 is refused. Observing the refusal needs a `shell: powershell` job, which is what Branch A would have required — and under Branch B there is nothing to keep green there. The floor test therefore guards the thing that actually regressed: no part of the tree quietly re-advertising 5.1.

`claude-docker scale 3` through `claude-docker.cmd` (acceptance criterion 3) needs a Windows host with Docker and is not verified here.

## Where

- Nine `#Requires` headers under `scripts/`
- `scripts/ClaudeDocker.psm1` — header comment
- `scripts/claude-docker.cmd` — interpreter and the pwsh-presence check
- Seven bash platform guards + `scripts/install.ps1` docstring + `README.md:73` — the guidance strings
- `README.md:34`, `:45`
- `tests/test_powershell_version_floor.ps1` (new), `.github/workflows/ci.yml`

## Notes for the reviewer

`ClaudeDocker.psm1`'s `Read-Secret` still carries a 5.1 branch (the BSTR path behind `if ($PSVersionTable.PSVersion.Major -ge 7)`). It is now unreachable under the declared floor. I left it: it is correct code, and removing it is a behavioural edit to a credential path that does not belong in a change about version declarations. Worth a follow-up sweep for dead 5.1 branches.
