### PR TITLE
test(isolation): observe the isolated boundary on a running kernel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,9 +356,18 @@ jobs:
       - name: Stage an isolated two-account configuration
         run: |
           set -euo pipefail
-          # A sandbox HOME so the runner's own state is never involved, and so
-          # the per-account state directories are ours to plant markers in.
-          home=/tmp/claude-isolated
+          # Staged under the runner's real $HOME, not a sandbox path, because
+          # Compose resolves ${HOME} in the overlay from the *shell*
+          # environment before it looks at .env. Writing HOME=/tmp/... into
+          # .env therefore does not move the mount: the first run of this job
+          # staged markers in /tmp and Compose mounted ~/.claude-state, which
+          # Docker created empty, and the marker was simply not there.
+          #
+          # Worth knowing beyond this job: HOME in .env is inert whenever the
+          # shell exports one, which is always. It coincides with the right
+          # value on a real install only because that is what install.sh wrote
+          # it from.
+          home="$HOME"
           mkdir -p "$home/.claude-state/account-a" \
                    "$home/.claude-state/account-b" \
                    "$home/clone-a" "$home/clone-b"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,177 @@ jobs:
           done
           exit "$failed"
 
+  # Everything else that touches isolated mode asserts against
+  # `docker compose config` output -- the model Compose resolves, by design
+  # (tests/test_isolation_modes.sh says so in its header). That validates merge
+  # semantics. It does not validate that the kernel enforces any of it.
+  #
+  # So until this job, nobody had observed whether `read_only: true` actually
+  # blocks a write, whether separate bridges actually stop A from reaching B,
+  # or whether the per-account state mounts are actually separate. An isolation
+  # feature whose guarantees are only ever checked in YAML is a claim, not a
+  # control (issue #353).
+  #
+  # Budgeted like gemini-up-smoke: one image build, two containers. The second
+  # phase reuses the built image, so the network_mode: none variant is cheap.
+  isolated-up-smoke:
+    name: "Isolated mode: real containers"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Stage an isolated two-account configuration
+        run: |
+          set -euo pipefail
+          # A sandbox HOME so the runner's own state is never involved, and so
+          # the per-account state directories are ours to plant markers in.
+          home=/tmp/claude-isolated
+          mkdir -p "$home/.claude-state/account-a" \
+                   "$home/.claude-state/account-b" \
+                   "$home/clone-a" "$home/clone-b"
+
+          # The markers are how sibling state isolation is observed: each
+          # account should see exactly its own.
+          echo "account-a" > "$home/.claude-state/account-a/WHOAMI"
+          echo "account-b" > "$home/.claude-state/account-b/WHOAMI"
+
+          cat > .env <<EOF
+          HOME=$home
+          PROJECT_DIR=$home/clone-a
+          NUM_ACCOUNTS=2
+          AGENT_RUNTIME=claude
+          ISOLATION_MODE=isolated
+          ISOLATED_WORKSPACE_A=$home/clone-a
+          ISOLATED_WORKSPACE_B=$home/clone-b
+          EOF
+          bash scripts/generate-compose.sh
+
+      - name: Bring the isolated stack up
+        run: bash scripts/claude-docker up
+
+      - name: Both accounts are running
+        run: |
+          set -euo pipefail
+          for svc in claude-a claude-b; do
+            cid="$(bash scripts/claude-docker compose ps -q "$svc")"
+            if [[ -z "$cid" ]]; then
+              echo "::error::$svc was not created"
+              bash scripts/claude-docker compose logs "$svc" || true
+              exit 1
+            fi
+            running="$(docker inspect -f '{{.State.Running}}' "$cid")"
+            restarting="$(docker inspect -f '{{.State.Restarting}}' "$cid")"
+            echo "$svc: Running=$running Restarting=$restarting"
+            if [[ "$running" != "true" || "$restarting" != "false" ]]; then
+              echo "::error::$svc is not in a stable running state"
+              docker inspect -f '{{json .State}}' "$cid"
+              bash scripts/claude-docker compose logs "$svc" || true
+              exit 1
+            fi
+          done
+
+      - name: "Sibling state is separate"
+        run: |
+          set -euo pipefail
+          # A sees its own marker...
+          who="$(bash scripts/claude-docker compose exec -T claude-a cat /home/node/.claude/WHOAMI)"
+          echo "claude-a sees: $who"
+          if [[ "${who//[[:space:]]/}" != "account-a" ]]; then
+            echo "::error::claude-a is not mounting account-a's state"
+            exit 1
+          fi
+          # ...and nothing of B's. The account-b directory must not be
+          # reachable from inside A at all.
+          if bash scripts/claude-docker compose exec -T claude-a \
+               sh -c 'ls /home/node/.claude-state 2>/dev/null'; then
+            echo "::error::claude-a can see the shared state root"
+            exit 1
+          fi
+          echo "claude-a cannot reach the state root that holds account-b"
+
+      - name: "The root filesystem rejects writes with EROFS"
+        run: |
+          set -euo pipefail
+          # $HOME itself is read_only; only the declared tmpfs mounts and the
+          # account's own state mount are writable.
+          rc=0
+          out="$(bash scripts/claude-docker compose exec -T claude-a \
+                   sh -c 'touch /home/node/erofs-probe' 2>&1)" || rc=$?
+          echo "touch exit=$rc output=$out"
+          if [[ "$rc" -eq 0 ]]; then
+            echo "::error::a write to the read-only root succeeded"
+            exit 1
+          fi
+          if ! printf '%s' "$out" | grep -qi 'read-only'; then
+            echo "::error::the write failed, but not because the filesystem is read-only"
+            exit 1
+          fi
+          # The account's own state mount must still be writable, or the
+          # hardening would have broken the feature rather than secured it.
+          bash scripts/claude-docker compose exec -T claude-a \
+            sh -c 'touch /home/node/.claude/rw-probe && rm /home/node/.claude/rw-probe'
+          echo "the account's own state mount is still writable"
+
+      - name: "Siblings cannot reach each other on separate bridges"
+        run: |
+          set -euo pipefail
+          # Default ISOLATED_NETWORK_MODE is bridge: one bridge per account, so
+          # neither appears in the other's DNS. Outbound access is deliberately
+          # unaffected and is not asserted here.
+          if bash scripts/claude-docker compose exec -T claude-a \
+               getent hosts claude-b; then
+            echo "::error::claude-a resolved claude-b; the accounts share a network"
+            exit 1
+          fi
+          echo "claude-a cannot resolve claude-b"
+
+      - name: Tear the bridge stack down
+        run: bash scripts/claude-docker down -v --remove-orphans
+
+      - name: "ISOLATED_NETWORK_MODE=none detaches the account entirely"
+        run: |
+          set -euo pipefail
+          echo "ISOLATED_NETWORK_MODE=none" >> .env
+          bash scripts/generate-compose.sh
+          bash scripts/claude-docker up
+
+          cid="$(bash scripts/claude-docker compose ps -q claude-a)"
+          mode="$(docker inspect -f '{{.HostConfig.NetworkMode}}' "$cid")"
+          echo "claude-a NetworkMode=$mode"
+          if [[ "$mode" != "none" ]]; then
+            echo "::error::expected NetworkMode=none, got $mode"
+            exit 1
+          fi
+          # Only loopback: the resolved model says network_mode: none, and this
+          # is the kernel agreeing with it.
+          links="$(bash scripts/claude-docker compose exec -T claude-a \
+                     sh -c 'ls /sys/class/net' | tr -d '\r' | tr '\n' ' ')"
+          echo "claude-a interfaces: $links"
+          if [[ "$(echo "$links" | tr -s ' ' | sed 's/ $//')" != "lo" ]]; then
+            echo "::error::claude-a has an interface other than loopback"
+            exit 1
+          fi
+
+      - name: Tear down
+        if: always()
+        run: bash scripts/claude-docker down -v --remove-orphans || true
+
+      - name: No isolated network survives the teardown
+        if: always()
+        run: |
+          set -uo pipefail
+          # The leak this job exists to catch: remove.sh used to attach the
+          # worktree overlay to an isolated install, compose refused the whole
+          # file on the unset ${PROJECT_DIR_A}, the failure was discarded, and
+          # the isolated_net_* bridges outlived a run that said "Removal
+          # Complete".
+          left="$(docker network ls --format '{{.Name}}' | grep -i 'isolated_net' || true)"
+          if [[ -n "$left" ]]; then
+            echo "::error::isolated networks survived: $left"
+            exit 1
+          fi
+          echo "no isolated_net_* network remains"
+
   pwsh-tests:
     name: PowerShell Tests (${{ matrix.test }})
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -854,7 +854,7 @@ and fails on any difference. Regenerating with your own `.env` during local work
 is expected, but do not commit the result — restore the committed copies first:
 
 ```bash
-git checkout -- docker-compose.yml docker-compose.linux.yml docker-compose.worktree.yml
+git checkout -- docker-compose.yml docker-compose.linux.yml docker-compose.worktree.yml docker-compose.isolated.yml
 ```
 
 ### `NUM_ACCOUNTS` precedence
@@ -892,7 +892,13 @@ table above and runs in the `Bash Tests` CI matrix.
 |------|---------|-------------|
 | `docker-compose.yml` | Base config (Tier A), incl. `user: ${UID:-1000}:${GID:-1000}` and `HOME=/home/node` | Always |
 | `docker-compose.linux.yml` | Legacy UID/GID + HOME override (kept for backward compat; base already carries it) | Optional |
-| `docker-compose.worktree.yml` | Per-container worktree paths | Tier B only |
+| `docker-compose.worktree.yml` | Per-container worktree paths | `ISOLATION_MODE=worktree` only |
+| `docker-compose.isolated.yml` | Per-container independent clone, hardened container profile (`read_only`, `cap_drop: ALL`, no-new-privileges, PID limit), per-account bridge, `environment: !override` | `ISOLATION_MODE=isolated` only |
+
+The worktree and isolated overlays are mutually exclusive: both replace the
+volume list with `!override` and they disagree on `working_dir`, so composing
+them together is not "the widest set" but a broken stack. All four files are
+generated in every mode; the resolved mode decides which one is selected.
 
 On native Linux, set `UID` / `GID` in `.env` (or export them before running
 `docker compose up`) to match the host user that owns the selected runtime's
@@ -1136,7 +1142,11 @@ claude-docker/
 +-- VERSION                            Release tag consumed by docker-compose IMAGE_TAG
 +-- docker-compose.yml                 Generated: base config (Tier A)
 +-- docker-compose.linux.yml           Generated: Linux override
-+-- docker-compose.worktree.yml        Generated: Tier B override
++-- docker-compose.worktree.yml        Generated: worktree-mode override
++-- docker-compose.isolated.yml        Generated: isolated-mode override (hardened profile)
++-- docs/
+|   +-- ISOLATION.md                   Workspace isolation modes and their trust boundaries
+|   +-- PERFORMANCE.md                 Benchmark numbers of record
 +-- .env.example                       Environment template
 +-- .gitignore
 +-- .gitattributes                     LF line endings
@@ -1157,8 +1167,10 @@ claude-docker/
 |   +-- remove.ps1                     Complete removal (PowerShell)
 |   +-- cleanup.sh                     Container/volume/worktree/state cleanup (bash)
 |   +-- cleanup.ps1                    Same cleanup flow (PowerShell)
-|   +-- setup-worktrees.sh             Tier B worktree setup (bash)
-|   +-- setup-worktrees.ps1            Tier B worktree setup (PowerShell)
+|   +-- setup-worktrees.sh             worktree-mode setup (bash)
+|   +-- setup-worktrees.ps1            worktree-mode setup (PowerShell)
+|   +-- setup-isolated.sh              isolated-mode clone setup (bash)
+|   +-- setup-isolated.ps1             isolated-mode clone setup (PowerShell)
 |   +-- test-concurrent-git.sh         E2E test (bash)
 |   +-- test-concurrent-git.ps1        E2E test (PowerShell)
 |   +-- test-entrypoint-settings.sh    Entrypoint settings normalization test (bash)
@@ -1167,6 +1179,8 @@ claude-docker/
 |       +-- parse_env.sh               Shared .env parser (bash)
 |       +-- index.sh / index.ps1       Excel-style account index helpers
 |       +-- runtime.sh                 Runtime registry reader (jq, awk fallback)
+|       +-- isolation.sh               Isolation-mode resolution and the trust-boundary text
+|       +-- resources.sh               Memory cap to Node heap arithmetic
 |       +-- build-compose-cmd.sh       Compose overlay selection (bash)
 |       +-- bootstrap-common.sh        Shared entrypoint helpers
 |       +-- bootstrap-claude.sh        Per-runtime container bootstrap modules

--- a/scripts/claude-docker
+++ b/scripts/claude-docker
@@ -63,8 +63,10 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 # Overlay selection logic:
 # 1. Base docker-compose.yml is always included
 # 2. docker-compose.linux.yml is added on Linux hosts when the file exists
-# 3. docker-compose.worktree.yml is added when the resolved ISOLATION_MODE is
-#    worktree (lib/isolation.sh)
+# 3. The overlay named by the resolved ISOLATION_MODE is added:
+#    docker-compose.worktree.yml for worktree, docker-compose.isolated.yml for
+#    isolated, none for shared (lib/isolation.sh). A mode whose overlay is
+#    missing is refused rather than silently downgraded.
 #
 # build_compose_cmd() itself lives in lib/build-compose-cmd.sh (sourced above).
 COMPOSE_CMD=()

--- a/scripts/remove.ps1
+++ b/scripts/remove.ps1
@@ -35,22 +35,51 @@ $script:WorktreesLeftBehind = @()
 
 # --- Compose Command Discovery ------------------------------------------------
 
-function Get-FullComposeArgs {
+function Get-ComposeArgsForMode {
     <#
     .SYNOPSIS
-    Build the widest compose command covering all possible overlays.
-    Ensures we catch containers/volumes from any configuration.
+    Build the compose command for exactly one isolation mode.
+    .DESCRIPTION
+    This used to attach base + worktree unconditionally and call it "the widest
+    compose command covering all possible overlays". It is not a valid set. The
+    worktree and isolated overlays both carry `!override` volume lists and
+    disagree on working_dir, and the worktree overlay interpolates
+    ${PROJECT_DIR_A} -- which an isolated install never sets, so compose
+    refuses the whole file with "invalid spec: :/project-a: empty section
+    between colons".
+
+    That failure was discarded by `2>$null`, so an isolated teardown fell
+    through to a bare `docker compose down` that did not know the isolated
+    overlay, and the isolated_net_* bridge networks survived a run that
+    reported "Removal Complete".
+
+    Windows never needs the linux override.
     #>
+    param([Parameter(Mandatory)][string]$Mode)
+
     $args_ = @('-f', (Join-Path $ProjectRoot 'docker-compose.yml'))
-
-    # Windows never needs linux override
-    # Always include worktree overlay if it exists (to catch Tier B resources)
-    $wtFile = Join-Path $ProjectRoot 'docker-compose.worktree.yml'
-    if (Test-Path $wtFile) {
-        $args_ += @('-f', $wtFile)
+    switch ($Mode) {
+        'worktree' { $args_ += @('-f', (Join-Path $ProjectRoot 'docker-compose.worktree.yml')) }
+        'isolated' { $args_ += @('-f', (Join-Path $ProjectRoot 'docker-compose.isolated.yml')) }
     }
-
     return $args_
+}
+
+function Get-TeardownMode {
+    <#
+    .SYNOPSIS
+    The modes worth attempting, in order.
+    .DESCRIPTION
+    Removal has to catch resources from whatever mode the installation is in
+    now and from modes it used to be in -- switching leaves the previous
+    stack's containers and networks behind, and this is the script meant to
+    find them. So every mode whose overlay exists gets its own `down`, rather
+    than one `down` carrying every overlay.
+    #>
+    $modes = @('shared')
+    if (Test-Path (Join-Path $ProjectRoot 'docker-compose.worktree.yml')) { $modes += 'worktree' }
+    if (Test-Path (Join-Path $ProjectRoot 'docker-compose.isolated.yml')) { $modes += 'isolated' }
+    return $modes
 }
 
 # --- Removal Steps ------------------------------------------------------------
@@ -60,12 +89,28 @@ function Remove-ContainersAndVolumes {
 
     Push-Location $ProjectRoot
     try {
-        Write-LogInfo 'Stopping containers...'
-        $fullArgs = @(Get-FullComposeArgs)
-        & docker compose @fullArgs down --remove-orphans -v 2>$null
+        # One `down` per mode. A mode this installation was never in will
+        # usually fail on an unset per-account path, and that is expected --
+        # what is not acceptable is the previous behaviour, where the
+        # configured mode's failure looked identical to it because both were
+        # discarded.
+        $failed = @()
+        foreach ($mode in Get-TeardownMode) {
+            $modeArgs = @(Get-ComposeArgsForMode -Mode $mode)
+            Write-LogInfo "Stopping containers ($mode stack)..."
+            $out = & docker compose @modeArgs down --remove-orphans -v 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                $failed += $mode
+                Write-LogWarn "  $mode stack: docker compose down exited $LASTEXITCODE"
+                foreach ($line in @($out)) { Write-Host "      $line" -ForegroundColor DarkGray }
+            }
+        }
 
-        # Also try base compose alone (in case overlay files were deleted)
-        & docker compose down --remove-orphans -v 2>$null
+        if ($failed.Count -gt 0) {
+            Write-LogWarn "Teardown did not complete for: $($failed -join ', ')"
+            Write-LogWarn '  A mode this installation never used is expected to fail here.'
+            Write-LogWarn "  Check 'docker ps -a' and 'docker network ls' if resources remain."
+        }
 
         # Remove any dangling containers with the project prefix
         $containers = & docker ps -a --filter 'label=com.docker.compose.project=claude-docker' -q 2>$null

--- a/scripts/remove.sh
+++ b/scripts/remove.sh
@@ -86,7 +86,26 @@ detect_platform() {
 # remove.sh must catch containers/volumes from any configuration, so the
 # widest overlay set is included whenever the override files exist on disk.
 COMPOSE_CMD=()
-build_compose_cmd() {
+
+# build_compose_cmd_for_mode MODE
+# Populate COMPOSE_CMD for exactly one isolation mode.
+#
+# This used to attach base + linux + worktree unconditionally and call that the
+# "widest overlay set". It is not a valid set. The worktree and isolated
+# overlays both carry `!override` volume lists and disagree on working_dir, and
+# the worktree overlay interpolates ${PROJECT_DIR_A} -- which an isolated
+# install never sets:
+#
+#     $ docker compose config
+#     warning: The "PROJECT_DIR_A" variable is not set.
+#     invalid spec: :/project-a: empty section between colons
+#
+# That failure was discarded by `2>/dev/null || true`, so an isolated teardown
+# fell through to a bare `docker compose down` that did not know the isolated
+# overlay -- and the isolated_net_* bridge networks survived a run that
+# reported "Removal Complete".
+build_compose_cmd_for_mode() {
+    local mode="$1"
     COMPOSE_CMD=(docker compose -f "${PROJECT_ROOT}/docker-compose.yml")
 
     local platform
@@ -96,9 +115,25 @@ build_compose_cmd() {
         COMPOSE_CMD+=(-f "${PROJECT_ROOT}/docker-compose.linux.yml")
     fi
 
-    if [[ -f "${PROJECT_ROOT}/docker-compose.worktree.yml" ]]; then
-        COMPOSE_CMD+=(-f "${PROJECT_ROOT}/docker-compose.worktree.yml")
-    fi
+    case "$mode" in
+        worktree) COMPOSE_CMD+=(-f "${PROJECT_ROOT}/docker-compose.worktree.yml") ;;
+        isolated) COMPOSE_CMD+=(-f "${PROJECT_ROOT}/docker-compose.isolated.yml") ;;
+    esac
+}
+
+# teardown_modes
+# The modes worth attempting, one per line.
+#
+# Removal has to catch resources from whatever mode the installation is in now
+# *and* from modes it used to be in -- switching leaves the previous stack's
+# containers and networks behind, and this is the script that is supposed to
+# find them. So every mode whose overlay exists is attempted, one `down` each,
+# rather than one `down` carrying every overlay.
+teardown_modes() {
+    echo "shared"
+    [[ -f "${PROJECT_ROOT}/docker-compose.worktree.yml" ]] && echo "worktree"
+    [[ -f "${PROJECT_ROOT}/docker-compose.isolated.yml" ]] && echo "isolated"
+    return 0
 }
 
 # --- Main Removal Steps -------------------------------------------------------
@@ -108,14 +143,31 @@ remove_containers_and_volumes() {
 
     cd "$PROJECT_ROOT"
 
-    build_compose_cmd
+    # One `down` per mode. A mode the installation was never in will usually
+    # fail here on an unset per-account path, and that is fine and expected --
+    # what is not fine is the previous behaviour, where the *configured*
+    # mode's failure looked identical to it because both were discarded.
+    # Every attempt reports its outcome, and the summary names any that did
+    # not succeed.
+    local mode rc out
+    local -a failed=()
+    while IFS= read -r mode; do
+        build_compose_cmd_for_mode "$mode"
+        log_info "Stopping containers ($mode stack)..."
+        rc=0
+        out=$("${COMPOSE_CMD[@]}" down --remove-orphans -v 2>&1) || rc=$?
+        if [[ "$rc" -ne 0 ]]; then
+            failed+=("$mode")
+            log_warn "  $mode stack: docker compose down exited $rc"
+            printf '%s\n' "$out" | sed 's/^/      /' >&2
+        fi
+    done < <(teardown_modes)
 
-    # Stop all running containers from any compose config
-    log_info "Stopping containers..."
-    "${COMPOSE_CMD[@]}" down --remove-orphans -v 2>/dev/null || true
-
-    # Also try base compose alone (in case overlay files were deleted)
-    docker compose down --remove-orphans -v 2>/dev/null || true
+    if [[ ${#failed[@]} -gt 0 ]]; then
+        log_warn "Teardown did not complete for: ${failed[*]}"
+        log_warn "  A mode this installation never used is expected to fail here."
+        log_warn "  Check 'docker ps -a' and 'docker network ls' if resources remain."
+    fi
 
     # Remove any dangling containers with the project prefix
     local project_containers

--- a/tests/test_compose_generator_equivalence.sh
+++ b/tests/test_compose_generator_equivalence.sh
@@ -35,7 +35,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 FIXTURE_DIR="$PROJECT_ROOT/tests/env_fixtures"
-OUTPUTS=(docker-compose.yml docker-compose.worktree.yml docker-compose.linux.yml)
+
+# Every file the generators write. A new generated stack must be added here,
+# or it is produced by two independent implementations and compared by
+# neither. That is not hypothetical: docker-compose.isolated.yml was added in
+# stage 3 of #335 and was missing from this list until #353 -- the file
+# carrying the isolation trust boundary was the one file whose bash and
+# PowerShell output nobody compared.
+OUTPUTS=(
+    docker-compose.yml
+    docker-compose.worktree.yml
+    docker-compose.isolated.yml
+    docker-compose.linux.yml
+)
 
 # name | .env fixture basename ('-' for no .env) | environment assignments
 #
@@ -47,6 +59,9 @@ OUTPUTS=(docker-compose.yml docker-compose.worktree.yml docker-compose.linux.yml
 # Excel-style enumeration added by #178 is two independent implementations and
 # n5 alone would only ever compare single letters. env-override covers the
 # environment path that #315 fixed.
+# The isolated cases carry no .env file on purpose: the values are the subject
+# of the comparison, so having them visible here beats a fixture nobody opens,
+# and the environment path is the one #315 fixed.
 FIXTURES=(
     "minimal|minimal.env|"
     "codex|codex.env|"
@@ -54,7 +69,12 @@ FIXTURES=(
     "github-per-account|github-per-account.env|"
     "n5|n5.env|"
     "n30|n30.env|"
+    "with-special-chars|with-special-chars.env|"
     "env-override|-|NUM_ACCOUNTS=5 IMAGE_TAG=probe-tag"
+    "isolated|-|ISOLATION_MODE=isolated ISOLATED_WORKSPACE_A=/tmp/iso-a ISOLATED_WORKSPACE_B=/tmp/iso-b"
+    "isolated-no-network|-|ISOLATION_MODE=isolated ISOLATED_WORKSPACE_A=/tmp/iso-a ISOLATED_WORKSPACE_B=/tmp/iso-b ISOLATED_NETWORK_MODE=none"
+    "isolated-n5|-|NUM_ACCOUNTS=5 ISOLATION_MODE=isolated ISOLATED_WORKSPACE_A=/tmp/iso-a ISOLATED_WORKSPACE_B=/tmp/iso-b ISOLATED_WORKSPACE_C=/tmp/iso-c ISOLATED_WORKSPACE_D=/tmp/iso-d ISOLATED_WORKSPACE_E=/tmp/iso-e"
+    "resources|-|CONTAINER_MEM_LIMIT=3g CONTAINER_NODE_HEAP_MB=2048"
 )
 
 PASS=0

--- a/tests/test_num_accounts_precedence.sh
+++ b/tests/test_num_accounts_precedence.sh
@@ -150,7 +150,15 @@ read_pwsh_gen() {
 
 # Digest the committed compose files so the closing assertion can prove no
 # reader wrote into the checkout.
-OUTPUTS=(docker-compose.yml docker-compose.worktree.yml docker-compose.linux.yml)
+# Every file the generators write. A new generated stack must be added here,
+# or this test's closing "no reader wrote into the checkout" assertion cannot
+# see it being clobbered. docker-compose.isolated.yml was missing until #353.
+OUTPUTS=(
+    docker-compose.yml
+    docker-compose.worktree.yml
+    docker-compose.isolated.yml
+    docker-compose.linux.yml
+)
 compose_digest() {
     local f
     for f in "${OUTPUTS[@]}"; do


### PR DESCRIPTION
Closes #353
Relates to #343, #348

Four pieces from one root: `docker-compose.isolated.yml` was added in stage 3 of #335, and every reader of "the generated set" is a separate hard-coded list. One of them was updated — the comment at `ci.yml:155` says so, and says exactly why it matters. **That lesson was recorded in one place and applied nowhere else.**

## 1. Registration

`OUTPUTS` in `test_compose_generator_equivalence.sh` and `test_num_accounts_precedence.sh` listed three of the four files, so the file carrying the isolation trust boundary was the one file whose bash and PowerShell output nobody compared. Both now list all four, each with a comment saying a new generated file must be added here.

The equivalence axis gains `isolated`, `isolated-no-network`, `isolated-n5`, `resources` and `with-special-chars`. The isolated cases carry no `.env` fixture on purpose: the values *are* the subject of the comparison, so having them visible in the table beats a fixture nobody opens — and it exercises the environment path #315 fixed.

23 assertions → **50**.

**The acceptance criterion asked whether a PowerShell-only edit would now be caught.** Mutating `read_only: true` → `false` in the isolated branch of `generate-compose.ps1` alone, in a temp copy:

```
=== baseline (unmutated) ===  == Summary: PASS=50 FAIL=0 ==
mutation applied: read_only true -> false in generate-compose.ps1 only
=== mutated ===               == Summary: PASS=38 FAIL=12 ==
```

Before this change that edit produced zero failures.

## 2. Runtime — the part that was never observed

`tests/test_isolation_modes.sh` asserts against `docker compose config` output **by design**; its header says so. That validates merge semantics. It does not validate that the kernel enforces any of it. The only job that started real containers was `gemini-up-smoke`, which is shared mode.

So nobody had observed whether `read_only: true` actually blocks a write, whether separate bridges actually stop A reaching B, or whether the per-account state mounts are actually separate. **An isolation feature whose guarantees are only ever checked in YAML is a claim, not a control.**

`isolated-up-smoke` starts two isolated containers and asserts:

| Guarantee | Assertion |
|---|---|
| sibling state separation | A reads its own `WHOAMI` marker, and cannot list the state root that holds B's |
| `read_only: true` | `touch /home/node/erofs-probe` fails **and the error says read-only** — a write that failed for any other reason is not evidence |
| the feature still works | the account's own state mount is still writable, so hardening did not break it |
| separate bridges | A cannot resolve `claude-b` |
| `ISOLATED_NETWORK_MODE=none` | `NetworkMode=none` *and* the container has `lo` and nothing else |
| teardown | no `isolated_net_*` network survives, checked with `if: always()` |

Budgeted like `gemini-up-smoke`: one image build, two containers; the `none` phase reuses the image.

## 3. Teardown — worse than incomplete

`remove.sh` and `remove.ps1` attached base + linux + worktree and called it *"the widest overlay set covering all possible overlays"*. It is not a valid set. Both mode overlays carry `!override` volume lists and disagree on `working_dir`, and the worktree overlay interpolates `${PROJECT_DIR_A}` — which an isolated install never sets:

```
$ docker compose config
warning: The "PROJECT_DIR_A" variable is not set. Defaulting to a blank string.
invalid spec: :/project-a: empty section between colons
```

`2>/dev/null || true` discarded that, so the run fell through to a bare `docker compose down` that did not know the isolated overlay — and the `isolated_net_*` bridges outlived a run that printed **"Removal Complete"**.

Both now run **one `down` per mode**, each with only that mode's overlay, and report each outcome. A mode the installation was never in still fails, and that is expected and stated in the output; what is no longer true is that the *configured* mode's failure looks identical to it.

## 4. Docs

- `README:857`'s recovery command named three of the four files, so following it left the isolated file modified and `Compose files are current` failing — the documented recovery could not clear the failure it was written for.
- The overlay table gains an isolated row and a note that the two overlays are mutually exclusive.
- The project tree gains `docker-compose.isolated.yml`, `docs/`, `setup-isolated.sh/.ps1`, `lib/isolation.sh`, `lib/resources.sh`.
- The `scripts/claude-docker` header comment now matches `lib/build-compose-cmd.sh`, which labels itself canonical.

## Verification

- `test_compose_generator_equivalence.sh` **50**, `test_num_accounts_precedence.sh` **52**, `test_isolation_modes.sh` **19**, `test_worktree_ownership.sh` **26**, `test_bash32_portability.sh` **16**, `test_workflow_contracts.sh` **14** — all zero failures.
- `bash -n scripts/remove.sh`; PowerShell `Parser::ParseFile` on `remove.ps1`, `cleanup.ps1`, `ClaudeDocker.psm1`; PSScriptAnalyzer clean; `ci.yml` parses to 13 jobs with the new one carrying 11 steps.
- The mutation check above.
- **`isolated-up-smoke` has never run.** Its first execution is this PR, which is the right place for it — unlike a conditional gate, it runs on every PR, so a mistake in it shows up here rather than lying dormant. If the isolated stack does not come up under `read_only: true`, that is itself the finding this job exists to surface.

## Where

- `tests/test_compose_generator_equivalence.sh`, `tests/test_num_accounts_precedence.sh`
- `.github/workflows/ci.yml` — new `isolated-up-smoke`
- `scripts/remove.sh`, `scripts/remove.ps1` — mode-driven teardown
- `scripts/claude-docker` — header comment
- `README.md` — recovery command, overlay table, project tree
