### PR TITLE
fix(tui): synchronize the shared config.Env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,21 @@ jobs:
         with:
           # Must match or exceed tui/go.mod's `go` directive (currently 1.24).
           go-version: "1.24"
+      # -race, not a plain `go test`. The TUI shares one *config.Env across the
+      # bubbletea event loop and every Cmd goroutine, and an unsynchronized map
+      # write there is `fatal error: concurrent map read and map write` -- a
+      # runtime fatal that skips bubbletea's terminal restore. Without the
+      # detector, tests/internal/config/env_race_test.go passes or fails on a
+      # scheduling accident (issue #351).
       - name: Run Go unit tests
         working-directory: ./tui
-        run: go test ./...
+        run: go test -race ./...
+      # go vet catches the class of mistake the compiler allows and the tests
+      # do not reach: lost struct tags, unreachable code, printf arity. It was
+      # not run at all before #351.
+      - name: Run go vet
+        working-directory: ./tui
+        run: go vet ./...
       # `go test ./...` compiles benchmark functions but never executes them,
       # so a benchmark harness that panics at runtime stays green forever.
       # -benchtime=1x runs each benchmark exactly once: enough to catch that,

--- a/tui/internal/config/env.go
+++ b/tui/internal/config/env.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 const (
@@ -31,7 +32,23 @@ const (
 )
 
 // Env holds parsed .env configuration with order-preserving entries.
+//
+// One *Env is created in main and shared for the process' lifetime, and
+// bubbletea runs every Cmd on its own goroutine. So `entries` and `index` are
+// reached from at least three goroutines at once: the event loop renders
+// through Get on every message, the refresh Cmd reads NUM_ACCOUNTS and
+// AGENT_RUNTIME, and the gh-auth Cmd writes the token key.
+//
+// Unsynchronized, the write's append branch against a concurrent read is
+// `fatal error: concurrent map read and map write` -- a runtime fatal, not a
+// panic, so bubbletea's recoverFromPanic never runs and the terminal is left
+// in altscreen with a raw stack dump.
+//
+// Moving the write onto the event loop would not be enough: the refresh Cmd
+// still reads from its own goroutine, so the collision would move rather than
+// go away. The lock covers every reader, present and future.
 type Env struct {
+	mu      sync.RWMutex
 	path    string
 	entries []entry
 	index   map[string]int // key -> entries[i]
@@ -84,6 +101,8 @@ func NewEmptyEnv(path string) *Env {
 
 // Get returns the value of a key, or empty string if not set.
 func (e *Env) Get(key string) string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	if i, ok := e.index[key]; ok {
 		return e.entries[i].value
 	}
@@ -91,7 +110,16 @@ func (e *Env) Get(key string) string {
 }
 
 // Set updates or appends a key=value entry.
+//
+// The append branch is the one that matters: it writes the map. It used to be
+// a one-time event, because the only caller wrote the fixed key GH_TOKEN and
+// every press after the first took the in-place update branch. Per-account
+// auth made the key GH_TOKEN_<LETTER>, so every account's first gh-auth press
+// appends -- and .env.example ships all three token keys commented out, which
+// LoadEnv does not index, so even shared mode appends on the first press.
 func (e *Env) Set(key, value string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	if i, ok := e.index[key]; ok {
 		e.entries[i].key = key
 		e.entries[i].value = value
@@ -105,10 +133,20 @@ func (e *Env) Set(key, value string) {
 // Save writes the env file back to disk, preserving order/comments.
 // Uses atomic rename + 0600 permissions because the file holds secrets.
 func (e *Env) Save() error {
-	if e.path == "" {
+	// Snapshot under the read lock, then write without holding it. The write
+	// includes a temp file, a rename and -- on Windows -- an icacls exec;
+	// holding the lock across that would stall every render for as long as
+	// the slowest of them.
+	e.mu.RLock()
+	path := e.path
+	snapshot := make([]entry, len(e.entries))
+	copy(snapshot, e.entries)
+	e.mu.RUnlock()
+
+	if path == "" {
 		return fmt.Errorf("env path not set")
 	}
-	dir := filepath.Dir(e.path)
+	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("mkdir: %w", err)
 	}
@@ -120,7 +158,7 @@ func (e *Env) Save() error {
 	defer os.Remove(tmpName)
 
 	w := bufio.NewWriter(tmp)
-	for _, ent := range e.entries {
+	for _, ent := range snapshot {
 		if ent.key != "" {
 			if _, err := fmt.Fprintf(w, "%s=%s\n", ent.key, ent.value); err != nil {
 				tmp.Close()
@@ -143,10 +181,10 @@ func (e *Env) Save() error {
 	if err := os.Chmod(tmpName, 0600); err != nil {
 		return fmt.Errorf("chmod: %w", err)
 	}
-	if err := os.Rename(tmpName, e.path); err != nil {
+	if err := os.Rename(tmpName, path); err != nil {
 		return fmt.Errorf("rename: %w", err)
 	}
-	if err := hardenSecretFile(e.path); err != nil {
+	if err := hardenSecretFile(path); err != nil {
 		return err
 	}
 	return nil

--- a/tui/internal/config/env_race_test.go
+++ b/tui/internal/config/env_race_test.go
@@ -1,0 +1,112 @@
+package config
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// TestEnvConcurrentSetGet drives the collision the TUI hits in normal use
+// (issue #351).
+//
+// One *Env is created in main and shared for the process' lifetime, and
+// bubbletea runs every Cmd on its own goroutine. The gh-auth Cmd calls Set
+// while the event loop renders through Get and the refresh Cmd reads
+// NUM_ACCOUNTS -- three goroutines on one map.
+//
+// Each Set here uses a *new* key so it takes the append branch, which is the
+// one that writes the map. That is not an artificial choice: per-account auth
+// made the key GH_TOKEN_<LETTER>, so every account's first gh-auth press
+// appends, and .env.example ships the token keys commented out, which LoadEnv
+// does not index -- so even shared mode appends on the first press.
+//
+// Unsynchronized this is `fatal error: concurrent map read and map write`, not
+// a recoverable panic: bubbletea's recoverFromPanic never runs, so the process
+// dies with a raw stack dump and leaves the terminal in altscreen.
+//
+// This test only means something under `go test -race`, which the go-test CI
+// job now passes. Without it a scheduling accident can let the run pass.
+func TestEnvConcurrentSetGet(t *testing.T) {
+	env := NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+	env.Set("NUM_ACCOUNTS", "2")
+	env.Set("AGENT_RUNTIME", "claude")
+
+	const iterations = 200
+	var wg sync.WaitGroup
+
+	// The gh-auth Cmd: a new token key per account.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			env.Set(fmt.Sprintf("GH_TOKEN_%d", i), "placeholder-not-a-token")
+		}
+	}()
+
+	// The event loop: renderIsolationBanner and App.View on every message.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = env.IsolationMode()
+			_ = env.Get("PROJECT_DIR_A")
+		}
+	}()
+
+	// The refresh Cmd: ListAccounts, on a third goroutine.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = env.NumAccounts()
+			_ = env.AgentRuntime()
+		}
+	}()
+
+	wg.Wait()
+
+	// The lock has to preserve the data, not just the memory model.
+	if got := env.Get("NUM_ACCOUNTS"); got != "2" {
+		t.Errorf("NUM_ACCOUNTS = %q after concurrent writes, want %q", got, "2")
+	}
+	for i := 0; i < iterations; i++ {
+		key := fmt.Sprintf("GH_TOKEN_%d", i)
+		if got := env.Get(key); got != "placeholder-not-a-token" {
+			t.Fatalf("%s = %q, want the written value; an append was lost", key, got)
+		}
+	}
+}
+
+// TestEnvConcurrentSaveAndGet covers the other direction: Save snapshots the
+// entries and then writes to disk without holding the lock, so a reader must
+// not be blocked by the write and must not observe a torn slice.
+func TestEnvConcurrentSaveAndGet(t *testing.T) {
+	env := NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+	env.Set("NUM_ACCOUNTS", "2")
+
+	const iterations = 50
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if err := env.Save(); err != nil {
+				t.Errorf("Save: %v", err)
+				return
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			env.Set(fmt.Sprintf("GH_TOKEN_%d", i), "placeholder-not-a-token")
+			_ = env.Get("NUM_ACCOUNTS")
+		}
+	}()
+
+	wg.Wait()
+}

--- a/tui/internal/ui/dashboard/update.go
+++ b/tui/internal/ui/dashboard/update.go
@@ -33,8 +33,15 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		return m, nil
 
 	case uiTickMsg:
-		// If refresh is in-flight, just reschedule without doing anything
-		if m.refreshing {
+		// If refresh is in-flight, just reschedule without doing anything.
+		//
+		// m.busy is checked for the same reason. This path used to look only
+		// at m.refreshing, so a retry deadline landing during gh-auth started
+		// a second command goroutine reading .env while the first was writing
+		// it. The `r` key has always had this guard; the timer did not, which
+		// made the collision something the operator could hit by waiting
+		// rather than by doing anything.
+		if m.refreshing || m.busy {
 			return m, tea.Tick(time.Second, func(time.Time) tea.Msg {
 				return uiTickMsg{}
 			})


### PR DESCRIPTION
Closes #351
Relates to #358

## What

One `*config.Env` is created in `main` and shared for the process' lifetime, and bubbletea runs every `Cmd` on its own goroutine. Three goroutines reach its map and slice at once:

| goroutine | site | operation |
|---|---|---|
| event loop (runs `View()` after **every** message) | `ui/app.go:75,80`, `dashboard/render.go:22` | `Get` |
| refresh `Cmd` | `account/manager_helpers.go:24-25` | `Get` |
| gh-auth `Cmd` | `dashboard/helpers.go:58` | **`Set`** |

Confirmed with the race detector against the current tree:

```
WARNING: DATA RACE
Write at 0x... by goroutine 8:
  runtime.mapassign_faststr()
  config.(*Env).Set()          env.go:101
Previous read at 0x... by goroutine 10:
  runtime.mapaccess2_faststr()
  config.(*Env).Get()          env.go:87
  config.(*Env).NumAccounts()  env.go:177
```

Unsynchronized this is `fatal error: concurrent map read and map write` — a runtime **fatal**, not a panic. Bubbletea's `recoverFromPanic`, which is what restores the terminal, never runs: the process dies with a raw stack dump and leaves the terminal in altscreen. It dies immediately before `env.Save()`, so the operator cannot tell whether the token was persisted.

## Why

`env.Set(...)` has been inside that command goroutine since gh-auth was added, but the call was `env.Set("GH_TOKEN", token)` — a key that, once written, stays in `index`, so every later press took the in-place update branch and never touched the map. Per-account auth changed one line to `env.Set(key, token)`, where `key` is `GH_TOKEN_<LETTER>`. Every account's first press now appends. And `.env.example` ships all three token keys **commented out**, which `LoadEnv` does not index — so even shared mode appends on the first press.

Two things made the collision reachable without the operator doing anything unusual:

- `m.busy` gates `tea.KeyMsg` but not rendering. Any message at all — a tick, a toast expiry, a resize — still drives `View()` on the event loop.
- The `uiTickMsg` branch checked `m.refreshing` but not `m.busy`, so a retry deadline landing during gh-auth fired `m.Refresh()` and put a **second** reader on a third goroutine.

The class was invisible to CI: `go-test` ran neither `go vet` nor `-race`.

## How

`Env` carries a `sync.RWMutex`. `Get` takes `RLock`, `Set` takes `Lock`.

**Why not the issue's preferred fix.** Moving the mutation into `Update` would put the write on the event loop — but the refresh `Cmd` still reads from *its* goroutine, so the collision would move rather than go away. The lock covers every reader, present and future; the move alone is not sufficient. That is a correction to the issue's analysis, not a shortcut.

`Save` snapshots the entries under the read lock and writes **without** holding it. The write is a temp file, a rename and — on Windows — an `icacls` exec; holding the lock across that would stall every render for as long as the slowest of them.

The `uiTickMsg` retry path now checks `m.busy` as well as `m.refreshing`. The `r` key has always had this guard; the timer did not, which made the collision something the operator reached by waiting.

### Verification

- **Red first.** `tests` in `tui/internal/config/env_race_test.go` run against `origin/develop`'s `env.go` in a temp copy report the DATA RACE quoted above and exit 1.
- **Green after.** `go test -race ./...` — every package `ok`. `go vet ./...` — clean. `gofmt -l .` — empty. Benchmark smoke — PASS.
- The race test uses a **new key per iteration** so it takes the append branch. That is the real path, not an artificial one, for the reason in the Why section above.
- It also asserts the data survives: `NUM_ACCOUNTS` still reads `2` and all 200 written keys read back. A lock that satisfied the detector while losing appends would pass a memory-safety-only test.
- A second test drives `Save` concurrently with `Set`/`Get`, covering the snapshot path.
- `-race` needs cgo, which the Windows host has no compiler for; verification ran under WSL Ubuntu 24.04 with Go 1.26 — the same distribution as `ubuntu-latest`.

### CI

`go test -race` and `go vet` are both added. **`-race` is what makes the new test mean anything** — without the detector it passes or fails on a scheduling accident, which is the same "runs but does not observe" shape the suite already has elsewhere.

## Where

- `tui/internal/config/env.go` — `Env`, `Get`, `Set`, `Save`
- `tui/internal/ui/dashboard/update.go` — the `uiTickMsg` retry guard
- `tui/internal/config/env_race_test.go` (new)
- `.github/workflows/ci.yml` — `go-test`

## Out of scope, from the issue's own list

`tickActive` is lowered while a scheduled `tea.Tick` may still be pending, which can leave a spare idle timer; `enrichAccounts` spawns two unbounded goroutines per account and the account count auto-expands from discovered state directories up to 702. Both belong with the rest of the TUI robustness work in #358.
