### PR TITLE
fix(powershell): report what docker actually did

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,6 +273,7 @@ jobs:
           - tests/test_worktree_ownership.sh
           - tests/test_install_start_containers.sh
           - tests/test_install_tier_b.sh
+          - tests/test_scale_prevalidation.sh
           - tests/test_bash32_portability.sh
           - tests/test_workflow_contracts.sh
           - scripts/test-entrypoint-settings.sh
@@ -528,6 +529,7 @@ jobs:
           - tests/test_worktree_path_guard.ps1
           - tests/test_cleanup_gate.ps1
           - tests/test_powershell_version_floor.ps1
+          - tests/test_powershell_exit_codes.ps1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run ${{ matrix.test }}

--- a/scripts/claude-docker
+++ b/scripts/claude-docker
@@ -834,6 +834,27 @@ cmd_scale() {
         exit 1
     fi
 
+    # Validate the new count against the isolation contract BEFORE touching
+    # .env. The generator is deliberately fail-closed so a failure "cannot
+    # leave a partially regenerated set behind" -- but the caller had already
+    # moved. On a worktree install holding only PROJECT_DIR_A/B, `scale 4`
+    # wrote NUM_ACCOUNTS=4, created account-c and account-d, and then died on
+    # "PROJECT_DIR_C is required when ISOLATION_MODE=worktree", leaving .env
+    # saying 4 and the compose files saying 2.
+    #
+    # Nothing downstream catches that split: `up` resolves the mode with the
+    # default account count of 1, so it passes and starts two containers,
+    # while get_service_names, the TUI and the help text all read
+    # NUM_ACCOUNTS and report four.
+    #
+    # Run in a subshell with the new count exported, so a rejection leaves
+    # nothing behind at all -- not even an exported variable.
+    if ! ( NUM_ACCOUNTS="$new_count" require_supported_isolation_mode "$new_count" >/dev/null ); then
+        log_error "Cannot scale to $new_count account(s); see the error above."
+        log_info "NUM_ACCOUNTS is unchanged at $current_count."
+        exit 1
+    fi
+
     if grep -q '^NUM_ACCOUNTS=' "$env_file" 2>/dev/null; then
         perl -i -pe "s/^NUM_ACCOUNTS=.*/NUM_ACCOUNTS=$new_count/" "$env_file"
     else

--- a/scripts/claude-docker.ps1
+++ b/scripts/claude-docker.ps1
@@ -40,6 +40,46 @@ Import-Module "$PSScriptRoot\ClaudeDocker.psm1" -Force
 
 $ProjectRoot = Split-Path $PSScriptRoot -Parent
 
+# --- Exit Code Propagation ----------------------------------------------------
+
+# What this script will exit with. The dispatch switch is the last statement in
+# the file, so every branch used to fall off the end with rc=0 no matter what
+# docker did.
+#
+# $ErrorActionPreference = 'Stop' does not cover this: a native command's
+# non-zero exit is not a PowerShell error.
+#
+#   pwsh -NoProfile -Command "$ErrorActionPreference='Stop'; & cmd /c exit 7; 'reached'"
+#   reached      <- and the caller sees rc=0
+#
+# The bash wrapper gets this from `set -euo pipefail`, which is why cmd_up can
+# print "Containers started." unguarded and still be correct. The PowerShell
+# port copied the structure without the guarantee underneath it.
+$script:ExitCode = 0
+
+function Test-ComposeSucceeded {
+    <#
+    .SYNOPSIS
+    Record docker's exit code and report whether it succeeded.
+    .DESCRIPTION
+    Called immediately after an Invoke-Compose. $LASTEXITCODE is an automatic
+    *global*, so the native command inside the module sets the same variable
+    this reads -- no plumbing needed, only the reading that was missing.
+
+    Returns $true on success so callers can gate their success message on it,
+    which is the other half of the defect: "Containers started." printed after
+    a missing image or an unresolvable bind source.
+    #>
+    param([Parameter(Mandatory)][string]$What)
+
+    if ($LASTEXITCODE -ne 0) {
+        $script:ExitCode = $LASTEXITCODE
+        Write-LogError "$What failed (docker exited $LASTEXITCODE)."
+        return $false
+    }
+    return $true
+}
+
 # --- Account Directory Helpers -----------------------------------------------
 
 function Get-GhAuthMode {
@@ -143,9 +183,11 @@ function Invoke-Up {
     Write-Host ''
     Write-Host 'Starting containers...' -ForegroundColor Cyan
     Invoke-Compose -ProjectRoot $ProjectRoot up --detach @Arguments
+    if (-not (Test-ComposeSucceeded 'up')) { return }
     Write-Host 'Containers started.' -ForegroundColor Green
     Write-Host ''
     Invoke-Compose -ProjectRoot $ProjectRoot ps
+    $null = Test-ComposeSucceeded 'ps'
 
     # Lightweight post-start GitHub auth check (non-blocking)
     Write-Host ''
@@ -160,21 +202,25 @@ function Invoke-Up {
 function Invoke-Down {
     Write-Host 'Stopping containers...' -ForegroundColor Cyan
     Invoke-Compose -ProjectRoot $ProjectRoot down @Arguments
+    if (-not (Test-ComposeSucceeded 'down')) { return }
     Write-Host 'Containers stopped.' -ForegroundColor Green
 }
 
 function Invoke-Restart {
     Write-Host 'Restarting containers...' -ForegroundColor Cyan
     Invoke-Compose -ProjectRoot $ProjectRoot restart @Arguments
+    if (-not (Test-ComposeSucceeded 'restart')) { return }
     Write-Host 'Containers restarted.' -ForegroundColor Green
 }
 
 function Invoke-Logs {
     Invoke-Compose -ProjectRoot $ProjectRoot logs -f @Arguments
+    $null = Test-ComposeSucceeded 'logs'
 }
 
 function Invoke-Ps {
     Invoke-Compose -ProjectRoot $ProjectRoot ps @Arguments
+    $null = Test-ComposeSucceeded 'ps'
 }
 
 function Invoke-Exec {
@@ -187,6 +233,9 @@ function Invoke-Exec {
     $rest = if ($Arguments.Count -gt 1) { $Arguments[1..($Arguments.Count - 1)] } else { @('bash') }
 
     Invoke-Compose -ProjectRoot $ProjectRoot exec $service @rest
+    # exec's exit code is the command's, and a caller scripting around this
+    # wrapper needs it.
+    $null = Test-ComposeSucceeded 'exec'
 }
 
 function Invoke-Agent {
@@ -251,6 +300,7 @@ function Invoke-Agent {
         $agentArgs += $skipFlag
     }
     Invoke-Compose -ProjectRoot $ProjectRoot exec $service @agentArgs
+    $null = Test-ComposeSucceeded "$label"
 }
 
 function Get-HostGhToken {
@@ -300,6 +350,10 @@ function Invoke-GhAuthShared {
     if ($running) {
         Write-Host 'Recreating containers to apply...' -ForegroundColor Cyan
         Invoke-Compose -ProjectRoot $ProjectRoot up --detach --force-recreate
+        # A failed recreate means the token was written to .env but no
+        # container picked it up. Verifying auth after that would report a
+        # stale answer, so stop here with the code recorded.
+        if (-not (Test-ComposeSucceeded 'up --force-recreate')) { return }
 
         Start-Sleep -Seconds 2
         $cid = Get-ContainerId -ProjectRoot $ProjectRoot -Service $primary
@@ -427,6 +481,9 @@ function Invoke-GhAuthPerAccount {
 
     Write-Host 'Recreating selected container(s) to apply...' -ForegroundColor Cyan
     Invoke-Compose -ProjectRoot $ProjectRoot up --detach --force-recreate @runningServices
+    # Same as the shared path: verifying auth against containers that were not
+    # recreated would report a stale answer.
+    if (-not (Test-ComposeSucceeded 'up --force-recreate')) { return }
     Start-Sleep -Seconds 2
     foreach ($service in $runningServices) {
         Test-ContainerGhAuth -Service $service | Out-Null
@@ -613,6 +670,7 @@ function Test-AllContainerGhAuth {
 function Invoke-Build {
     Write-Host 'Building Docker image...' -ForegroundColor Cyan
     Invoke-Compose -ProjectRoot $ProjectRoot build @Arguments
+    if (-not (Test-ComposeSucceeded 'build')) { return }
     Write-Host 'Build complete.' -ForegroundColor Green
 }
 
@@ -636,9 +694,13 @@ function Invoke-Update {
 
     Write-Host '[3/5] Rebuilding image (--no-cache)...' -ForegroundColor Cyan
     Invoke-Compose -ProjectRoot $ProjectRoot build --no-cache
+    # Recreating containers from an image that failed to build would replace a
+    # working stack with a broken one, so this stops rather than continuing.
+    if (-not (Test-ComposeSucceeded 'build --no-cache')) { return }
 
     Write-Host '[4/5] Recreating containers...' -ForegroundColor Cyan
     Invoke-Compose -ProjectRoot $ProjectRoot up --detach --force-recreate
+    if (-not (Test-ComposeSucceeded 'up --force-recreate')) { return }
 
     # Verify version and GitHub auth
     Write-Host '[5/5] Verifying...' -ForegroundColor Cyan
@@ -687,6 +749,27 @@ function Invoke-Scale {
         Write-LogError '.env not found. Run install.ps1 first.'
         exit 1
     }
+    # Validate the new count against the isolation contract BEFORE touching
+    # .env. The generators are deliberately fail-closed so a failure "cannot
+    # leave a partially regenerated set behind" -- but the caller had already
+    # moved. On a worktree install holding only PROJECT_DIR_A/B, `scale 4`
+    # wrote NUM_ACCOUNTS=4, created account-c and account-d, and then died on
+    # "PROJECT_DIR_C is required when ISOLATION_MODE=worktree", leaving .env
+    # saying 4 and the compose files saying 2.
+    #
+    # Nothing downstream catches that split: `up` resolves the mode with the
+    # default account count of 1, so it passes and starts two containers,
+    # while Get-ServiceNames, the TUI and the help text all read NUM_ACCOUNTS
+    # and report four.
+    try {
+        $null = Get-SupportedIsolationMode -ProjectRoot $ProjectRoot -AccountCount $newCount
+    }
+    catch {
+        Write-LogError "Cannot scale to $newCount account(s): $($_.Exception.Message)"
+        Write-LogInfo "NUM_ACCOUNTS is unchanged at $currentCount."
+        exit 1
+    }
+
     Set-EnvValue -Path $envFile -Key 'NUM_ACCOUNTS' -Value $newCount
 
     # Create state directories for new accounts
@@ -718,7 +801,9 @@ function Invoke-Scale {
     if ($running) {
         Write-Host 'Restarting containers...' -ForegroundColor Cyan
         Invoke-Compose -ProjectRoot $ProjectRoot down
+        $null = Test-ComposeSucceeded 'down'
         Invoke-Compose -ProjectRoot $ProjectRoot up --detach
+        if (-not (Test-ComposeSucceeded 'up')) { return }
     }
 
     Write-Host "Scaled to $newCount account(s)." -ForegroundColor Green
@@ -738,10 +823,13 @@ function Invoke-Config {
     Write-Host "Compose args: docker compose $($baseArgs -join ' ')" -ForegroundColor DarkGray
     Write-Host ''
     Invoke-Compose -ProjectRoot $ProjectRoot config @Arguments
+    $null = Test-ComposeSucceeded 'config'
 }
 
 function Invoke-ComposePass {
     Invoke-Compose -ProjectRoot $ProjectRoot @Arguments
+    # The raw pass-through: `compose --bogus-flag` must not exit 0.
+    $null = Test-ComposeSucceeded 'compose'
 }
 
 function Invoke-Usage {
@@ -941,7 +1029,8 @@ function Invoke-BuildTui {
 # here. Matched before the static switch.
 if ($Command -in (Get-RuntimeList -ProjectRoot $ProjectRoot)) {
     Invoke-Agent -Subcommand $Command
-    return
+    # `claude` / `codex` used to mask the agent's own exit code.
+    exit $script:ExitCode
 }
 
 switch ($Command) {
@@ -968,3 +1057,7 @@ switch ($Command) {
         exit 1
     }
 }
+
+# The one place all sixteen branches needed. Without it every docker-backed
+# subcommand fell off the end of the file with rc=0, whatever docker did.
+exit $script:ExitCode

--- a/scripts/setup-worktrees.ps1
+++ b/scripts/setup-worktrees.ps1
@@ -57,8 +57,22 @@ try {
         $upper  = Get-AccountLetterUpper -Index $idx
         $worktree = "${RepoDir}-${letter}"
 
+        # `git branch` failing is expected and ignored: the branch usually
+        # already exists on a re-run. The bash counterpart is explicit about
+        # this with `|| true`.
         & git branch $branch 2>$null
+
         & git worktree add $worktree $branch
+        # The success line used to print regardless. When the branch is
+        # already checked out in another worktree, or the target directory
+        # exists, install.ps1 went on to write $worktree into PROJECT_DIR_<X>
+        # anyway -- and the later `up` bound a source that does not exist,
+        # with no trace of git's original complaint. The bash script has the
+        # same shape and aborts under `set -euo pipefail`; this is the
+        # equivalent.
+        if ($LASTEXITCODE -ne 0) {
+            throw "git worktree add failed for $worktree (branch: $branch, exit $LASTEXITCODE)"
+        }
 
         Write-Host "  ${upper}: $worktree (branch: $branch)"
     }

--- a/tests/test_powershell_exit_codes.ps1
+++ b/tests/test_powershell_exit_codes.ps1
@@ -1,0 +1,146 @@
+# test_powershell_exit_codes.ps1 - the PowerShell CLI reports what docker did
+# (issue #355).
+#
+# Run:  pwsh -NoProfile -File tests/test_powershell_exit_codes.ps1
+# Exits non-zero on any failure.
+#
+# Invoke-Compose ran docker and discarded the result, and the dispatch switch
+# is the last statement in claude-docker.ps1, so every docker-backed
+# subcommand fell off the end with rc=0 no matter what happened. "Containers
+# started." printed after a missing image; "Build complete." after a failed
+# build.
+#
+# $ErrorActionPreference = 'Stop' does not cover this -- a native command's
+# non-zero exit is not a PowerShell error:
+#
+#   pwsh -NoProfile -Command "$ErrorActionPreference='Stop'; & cmd /c exit 7; 'reached'"
+#   reached      <- caller sees rc=0
+#
+# The bash wrapper gets it from `set -euo pipefail`, which is why cmd_up can
+# print its success line unguarded and still be correct.
+#
+# These assertions are structural. claude-docker.ps1 carries a Windows-only
+# platform guard, so the CI runner cannot execute a single subcommand of it;
+# running it on a Windows runner would mean driving docker from a test. What
+# can be checked everywhere, and what actually regressed, is that no compose
+# call is left unchecked and no success line is printed before its guard.
+
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent $ScriptDir
+$ScriptsDir = Join-Path $ProjectRoot 'scripts'
+
+$script:Pass = 0
+$script:Fail = 0
+
+function Assert-Eq {
+    param(
+        [Parameter(Mandatory)][string]$Label,
+        [Parameter(Mandatory)][AllowEmptyString()][AllowNull()][object]$Expected,
+        [Parameter(Mandatory)][AllowEmptyString()][AllowNull()][object]$Actual
+    )
+    if ([string]$Expected -eq [string]$Actual) {
+        Write-Host ("  PASS  {0}" -f $Label)
+        $script:Pass++
+    } else {
+        Write-Host ("  FAIL  {0}`n        expected: {1}`n        actual:   {2}" -f `
+            $Label, ([string]$Expected), ([string]$Actual))
+        $script:Fail++
+    }
+}
+
+$cliPath = Join-Path $ScriptsDir 'claude-docker.ps1'
+$lines = @(Get-Content -LiteralPath $cliPath)
+
+Write-Host '== Every compose call is checked =='
+
+# A call is "checked" when a Test-ComposeSucceeded appears within the next
+# four lines -- wide enough for a blank line and a short comment explaining
+# why the guard returns, narrow enough that the guard still has to belong to
+# this call rather than to the next one.
+$unchecked = @()
+for ($i = 0; $i -lt $lines.Count; $i++) {
+    if ($lines[$i] -notmatch '^\s*Invoke-Compose\s') { continue }
+    $window = @($lines[($i + 1)..([math]::Min($i + 4, $lines.Count - 1))])
+    if (-not ($window -match 'Test-ComposeSucceeded')) {
+        $unchecked += ("line {0}: {1}" -f ($i + 1), $lines[$i].Trim())
+    }
+}
+Assert-Eq 'no Invoke-Compose call is left unchecked' '' ($unchecked -join ' | ')
+
+# The count is asserted too: a refactor that deleted the calls would satisfy
+# the check above vacuously.
+$composeCalls = @($lines | Where-Object { $_ -match '^\s*Invoke-Compose\s' }).Count
+Assert-Eq 'the file still makes compose calls' $true ($composeCalls -ge 10)
+
+Write-Host '== Success messages are gated on a zero exit =='
+
+# Each of these used to print unconditionally. A guard must appear in the
+# three lines before it.
+$successLines = @(
+    'Containers started.'
+    'Containers stopped.'
+    'Containers restarted.'
+    'Build complete.'
+)
+foreach ($msg in $successLines) {
+    $idx = -1
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        if ($lines[$i] -like "*'$msg'*") { $idx = $i; break }
+    }
+    if ($idx -lt 0) {
+        Assert-Eq "'$msg' is present" 'present' 'missing'
+        continue
+    }
+    $before = @($lines[([math]::Max($idx - 3, 0))..($idx - 1)])
+    Assert-Eq "'$msg' is preceded by a success guard" $true `
+        ([bool]($before -match 'Test-ComposeSucceeded'))
+}
+
+Write-Host '== The script exits with what it recorded =='
+
+Assert-Eq 'the exit-code variable is initialized' $true `
+    ([bool]($lines -match '^\s*\$script:ExitCode\s*=\s*0\s*$'))
+# The dispatch switch is the last statement, so this single line is what
+# carries every branch's result out.
+Assert-Eq 'the file ends by exiting with it' $true `
+    ([bool]($lines -match '^\s*exit \$script:ExitCode\s*$'))
+# The runtime subcommands return early, before the switch, and used to mask
+# the agent's own exit code with a bare `return`.
+$runtimeBranch = ($lines -join "`n")
+Assert-Eq 'the runtime subcommand branch exits with it too' $true `
+    ($runtimeBranch -match 'Invoke-Agent -Subcommand \$Command\s*\r?\n(\s*#[^\r\n]*\r?\n)*\s*exit \$script:ExitCode')
+
+Write-Host '== setup-worktrees.ps1 stops when git refuses =='
+
+# install.ps1 derives PROJECT_DIR_<X> from the repo path and writes it
+# regardless of whether the worktree was created, so a silent `git worktree
+# add` failure produced a bind source that does not exist.
+$wtPath = Join-Path $ScriptsDir 'setup-worktrees.ps1'
+$wt = Get-Content -LiteralPath $wtPath -Raw
+Assert-Eq 'the worktree add result is checked' $true `
+    ($wt -match 'git worktree add[^\r\n]*\r?\n(\s*#[^\r\n]*\r?\n)*\s*if \(\$LASTEXITCODE -ne 0\)')
+Assert-Eq 'the failure throws rather than warning' $true `
+    ($wt -match 'throw "git worktree add failed')
+
+Write-Host '== scale validates before it mutates =='
+
+# The bash half of this is exercised end to end by
+# tests/test_scale_prevalidation.sh; here it is the PowerShell caller's shape.
+$cli = $lines -join "`n"
+$validateIdx = $cli.IndexOf('Get-SupportedIsolationMode -ProjectRoot $ProjectRoot -AccountCount $newCount')
+$writeIdx = $cli.IndexOf("Set-EnvValue -Path `$envFile -Key 'NUM_ACCOUNTS'")
+Assert-Eq 'scale calls the isolation check' $true ($validateIdx -ge 0)
+Assert-Eq 'scale writes NUM_ACCOUNTS' $true ($writeIdx -ge 0)
+if ($validateIdx -ge 0 -and $writeIdx -ge 0) {
+    # Order is the whole point: the generator was already fail-closed, and the
+    # caller moved first anyway.
+    Assert-Eq 'the check happens before the write' $true ($validateIdx -lt $writeIdx)
+}
+
+Write-Host ''
+Write-Host ("== Summary: PASS={0} FAIL={1} ==" -f $script:Pass, $script:Fail)
+if ($script:Fail -gt 0) { exit 1 }

--- a/tests/test_scale_prevalidation.sh
+++ b/tests/test_scale_prevalidation.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# test_scale_prevalidation.sh - `scale N` validates before it mutates
+# (issue #355).
+#
+# Run:  bash tests/test_scale_prevalidation.sh
+# Exits non-zero on any failure.
+#
+# Both wrappers wrote NUM_ACCOUNTS first and ran the generator afterwards. The
+# generator is deliberately fail-closed -- it validates the isolation mode for
+# every account before its first write, so a failure "cannot leave a partially
+# regenerated set behind" -- but the caller had already moved.
+#
+# On a worktree install holding only PROJECT_DIR_A and PROJECT_DIR_B,
+# `scale 4` wrote NUM_ACCOUNTS=4, created account-c and account-d, and then
+# died on "PROJECT_DIR_C is required when ISOLATION_MODE=worktree". What
+# remained was .env saying 4 and the compose files saying 2.
+#
+# Nothing downstream catches that split, which is what makes it worth a test:
+# `up` resolves the mode with the default account count of 1, so it passes and
+# starts two containers, while get_service_names, the TUI and the help text
+# all read NUM_ACCOUNTS and report four.
+#
+# The subject is the pre-validation, so docker is stubbed and never reached.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        printf '  PASS  %s\n' "$label"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL  %s\n        expected: %s\n        actual:   %s\n' \
+            "$label" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# A sandbox project root: scripts plus the registry, and its own .env.
+SANDBOX="$WORK/repo"
+mkdir -p "$SANDBOX/tui/internal/config"
+cp -r "$PROJECT_ROOT/scripts" "$SANDBOX/scripts"
+cp "$PROJECT_ROOT/tui/internal/config/runtimes.json" "$SANDBOX/tui/internal/config/"
+cp "$PROJECT_ROOT/VERSION" "$SANDBOX/"
+
+# docker is stubbed so nothing can reach a daemon; the pre-validation must
+# reject before anything would call it anyway.
+mkdir -p "$WORK/bin"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$WORK/bin/docker"
+chmod +x "$WORK/bin/docker"
+
+# A worktree install with paths for two accounts only -- the exact shape the
+# defect needs.
+write_env() {
+    cat > "$SANDBOX/.env" <<EOF
+HOME=$WORK/home
+PROJECT_DIR=$WORK/project
+NUM_ACCOUNTS=2
+AGENT_RUNTIME=claude
+ISOLATION_MODE=worktree
+PROJECT_DIR_A=$WORK/project-a
+PROJECT_DIR_B=$WORK/project-b
+EOF
+}
+mkdir -p "$WORK/home" "$WORK/project" "$WORK/project-a" "$WORK/project-b"
+write_env
+
+num_accounts() {
+    grep '^NUM_ACCOUNTS=' "$SANDBOX/.env" | tail -1 | cut -d= -f2-
+}
+
+run_scale() {
+    local n="$1"
+    ( cd "$SANDBOX" && PATH="$WORK/bin:$PATH" HOME="$WORK/home" \
+        bash "$SANDBOX/scripts/claude-docker" scale "$n" ) \
+        >"$WORK/scale-$n.log" 2>&1
+    echo "$?"
+}
+
+echo "== A scale the isolation contract rejects changes nothing =="
+
+# Account C has no PROJECT_DIR_C, so worktree mode cannot support 4.
+status="$(run_scale 4)"
+assert_eq "scale 4 exits non-zero" "1" "$status"
+assert_eq "NUM_ACCOUNTS is unchanged" "2" "$(num_accounts)"
+
+# The state directories are created after the .env write in the original
+# order, so their absence is a second, independent witness that the caller
+# stopped before mutating anything.
+for letter in c d; do
+    if [[ -d "$WORK/home/.claude-state/account-$letter" ]]; then
+        assert_eq "no account-$letter state directory was created" "absent" "present"
+    else
+        assert_eq "no account-$letter state directory was created" "absent" "absent"
+    fi
+done
+
+# The message has to name the missing variable, or the user cannot act on it.
+if grep -q 'PROJECT_DIR_C is required' "$WORK/scale-4.log"; then
+    assert_eq "the rejection names the missing variable" "named" "named"
+else
+    assert_eq "the rejection names the missing variable" "named" "not named"
+    sed 's/^/        /' "$WORK/scale-4.log"
+fi
+
+echo "== A scale the contract accepts still works =="
+
+# Down to one account: worktree mode only needs PROJECT_DIR_A, so this is
+# allowed and must not be blocked by the new check.
+status="$(run_scale 1)"
+assert_eq "scale 1 exits 0" "0" "$status"
+assert_eq "NUM_ACCOUNTS became 1" "1" "$(num_accounts)"
+
+echo
+echo "== Summary: PASS=$PASS FAIL=$FAIL =="
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Closes #355
Relates to #349, #359

## What

`Invoke-Compose` ran docker and discarded the result, and the dispatch switch is the last statement in `claude-docker.ps1`, so **every docker-backed subcommand exited 0 no matter what docker did**.

| Call site | Symptom |
|---|---|
| `Invoke-Up` | `Containers started.` after a missing image or an unresolvable bind source |
| `Invoke-Build` | `Build complete.` after a failed build |
| `Invoke-Update` | `Update complete.` — and containers recreated from an image that failed to build |
| `Invoke-Down` / `Invoke-Restart` | `Containers stopped.` / `Containers restarted.` |
| `logs`, `ps`, `exec`, `config`, raw `compose` | rc=0 for any docker failure, including an unknown flag |
| `Invoke-Agent` | `claude` / `codex` masked the agent's own exit code |

`$ErrorActionPreference = 'Stop'` does not cover this. A native command's non-zero exit is not a PowerShell error:

```
pwsh -NoProfile -Command "$ErrorActionPreference='Stop'; & cmd /c exit 7; 'reached'"
reached          <- caller sees rc=0
```

## Why

The bash wrapper gets all of it from `set -euo pipefail`, which is why `cmd_up` can print `Containers started.` unguarded and still be correct. The PowerShell port copied the structure without the guarantee underneath it.

## How

`$LASTEXITCODE` is an automatic **global**, so the native command inside the module already sets the variable the caller needs — only the reading was missing. No plumbing, no `Invoke-Native` wrapper.

- `Test-ComposeSucceeded` records the code in `$script:ExitCode` and returns whether it was zero.
- Every `Invoke-Compose` call is followed by one; the five success messages are gated on it.
- A single `exit $script:ExitCode` after the switch carries all sixteen branches out. The runtime subcommands return before the switch, so they exit with it too.

**The structural test found four call sites the first pass missed, two of them real defects**: the gh-auth recreate in both the shared and the per-account path. Verifying auth against containers that were not recreated reports a stale answer, so those now stop.

### `setup-worktrees.ps1`

Printed its success line whether or not `git worktree add` succeeded. `install.ps1` then derived `PROJECT_DIR_<X>` from the repo path and wrote it regardless, so a later `up` bound a source that does not exist, with no trace of git's original complaint. It throws now — what the bash script gets from `set -e`.

### `scale` validated after it mutated

Both wrappers wrote `NUM_ACCOUNTS` first and ran the generator afterwards. The generators are deliberately fail-closed so a failure *"cannot leave a partially regenerated set behind"* — but the caller had already moved.

Reproduced against `origin/develop`, worktree install with `PROJECT_DIR_A`/`B` only, `scale 4`:

```
  PASS  scale 4 exits non-zero
  FAIL  NUM_ACCOUNTS is unchanged     expected: 2   actual: 4
  FAIL  no account-c state directory  expected: absent   actual: present
  FAIL  no account-d state directory  expected: absent   actual: present
```

Nothing downstream catches that split: `up` resolves the mode with the default account count of 1, so it passes and starts two containers, while `get_service_names`, the TUI and the help text all read `NUM_ACCOUNTS` and report four. Both wrappers now validate first; the bash side does it in a subshell so a rejection leaves not even an exported variable behind.

## Verification

- `tests/test_scale_prevalidation.sh` (new, 7 assertions, `bash-tests` matrix) — `PASS=7`. **Red first**: `PASS=4 FAIL=3` against develop, output above. It also asserts the *accepted* direction still works (`scale 1` on the same install), so the new check cannot pass by rejecting everything.
- `tests/test_powershell_exit_codes.ps1` (new, 14 assertions, `pwsh-tests` matrix) — `PASS=14`.
- `test_num_accounts_precedence.sh` (52), `test_agent_attach_argv.sh` (9), `test_github_account_selection.sh` (19), `test_bash32_portability.sh` (16), `test_workflow_contracts.sh` (14), `test_powershell_version_floor.ps1` (8), `test_powershell_platform_guard.ps1` (24), `test_isolation_modes.ps1` (48) — all zero failures.
- `bash -n scripts/claude-docker`; PSScriptAnalyzer clean.

### Why the PowerShell test is structural

`claude-docker.ps1` carries a Windows-only platform guard, so the Linux runner cannot execute a single subcommand of it, and running it on a Windows runner would mean driving docker from a test. What can be checked everywhere — and what actually regressed — is that no compose call is left unchecked, no success line precedes its guard, and the file still ends by exiting with what it recorded. The count of compose calls is asserted too, so a refactor that deleted them cannot satisfy the check vacuously.

## One acceptance criterion is void, not unmet

> `claude-docker.ps1 tui` and `build-tui` attempt `Install-TuiRelease` before pointing the user at a Go install

#371 removed the download fallback from **both** sides per the decision on #348, and deleted `lib/tui-release.ps1`. The asymmetry this criterion described is resolved in the other direction: neither wrapper offers a download, because this repository publishes no releases and the offer could only 404.

## Where

- `scripts/claude-docker.ps1` — `Test-ComposeSucceeded`, twelve call sites, `Invoke-Scale`, the trailing `exit`
- `scripts/claude-docker` — `cmd_scale` pre-validation
- `scripts/setup-worktrees.ps1` — the `git worktree add` result
- `tests/test_scale_prevalidation.sh`, `tests/test_powershell_exit_codes.ps1` (both new), `.github/workflows/ci.yml`
