### PR TITLE
fix(release): build the tag the release is named after

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# No job here writes anything back to the repository, so the token does not
+# need to. Without this block GITHUB_TOKEN takes the repository default, which
+# can be read-write.
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     name: Shellcheck
@@ -216,6 +222,7 @@ jobs:
           - tests/test_install_start_containers.sh
           - tests/test_install_tier_b.sh
           - tests/test_bash32_portability.sh
+          - tests/test_workflow_contracts.sh
           - scripts/test-entrypoint-settings.sh
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/release-tui.yml
+++ b/.github/workflows/release-tui.yml
@@ -11,12 +11,81 @@ on:
         required: true
         type: string
 
+# Read by default. Only the release job publishes, and it raises this to
+# `contents: write` for itself -- the five build jobs used to run with a write
+# token they had no use for.
 permissions:
-  contents: write
+  contents: read
+
+# Keyed on the tag rather than the ref, so a dispatch and a tag push for the
+# same version serialize instead of racing. Losing that race puts assets built
+# from two different commits into one release; every asset ships a paired
+# .sha256, but the checksums would agree with the wrong binaries.
+#
+# cancel-in-progress is false on purpose: cancelling a run that has begun
+# uploading leaves a partially populated release, which is worse than waiting.
+concurrency:
+  group: release-tui-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
+  # A dispatch names a tag, but the build checkout used to ignore it: no
+  # `ref:`, so it took the branch selected in the dispatch UI, while the
+  # publish step named the release after the input. The tag stopped
+  # identifying the code it shipped.
+  #
+  # Resolving once, in its own job, means a bad tag costs one job instead of
+  # five and can never reach an upload.
+  resolve-tag:
+    name: Resolve and validate the tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Tags are needed to answer "does this tag exist"; the default
+          # shallow checkout does not carry them.
+          fetch-depth: 0
+
+      - name: Resolve
+        id: resolve
+        shell: bash
+        # inputs.tag reaches the script through env, never interpolated into
+        # the body. The dispatcher already holds write access so this crosses
+        # no new trust boundary, but the interpolated form is the
+        # script-injection shape and the fix costs one line.
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          # Precedence is the input first, matching the publish step. The
+          # build step had it backwards -- ${GITHUB_REF_NAME:-inputs.tag} --
+          # and GITHUB_REF_NAME is always set in Actions, so the fallback to
+          # the input was unreachable.
+          tag="${INPUT_TAG:-$GITHUB_REF_NAME}"
+
+          if [[ ! "$tag" =~ ^v[0-9][0-9A-Za-z.-]*$ ]]; then
+            echo "::error::tag '$tag' does not match ^v[0-9][0-9A-Za-z.-]*$"
+            exit 1
+          fi
+
+          # The input's own description says the tag must already exist. That
+          # was never checked, so a typo produced a release built from a
+          # branch under a name nobody could trace back.
+          if ! git rev-parse --verify --quiet "refs/tags/${tag}^{commit}" >/dev/null; then
+            echo "::error::tag '$tag' does not exist in this repository"
+            exit 1
+          fi
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "resolved tag: $tag"
+
   build:
     name: Build ${{ matrix.target.os }}/${{ matrix.target.goarch }}
+    needs: resolve-tag
     runs-on: ${{ matrix.target.runner }}
     strategy:
       fail-fast: false
@@ -30,6 +99,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # The resolved tag, not the dispatch branch. This is the line whose
+          # absence let a release ship code from somewhere else.
+          ref: ${{ needs.resolve-tag.outputs.tag }}
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
@@ -43,12 +116,16 @@ jobs:
         env:
           GOOS: ${{ matrix.target.os }}
           GOARCH: ${{ matrix.target.goarch }}
+          EXT: ${{ matrix.target.ext }}
           CGO_ENABLED: '0'
+          # One source for the stamp and the tree: the same value the checkout
+          # above used.
+          TAG: ${{ needs.resolve-tag.outputs.tag }}
         run: |
-          ref="${GITHUB_REF_NAME:-${{ inputs.tag }}}"
-          out="claude-docker-tui-${GOOS}-${GOARCH}${{ matrix.target.ext }}"
+          set -euo pipefail
+          out="claude-docker-tui-${GOOS}-${GOARCH}${EXT}"
           go build -trimpath \
-              -ldflags "-s -w -X main.version=${ref}" \
+              -ldflags "-s -w -X main.version=${TAG}" \
               -o "$out" .
           echo "ASSET=$out" >> "$GITHUB_ENV"
 
@@ -75,8 +152,11 @@ jobs:
 
   release:
     name: Publish release
-    needs: build
+    needs: [resolve-tag, build]
     runs-on: ubuntu-latest
+    # The only job that needs to write, and the only one that gets to.
+    permissions:
+      contents: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
@@ -98,7 +178,9 @@ jobs:
       - name: Publish release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
-          tag_name: ${{ inputs.tag || github.ref_name }}
+          # The resolved tag, so the name, the tree and the stamp are one
+          # value rather than three that happen to agree.
+          tag_name: ${{ needs.resolve-tag.outputs.tag }}
           files: |
             artifacts/claude-docker-tui-*
             artifacts/SHA256SUMS

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# test_workflow_contracts.sh - properties the release workflow has to keep
+# (issue #352).
+#
+# Run:  bash tests/test_workflow_contracts.sh
+# Exits non-zero on any failure.
+#
+# workflow_dispatch on release-tui.yml published binaries built from the
+# dispatch branch while naming the release after inputs.tag, so the tag no
+# longer identified the code it shipped. Two halves of one file disagreed: the
+# publish step read `inputs.tag || github.ref_name` while the build step read
+# `${GITHUB_REF_NAME:-inputs.tag}` -- and GITHUB_REF_NAME is always set in
+# Actions, so the input never won there. The build checkout had no `ref:` at
+# all.
+#
+# A workflow cannot be unit-tested without dispatching it, and dispatching a
+# release is not something a test can do. These assertions are therefore about
+# the file: the shapes whose absence caused the defect. They are grep-based
+# rather than YAML-parsed so the suite keeps its zero external dependencies;
+# each pattern is anchored tightly enough that a reformat is more likely to
+# fail loudly than to pass wrongly.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKFLOWS="$PROJECT_ROOT/.github/workflows"
+RELEASE="$WORKFLOWS/release-tui.yml"
+CI="$WORKFLOWS/ci.yml"
+
+PASS=0
+FAIL=0
+
+pass() { printf '  PASS  %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; FAIL=$((FAIL + 1)); }
+
+# assert_matches LABEL FILE PATTERN
+assert_matches() {
+    local label="$1" file="$2" pattern="$3"
+    if grep -qE "$pattern" "$file"; then
+        pass "$label"
+    else
+        fail "$label" "no line in $(basename "$file") matches: $pattern"
+    fi
+}
+
+# assert_absent LABEL FILE PATTERN
+# Whole-line YAML comments are excluded from the result. The comments that
+# record why a shape was removed have to name it, and a guard that fires on
+# its own explanation teaches the next person to delete the explanation. Only
+# lines whose first non-blank character is # are dropped, so a value carrying
+# a trailing comment is still checked.
+assert_absent() {
+    local label="$1" file="$2" pattern="$3"
+    local hit
+    hit=$(grep -nE "$pattern" "$file" | grep -vE '^[0-9]+: *#' | head -n 3)
+    if [[ -z "$hit" ]]; then
+        pass "$label"
+    else
+        fail "$label" "$(printf '%s' "$hit" | tr '\n' ' ')"
+    fi
+}
+
+for f in "$RELEASE" "$CI"; do
+    if [[ ! -r "$f" ]]; then
+        fail "workflow exists" "$f"
+        echo "== Summary: PASS=$PASS FAIL=$FAIL =="
+        exit 1
+    fi
+done
+
+echo "== release-tui.yml builds the tag it names =="
+
+# The line whose absence let a release ship code from a branch.
+assert_matches 'the build checkout pins a ref' "$RELEASE" \
+    '^ +ref: \$\{\{ needs\.resolve-tag\.outputs\.tag \}\}'
+
+# The stamp and the tree must come from the same value.
+assert_matches 'the version stamp uses the resolved tag' "$RELEASE" \
+    '^ +TAG: \$\{\{ needs\.resolve-tag\.outputs\.tag \}\}'
+assert_matches 'the release is named with the resolved tag' "$RELEASE" \
+    '^ +tag_name: \$\{\{ needs\.resolve-tag\.outputs\.tag \}\}'
+
+# The reversed precedence that made the input unreachable.
+assert_absent 'no ${GITHUB_REF_NAME:-...} fallback remains' "$RELEASE" \
+    'GITHUB_REF_NAME:-'
+
+echo "== the tag input is validated before anything is built =="
+
+assert_matches 'the tag is matched against a version pattern' "$RELEASE" \
+    '\^v\[0-9\]\[0-9A-Za-z\.-\]\*\$'
+assert_matches 'the tag is verified to exist' "$RELEASE" \
+    'git rev-parse --verify'
+assert_matches 'build waits on the resolver' "$RELEASE" \
+    '^ +needs: resolve-tag$'
+
+echo "== inputs.tag never reaches a run: body =="
+
+# Interpolating an input into a script is the injection shape even when the
+# dispatcher already has write access. Every use must go through step env:.
+# The one legitimate occurrence is the env: assignment itself, and the two
+# workflow-level expressions (concurrency group, publish precedence), none of
+# which is inside a run body -- so the check is that no `run` line carries it.
+inline=$(grep -nE '\$\{\{ *inputs\.tag *\}\}' "$RELEASE" \
+         | grep -vE 'INPUT_TAG:|concurrency|group:' | head -n 5)
+if [[ -z "$inline" ]]; then
+    pass 'inputs.tag appears only in env: and the concurrency group'
+else
+    fail 'inputs.tag appears only in env: and the concurrency group' \
+        "$(printf '%s' "$inline" | tr '\n' ' ')"
+fi
+
+echo "== the write token is scoped to the job that writes =="
+
+# The workflow-level default, read from the line immediately after the
+# top-level `permissions:` key rather than from anywhere in the file -- a
+# `contents: read` nested under some job would otherwise satisfy a loose grep.
+default_perm=$(grep -A1 -E '^permissions:$' "$RELEASE" | tail -n 1)
+if [[ "$default_perm" =~ ^[[:space:]]+contents:[[:space:]]read$ ]]; then
+    pass 'release-tui.yml defaults to contents: read'
+else
+    fail 'release-tui.yml defaults to contents: read' "got: $default_perm"
+fi
+
+# contents: write must appear exactly once, and under the release job.
+write_count=$(grep -cE '^ +contents: write$' "$RELEASE")
+if [[ "$write_count" -eq 1 ]]; then
+    pass 'contents: write is declared exactly once'
+else
+    fail 'contents: write is declared exactly once' "found $write_count"
+fi
+
+echo "== the workflow serializes on the tag =="
+
+assert_matches 'release-tui.yml declares a concurrency group' "$RELEASE" \
+    '^ +group: release-tui-'
+
+echo "== ci.yml declares a read-only token =="
+
+assert_matches 'ci.yml declares workflow-level permissions' "$CI" \
+    '^permissions:$'
+assert_matches 'ci.yml grants only contents: read' "$CI" \
+    '^ +contents: read$'
+assert_absent 'ci.yml grants no write scope' "$CI" \
+    '^ +[a-z-]+: write$'
+
+echo
+echo "== Summary: PASS=$PASS FAIL=$FAIL =="
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Closes #352
Relates to #359

## What

`workflow_dispatch` published binaries built from the **dispatch branch** while naming the release after `inputs.tag`, so the tag stopped identifying the code it shipped.

Two halves of one file disagreed about how to read the tag:

| Step | Expression | Prefers |
|---|---|---|
| Publish | `inputs.tag \|\| github.ref_name` | the input |
| Build | `${GITHUB_REF_NAME:-${{ inputs.tag }}}` | the ref |

`GITHUB_REF_NAME` is always set in Actions, so the build step's fallback to the input was **unreachable**. And the build checkout had no `ref:` at all, so it took whichever branch the dispatch UI selected:

| Dispatch input | Tree built | `main.version` | Release tag |
|---|---|---|---|
| `tag: v2026.08.01`, branch `develop` | `develop` HEAD | `develop` | `v2026.08.01` |
| `tag: v2026.08.01`, branch `main` | `main` HEAD | `main` | `v2026.08.01` |

A `push: tags: v*` run was unaffected — there the checkout and `GITHUB_REF_NAME` both resolve to the tag.

## Why

The dispatch path was added on top of a tag-push-only workflow and only the publish side was updated. The input's own description already stated the contract the build side did not honour: *"Tag to release against (must already exist)"* — and nothing checked that it existed.

This matters more than a mislabeled artifact because consumers download `latest` unattended: `cmd_tui` calls `download_tui_release` with no prompt. `tui-release.sh` verifies a SHA256, but that checksum ships from the same release, so it proves transfer integrity, not origin.

## How

A `resolve-tag` job produces **one** value that the checkout, the `-ldflags` stamp and `tag_name` all read. Three expressions that happened to agree became one that cannot disagree.

It validates the tag against `^v[0-9][0-9A-Za-z.-]*$` and verifies it exists with `git rev-parse --verify`, in its own job — so a typo costs one job instead of five and can never reach an upload. `inputs.tag` reaches the script through step `env:` rather than being interpolated into the body; the dispatcher already holds write access so this crosses no new trust boundary, but it is the script-injection shape and the fix is one line.

Hardening in the same file:

- `permissions: contents: read` at workflow level, with `contents: write` declared **only** on `release`. Five build jobs were running with a write token they had no use for.
- A `concurrency` group keyed on the resolved tag, `cancel-in-progress: false`. A dispatch and a tag push for the same version now serialize instead of landing assets built from two different commits in one release. Cancelling is the wrong choice here: a run that has begun uploading leaves a partially populated release.
- `ci.yml` declares `permissions: contents: read`. It had no `permissions` block at any level, so `GITHUB_TOKEN` took the repository default, and no job in it writes.

### Verification

- `tests/test_workflow_contracts.sh` (new, 14 assertions, added to the `bash-tests` matrix) — `PASS=14 FAIL=0`.
  - **Red first**: against `origin/develop`'s workflows in a temp copy, `PASS=2 FAIL=12`, naming each missing shape and quoting `48: ref="${GITHUB_REF_NAME:-${{ inputs.tag }}}"`.
  - A release workflow cannot be unit-tested without dispatching it, and dispatching a release is not something a test can do — so the assertions are about the file: the shapes whose absence caused the defect.
  - The `contents: read` default is read from the line **immediately after** the top-level `permissions:` key, not from anywhere in the file, so a `contents: read` nested under some job cannot satisfy it.
- Both workflows parsed with `yaml.safe_load`: `release-tui.yml` yields jobs `[resolve-tag, build, release]`, workflow `permissions {'contents': 'read'}`, release-job `permissions {'contents': 'write'}`. `ci.yml` yields 11 jobs and `{'contents': 'read'}`. A YAML error in `release-tui.yml` would not have failed this PR's CI — a different workflow simply would not run — so it is checked here rather than discovered at the next release.
- An earlier revision of the contract test flagged the comment that *explains* the removed `${GITHUB_REF_NAME:-...}` form. It now excludes whole-line YAML comments; a value with a trailing comment is still checked.

### Not verified here

The end-to-end behaviour — dispatching with an existing tag and getting a binary that reports it — needs a real dispatch, and there are no tags in this repository yet (which is #359's subject). What this PR guarantees is the shape; the first real release will be the first execution.

## Where

- `.github/workflows/release-tui.yml` — new `resolve-tag` job, build checkout `ref:`, build `env:`, job-scoped `permissions`, `concurrency`
- `.github/workflows/ci.yml` — workflow-level `permissions`, new matrix entry
- `tests/test_workflow_contracts.sh` (new)

## Out of scope, from the issue

Build provenance (`actions/attest-build-provenance` plus `gh attestation verify` in `download_tui_release`) would close the origin gap that checksums cannot. It is a separate decision and not filed yet.
