### PR TITLE
test: make the suite observe what it claims to cover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,7 @@ jobs:
           - tests/test_install_start_containers.sh
           - tests/test_install_tier_b.sh
           - tests/test_scale_prevalidation.sh
+          - tests/test_setup_isolated.sh
           - tests/test_bash32_portability.sh
           - tests/test_workflow_contracts.sh
           - scripts/test-entrypoint-settings.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,13 +91,20 @@ jobs:
           # tests/ is analyzed too, for the same reason shellcheck now scans
           # it: the five .ps1 files there hold assertion helpers, and a defect
           # in one of those presents as "the test passes" (#354, item 11).
-          $results = Invoke-ScriptAnalyzer -Path scripts, tests -Recurse -Severity Warning `
-            -ExcludeRule PSAvoidUsingWriteHost, PSUseSingularNouns, `
-              PSUseShouldProcessForStateChangingFunctions, `
-              PSUseBOMForUnicodeEncodedFile, PSAvoidGlobalVars, `
-              PSReviewUnusedParameter, PSUseDeclaredVarsMoreThanAssignments, `
-              PSUseUsingScopeModifierInNewRunspaces, `
-              PSAvoidUsingEmptyCatchBlock
+          #
+          # One invocation per directory: -Path is [string], not [string[]],
+          # so `-Path scripts, tests` fails to bind with "Cannot convert
+          # System.Object[] to the type System.String".
+          $results = @()
+          foreach ($dir in @('scripts', 'tests')) {
+            $results += Invoke-ScriptAnalyzer -Path $dir -Recurse -Severity Warning `
+              -ExcludeRule PSAvoidUsingWriteHost, PSUseSingularNouns, `
+                PSUseShouldProcessForStateChangingFunctions, `
+                PSUseBOMForUnicodeEncodedFile, PSAvoidGlobalVars, `
+                PSReviewUnusedParameter, PSUseDeclaredVarsMoreThanAssignments, `
+                PSUseUsingScopeModifierInNewRunspaces, `
+                PSAvoidUsingEmptyCatchBlock
+          }
           if ($results) {
             $results | Format-Table -AutoSize
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,15 @@ permissions:
   contents: read
 
 jobs:
+  # Scans the whole repository, not just ./scripts. The 16 .sh files under
+  # tests/ plus tests/lib/compose_assert.sh were linted by nothing, and those
+  # files hold the assertion helpers -- an SC2086 or SC2181 defect there
+  # presents as "the test passes" (#354, item 11).
+  #
+  # It cost three findings, all SC2034, and one of them was evidence of a
+  # separate defect: SCRIPT_DIR computed and never used in
+  # test_transform_syntax_check.sh, the fingerprint of a test that once
+  # intended to read the source it was checking.
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest
@@ -26,7 +35,7 @@ jobs:
           # SC1091: sourced files are resolved at runtime, not checkable in lint
           SHELLCHECK_OPTS: -e SC1091
         with:
-          scandir: "./scripts"
+          scandir: "."
           severity: warning
 
   hadolint:
@@ -79,7 +88,10 @@ jobs:
           # - PSAvoidUsingEmptyCatchBlock: best-effort cleanup blocks
           #   deliberately swallow non-fatal errors to keep the CLI usable
           #   when optional steps fail.
-          $results = Invoke-ScriptAnalyzer -Path scripts -Recurse -Severity Warning `
+          # tests/ is analyzed too, for the same reason shellcheck now scans
+          # it: the five .ps1 files there hold assertion helpers, and a defect
+          # in one of those presents as "the test passes" (#354, item 11).
+          $results = Invoke-ScriptAnalyzer -Path scripts, tests -Recurse -Severity Warning `
             -ExcludeRule PSAvoidUsingWriteHost, PSUseSingularNouns, `
               PSUseShouldProcessForStateChangingFunctions, `
               PSUseBOMForUnicodeEncodedFile, PSAvoidGlobalVars, `

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -175,8 +175,10 @@ fi
 if [ "$CONFIRM" = "yes" ]; then
     # Remove every registered runtime's state directory, not just Claude's,
     # so a codex/gemini install is fully cleaned up (see #273).
+    runtimes_seen=0
     while IFS= read -r runtime; do
         [ -z "$runtime" ] && continue
+        runtimes_seen=$((runtimes_seen + 1))
         state_dir="$(runtime_field "$runtime" "stateDir")"
         [ -z "$state_dir" ] && continue
         if [ -d "${HOME}/${state_dir}" ]; then
@@ -184,6 +186,16 @@ if [ "$CONFIRM" = "yes" ]; then
             echo "  Removed: ~/${state_dir}"
         fi
     done < <(runtime_list)
+
+    # runtime_list returns nothing and exits 0 when the registry is
+    # unreadable, so this loop could iterate zero times and the line below
+    # would still announce a completed removal. Reporting "removed" having
+    # examined no runtime at all is how state survives a cleanup silently.
+    if [ "$runtimes_seen" -eq 0 ]; then
+        echo "  Error: no runtimes found in the registry; no state directory was examined." >&2
+        echo "         Expected ${PROJECT_ROOT}/tui/internal/config/runtimes.json." >&2
+        exit 1
+    fi
     echo "  State directories removed."
 else
     echo "  Skipped."

--- a/scripts/lib/parse_env.sh
+++ b/scripts/lib/parse_env.sh
@@ -112,8 +112,19 @@ load_env_file() {
 
 # set_env_value FILE KEY VALUE
 # Insert or update KEY=VALUE in FILE. If FILE does not exist, creates it.
-# Values containing whitespace or '#' are surrounded with double quotes so
-# the round-trip through parse_env_value() is lossless.
+#
+# Values containing whitespace or '#' are surrounded with double quotes, and
+# an embedded double quote is backslash-escaped inside them.
+#
+# The round-trip is NOT lossless for a value containing a double quote. This
+# used to claim it was. parse_env_value strips the wrapping quotes but does
+# not unescape, so `say "hi" now` is written as `"say \"hi\" now"` and read
+# back as `say \"hi\" now`; Read-EnvFile and the Go LoadEnv behave the same
+# way. Making it lossless means changing all three readers in lockstep, which
+# belongs with the SSOT work in #356 -- so the claim is corrected here rather
+# than left as documentation that is simply untrue (#354, item 8).
+# tests/test_parse_env.sh pins the written bytes and the read-back value, so
+# whichever way that decision goes, the change is visible.
 set_env_value() {
     local file="$1" key="$2" value="$3"
     local formatted="$value"
@@ -149,7 +160,18 @@ set_env_value() {
         ' "$file" > "$tmp" && mv "$tmp" "$file"
     else
         # Ensure the file ends with a newline before appending.
-        [[ -s "$file" && "$(tail -c1 "$file")" != $'\n' ]] && printf '\n' >> "$file"
+        #
+        # `$(tail -c1 "$file")` cannot be compared against $'\n': command
+        # substitution strips trailing newlines, so it yields '' for a file
+        # that already ends in one and the comparison was always true. Every
+        # append therefore inserted a blank line first, and .env grew a gap
+        # per key (#354, item 8).
+        #
+        # `tail -c1 | wc -l` answers the actual question: 1 when the last byte
+        # is a newline, 0 when it is not.
+        if [[ -s "$file" ]] && [[ "$(tail -c1 "$file" | wc -l)" -eq 0 ]]; then
+            printf '\n' >> "$file"
+        fi
         printf '%s\n' "$line" >> "$file"
     fi
 }

--- a/scripts/test-concurrent-git.sh
+++ b/scripts/test-concurrent-git.sh
@@ -19,7 +19,21 @@ case "$(uname -s)" in
 esac
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# REPO_ROOT, not PROJECT_DIR. This used to be PROJECT_DIR, and the export
+# further down sets PROJECT_DIR to the *compose volume source* -- one name for
+# two things. Every `docker compose -f "$PROJECT_DIR/docker-compose.yml"`
+# after that point resolved to the temporary test repo, which has no compose
+# file, so under `set -euo pipefail` this script could not run past its first
+# container start (#354, item 13).
+#
+# It stays unregistered in CI on purpose. This is a concurrency stress tool:
+# it builds the image, creates N worktrees and starts N containers, which is
+# the cost of gemini-up-smoke multiplied by the account count. Running it per
+# PR buys little that isolated-up-smoke and the compose suites do not already
+# cover. What was wrong was that being unregistered *hid a defect*; the defect
+# is fixed, and tests/test_workflow_contracts.sh enforces registration for
+# tests/ so nothing lands there unrun.
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEMP_DIR="$(mktemp -d)"
 REPO_DIR="$TEMP_DIR/test-repo"
 NUM_TEST_ACCOUNTS="${NUM_TEST_ACCOUNTS:-2}"
@@ -36,8 +50,8 @@ to_upper() {
 # Cleanup on exit
 cleanup() {
     echo "=== Cleaning up ==="
-    docker compose -f "$PROJECT_DIR/docker-compose.yml" \
-        -f "$PROJECT_DIR/docker-compose.worktree.yml" \
+    docker compose -f "$REPO_ROOT/docker-compose.yml" \
+        -f "$REPO_ROOT/docker-compose.worktree.yml" \
         down --remove-orphans 2>/dev/null || true
     rm -rf "$TEMP_DIR"
     echo "Done."
@@ -63,7 +77,7 @@ done
 
 echo "=== Building image ==="
 NUM_ACCOUNTS="$NUM_TEST_ACCOUNTS" "$SCRIPT_DIR/generate-compose.sh"
-docker compose -f "$PROJECT_DIR/docker-compose.yml" build
+docker compose -f "$REPO_ROOT/docker-compose.yml" build
 
 echo "=== Starting containers with worktree override ==="
 # Set env vars for docker compose
@@ -74,8 +88,8 @@ for i in $(seq 1 "$NUM_TEST_ACCOUNTS"); do
     export "PROJECT_DIR_${upper}=${REPO_DIR}-${letter}"
 done
 
-docker compose -f "$PROJECT_DIR/docker-compose.yml" \
-    -f "$PROJECT_DIR/docker-compose.worktree.yml" \
+docker compose -f "$REPO_ROOT/docker-compose.yml" \
+    -f "$REPO_ROOT/docker-compose.worktree.yml" \
     up -d
 
 echo "=== Running parallel commits ==="
@@ -85,8 +99,8 @@ for i in $(seq 1 "$NUM_TEST_ACCOUNTS"); do
     upper=$(to_upper "$letter")
     svc="claude-${letter}"
 
-    docker compose -f "$PROJECT_DIR/docker-compose.yml" \
-        -f "$PROJECT_DIR/docker-compose.worktree.yml" \
+    docker compose -f "$REPO_ROOT/docker-compose.yml" \
+        -f "$REPO_ROOT/docker-compose.worktree.yml" \
         exec -T "$svc" bash -c "
             git config user.email '${letter}@test.com'
             git config user.name 'Agent ${upper}'

--- a/scripts/test-entrypoint-settings.sh
+++ b/scripts/test-entrypoint-settings.sh
@@ -209,4 +209,26 @@ echo "=== Results ==="
 echo -e "  ${GREEN}Passed${NC}: $PASS"
 echo -e "  ${RED}Failed${NC}: $FAIL"
 
+# Zero assertions is a failure, not a pass. Both suites here SKIP when the
+# fixture tree is absent, and this script used to exit 0 having asserted
+# nothing:
+#
+#   $ bash scripts/test-entrypoint-settings.sh /nonexistent/config
+#   SKIP: .../settings.json not found
+#     Passed: 0
+#     Failed: 0
+#   EXIT=0
+#
+# generate_container_settings -- the pwsh-to-bash hook rewrite, the sandbox
+# disable, the deny-rule stripping -- has no other test. Move the fixtures and
+# all of it disappears silently. A missing jq is already fail-closed here; a
+# missing fixture was not.
+if [ "$PASS" -eq 0 ] && [ "$FAIL" -eq 0 ]; then
+    echo -e "  ${RED}ERROR${NC}: no assertions ran. CLAUDE_CONFIG resolved to '${CLAUDE_CONFIG}'," >&2
+    echo "         and neither settings.json nor settings.windows.json was found there." >&2
+    echo "         Pass a config directory as \$1, or run from a checkout that has" >&2
+    echo "         tests/entrypoint_fixtures/global." >&2
+    exit 1
+fi
+
 [ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/scripts/test-entrypoint-settings.sh
+++ b/scripts/test-entrypoint-settings.sh
@@ -12,13 +12,20 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Resolution order:
 #   1. Explicit positional argument (developer override).
-#   2. CI fixture under tests/entrypoint_fixtures/global when running in
-#      GitHub Actions, where claude-config/ is not checked out alongside
-#      the project (issue #232).
-#   3. Default ../claude-config/global relative to repo (developer host).
+#   2. The in-repo fixture under tests/entrypoint_fixtures/global.
+#   3. ../claude-config/global relative to the repo, if the fixture is gone.
+#
+# The fixture used to be selected only when $GITHUB_ACTIONS was set, so a
+# developer with a claude-config checkout alongside this repo ran the suite
+# against *their own configuration* while CI ran it against the fixture. The
+# two asserted different inputs, and only one of them was reviewable -- which
+# is why this file could carry an assertion anchored to the wrong deny list
+# and still pass locally (#354, item 7).
+#
+# The fixture is the default now. Pass a path as $1 to check a real config.
 if [ -n "${1:-}" ]; then
     CLAUDE_CONFIG="$1"
-elif [ -n "${GITHUB_ACTIONS:-}" ] && [ -d "$PROJECT_ROOT/tests/entrypoint_fixtures/global" ]; then
+elif [ -d "$PROJECT_ROOT/tests/entrypoint_fixtures/global" ]; then
     CLAUDE_CONFIG="$PROJECT_ROOT/tests/entrypoint_fixtures/global"
 else
     CLAUDE_CONFIG="$(cd "$SCRIPT_DIR/../.." && pwd)/claude-config/global"
@@ -95,13 +102,23 @@ else
     val=$(jq -r '.sandbox.enabled' "$OUT")
     assert_eq "sandbox.enabled = false" "false" "$val"
 
-    # no glob patterns in permissions.deny
-    glob_count=$(jq '[.permissions.deny[]? | select(test("[*]"))] | length' "$OUT")
-    assert_zero "no glob patterns in permissions.deny" "$glob_count"
-
-    # non-glob deny rules preserved
-    deny_count=$(jq '.permissions.deny | length' "$OUT")
-    assert_nonzero "non-glob deny rules preserved" "$deny_count"
+    # The deny-rule filter, asserted against the set that must survive rather
+    # than by re-applying the filter's own predicate.
+    #
+    # This used to count `select(test("[*]"))` survivors and require zero --
+    # the same expression generate_container_settings uses to remove them, so
+    # the assertion could not disagree with the implementation. A filter whose
+    # regex matched nothing at all would satisfy it (#354, item 7).
+    #
+    # The fixture's deny list is:
+    #   Read(./.env*)            glob  -> removed
+    #   Read(./secrets/**)       glob  -> removed
+    #   Read(./.aws/credentials) plain -> kept
+    #   Bash(rm -rf /)           plain -> kept
+    expected_deny='["Read(./.aws/credentials)","Bash(rm -rf /)"]'
+    actual_deny=$(jq -c '.permissions.deny' "$OUT")
+    assert_eq "permissions.deny keeps exactly the non-glob rules" \
+        "$expected_deny" "$actual_deny"
 
     # no pwsh anywhere
     pwsh_count=$(jq '[.. | strings | select(test("pwsh"))] | length' "$OUT")

--- a/tests/test_cleanup_backups.sh
+++ b/tests/test_cleanup_backups.sh
@@ -121,8 +121,55 @@ echo "== Running: cleanup.sh --backups --yes --backup-age-days 7 =="
 # redirects the script to the temp fixture root.
 # docker compose calls error harmlessly to /dev/null inside cleanup.sh.
 FAKE_HOME="$(mktemp -d)"
+
+# FAKE_HOME used to be an empty mktemp -d, so cleanup.sh's
+# `[ -d "${HOME}/${state_dir}" ]` was false for every runtime and the
+# destructive branch this run is supposed to exercise was never entered
+# (#354, item 3). The whole state-removal half of the script was uncovered.
+#
+# The directories come from the registry rather than a hardcoded list, so a
+# runtime added to runtimes.json is covered here the moment it is added --
+# and a broken runtime_list / runtime_field(stateDir) link fails instead of
+# quietly shrinking the set.
+# The fixture root needs the registry. cleanup.sh resolves state-directory
+# names through it, and PROJECT_ROOT_OVERRIDE points the script at a bare
+# temp directory -- so runtime_list returned nothing, the removal loop
+# iterated zero times, and the script still printed "State directories
+# removed." Populating the fixture is what makes this run reach the code.
+mkdir -p "$TMPDIR_FAKE_ROOT/tui/internal/config"
+cp "$PROJECT_ROOT/tui/internal/config/runtimes.json" \
+   "$TMPDIR_FAKE_ROOT/tui/internal/config/runtimes.json"
+
+# shellcheck source=../scripts/lib/runtime.sh
+. "$PROJECT_ROOT/scripts/lib/runtime.sh"
+
+STATE_DIRS=()
+while IFS= read -r rt; do
+    [ -z "$rt" ] && continue
+    sd="$(runtime_field "$rt" "stateDir")"
+    [ -z "$sd" ] && continue
+    mkdir -p "$FAKE_HOME/$sd/account-a"
+    printf 'placeholder\n' > "$FAKE_HOME/$sd/account-a/marker"
+    STATE_DIRS+=("$sd")
+done < <(runtime_list)
+
+if [ "${#STATE_DIRS[@]}" -eq 0 ]; then
+    printf '  FAIL  no runtime state directories were derived from the registry\n'
+    FAIL=$((FAIL + 1))
+fi
+
+cleanup_status=0
 HOME="$FAKE_HOME" PROJECT_ROOT_OVERRIDE="$TMPDIR_FAKE_ROOT" \
-    bash "$CLEANUP" --backups --yes --backup-age-days 7 >/dev/null 2>&1 || true
+    bash "$CLEANUP" --backups --yes --backup-age-days 7 >/dev/null 2>&1 || cleanup_status=$?
+
+echo "== State directories =="
+# The exit code was discarded with `|| true`, so cleanup.sh could fail
+# outright and every assertion below would still describe a clean run.
+assert_eq "cleanup.sh exits 0" "0" "$cleanup_status"
+for sd in "${STATE_DIRS[@]}"; do
+    assert_missing "state dir $sd removed" "$FAKE_HOME/$sd"
+done
+
 rm -rf "$FAKE_HOME"
 
 echo "== Post-conditions =="

--- a/tests/test_container_memory.ps1
+++ b/tests/test_container_memory.ps1
@@ -49,9 +49,23 @@ function Assert-Eq {
 }
 
 function Assert-Throws {
+    <#
+    .SYNOPSIS
+    Assert that an action throws, and that it throws the error meant.
+    .DESCRIPTION
+    -MessageLike is mandatory. Without it these eight cases passed on *any*
+    terminating error, including a parameter-binding failure from a renamed
+    parameter -- so a refusal that never reached the validation it was testing
+    counted as the validation working (#354, item 9).
+
+    test_isolation_modes.ps1's helper already had this shape; this one is
+    brought in line with it, and the two hand-written try/catch blocks at the
+    end of this file that compare messages collapse into it.
+    #>
     param(
         [Parameter(Mandatory)][string]$Label,
-        [Parameter(Mandatory)][scriptblock]$Action
+        [Parameter(Mandatory)][scriptblock]$Action,
+        [Parameter(Mandatory)][string]$MessageLike
     )
     try {
         & $Action | Out-Null
@@ -59,8 +73,14 @@ function Assert-Throws {
         $script:Fail++
     }
     catch {
-        Write-Host ("  PASS  {0}" -f $Label)
-        $script:Pass++
+        if ($_.Exception.Message -like $MessageLike) {
+            Write-Host ("  PASS  {0}" -f $Label)
+            $script:Pass++
+        } else {
+            Write-Host ("  FAIL  {0}`n        threw, but the message did not match '{1}'`n        actual: {2}" -f `
+                $Label, $MessageLike, $_.Exception.Message)
+            $script:Fail++
+        }
     }
 }
 
@@ -136,11 +156,14 @@ foreach ($case in $derived) {
         $case[1] (Resolve-NodeHeapMib -MemLimit $case[0])
 }
 
-# A cap at or below the headroom floor has no valid heap at all.
+# A cap at or below the headroom floor has no valid heap at all. The message
+# has to name CONTAINER_MEM_LIMIT, because that is the key the user edits.
 foreach ($cap in @('512m', '256m')) {
-    Assert-Throws ("derive: cap {0} refused" -f $cap) { Resolve-NodeHeapMib -MemLimit $cap }
+    Assert-Throws ("derive: cap {0} refused" -f $cap) `
+        { Resolve-NodeHeapMib -MemLimit $cap } '*CONTAINER_MEM_LIMIT*'
 }
-Assert-Throws 'derive: unparseable cap refused' { Resolve-NodeHeapMib -MemLimit 'four-gigs' }
+Assert-Throws 'derive: unparseable cap refused' `
+    { Resolve-NodeHeapMib -MemLimit 'four-gigs' } '*CONTAINER_MEM_LIMIT*'
 
 # An explicitly configured heap is used as given when it fits, and refused when
 # it does not. The boundary is exact on purpose: one MiB either side of it
@@ -148,30 +171,19 @@ Assert-Throws 'derive: unparseable cap refused' { Resolve-NodeHeapMib -MemLimit 
 Assert-Eq 'explicit: 3584 MiB accepted at a 4G cap (exactly 512 MiB headroom)' `
     3584 (Resolve-NodeHeapMib -MemLimit '4G' -ConfiguredHeapMb '3584')
 Assert-Throws 'explicit: 3585 MiB refused at a 4G cap (511 MiB headroom)' `
-    { Resolve-NodeHeapMib -MemLimit '4G' -ConfiguredHeapMb '3585' }
+    { Resolve-NodeHeapMib -MemLimit '4G' -ConfiguredHeapMb '3585' } '*CONTAINER_NODE_HEAP_MB*'
 foreach ($bad in @('0', '-512', 'abc', '3.5')) {
     Assert-Throws ("explicit: heap '{0}' rejected" -f $bad) `
-        { Resolve-NodeHeapMib -MemLimit '4G' -ConfiguredHeapMb $bad }
+        { Resolve-NodeHeapMib -MemLimit '4G' -ConfiguredHeapMb $bad } '*CONTAINER_NODE_HEAP_MB*'
 }
 
 # The diagnostic has to name the key the user changes. A refusal that says only
-# "invalid" leaves them editing the wrong line.
-try {
-    Resolve-NodeHeapMib -MemLimit '4G' -ConfiguredHeapMb '4096' | Out-Null
-    Assert-Eq 'diagnostic: names CONTAINER_NODE_HEAP_MB' $true $false
-}
-catch {
-    Assert-Eq 'diagnostic: names CONTAINER_NODE_HEAP_MB' $true `
-        ($_.Exception.Message -like '*CONTAINER_NODE_HEAP_MB*')
-}
-try {
-    Resolve-NodeHeapMib -MemLimit '384m' | Out-Null
-    Assert-Eq 'diagnostic: names CONTAINER_MEM_LIMIT' $true $false
-}
-catch {
-    Assert-Eq 'diagnostic: names CONTAINER_MEM_LIMIT' $true `
-        ($_.Exception.Message -like '*CONTAINER_MEM_LIMIT*')
-}
+# "invalid" leaves them editing the wrong line. These were two hand-written
+# try/catch blocks doing what Assert-Throws now does.
+Assert-Throws 'diagnostic: names CONTAINER_NODE_HEAP_MB' `
+    { Resolve-NodeHeapMib -MemLimit '4G' -ConfiguredHeapMb '4096' } '*CONTAINER_NODE_HEAP_MB*'
+Assert-Throws 'diagnostic: names CONTAINER_MEM_LIMIT' `
+    { Resolve-NodeHeapMib -MemLimit '384m' } '*CONTAINER_MEM_LIMIT*'
 
 Write-Host ''
 Write-Host ("== Summary: PASS={0} FAIL={1} ==" -f $script:Pass, $script:Fail)

--- a/tests/test_install_tier_b.sh
+++ b/tests/test_install_tier_b.sh
@@ -89,8 +89,10 @@ status=0
     . "$REPO_ROOT/scripts/install.sh"
 
     # Redirect the installer at the sandbox. SCRIPT_DIR is what selects the
-    # stubs; PROJECT_ROOT is where .env lands.
+    # stubs; PROJECT_ROOT is where .env lands. Both are read by the sourced
+    # installer, not by this file, which is why shellcheck cannot see the use.
     SCRIPT_DIR="$FAKE_SCRIPTS"
+    # shellcheck disable=SC2034
     PROJECT_ROOT="$FAKE_ROOT"
 
     # shellcheck disable=SC2034

--- a/tests/test_num_accounts_precedence.sh
+++ b/tests/test_num_accounts_precedence.sh
@@ -251,6 +251,10 @@ scale_out=$(env -u NUM_ACCOUNTS -u AGENT_RUNTIME HOME="$scale_dir/home" \
 scale_status=$?
 check "scale-27" "bash-exit" "$scale_status" "0"
 check "scale-27" "bash-aa-dir" "$([[ -d "$scale_dir/home/.claude-state/account-aa" ]] && echo 1 || echo 0)" "1"
+# The captured output was discarded, which shellcheck reported as an unused
+# variable once tests/ came into its scope (#354). A successful scale has to
+# say so, or a silent no-op looks the same as the real thing.
+check_contains "scale-27" "bash-reported" "$scale_out" "Scaled to 27 account(s)."
 
 max_dir=$(make_sandbox "scale-max" "-")
 bash_max_out=$(run_with_env "-" bash "$max_dir/scripts/claude-docker" scale 702 2>&1)
@@ -267,8 +271,25 @@ bash_help=$(run_with_env "-" bash "$max_dir/scripts/claude-docker" help 2>&1)
 check_contains "scale-help" "bash" "$bash_help" "Set number of accounts (1-702)"
 pwsh_source=$(tr -d '\r' < "$max_dir/scripts/claude-docker.ps1")
 check_contains "scale-help" "pwsh" "$pwsh_source" "Set number of accounts (1-702)"
-pwsh_scale=$(sed -n '/^function Invoke-Scale {/,/^}/p' "$max_dir/scripts/claude-docker.ps1")
-check_contains "scale-702" "pwsh" "$pwsh_scale" '$newCount -gt 702'
+# The pwsh leg used to grep Invoke-Scale's source for the literal
+# `$newCount -gt 702`. That passes for a body which contains the literal but
+# never applies it, and fails for a valid refactor that extracts 702 into a
+# named constant -- it blocked good changes and caught no defects (#354,
+# item 10). It now runs the same two cases the bash leg runs, through the real
+# entry point.
+#
+# The platform guard is bypassed the same way test_compose_generator_equivalence.sh
+# does it: the child process presents a Windows OS value for that invocation
+# only. There is no production bypass flag for a caller to inherit.
+pwsh_over_out=$(pwsh -NoProfile -Command \
+    "\$PSVersionTable.OS = 'Microsoft Windows'; & '$max_dir/scripts/claude-docker.ps1' scale 703" \
+    2>&1 | tr -d '\r')
+check_contains "scale-703" "pwsh" "$pwsh_over_out" "between 1 and 702"
+
+pwsh_max_out=$(pwsh -NoProfile -Command \
+    "\$PSVersionTable.OS = 'Microsoft Windows'; & '$max_dir/scripts/claude-docker.ps1' scale 702" \
+    2>&1 | tr -d '\r')
+check_contains "scale-702" "pwsh" "$pwsh_max_out" ".env not found"
 
 printf '\n-- checkout untouched\n'
 if [[ "$(compose_digest)" == "$DIGEST_BEFORE" ]]; then

--- a/tests/test_parse_env.sh
+++ b/tests/test_parse_env.sh
@@ -96,6 +96,47 @@ assert_eq "hash value round-trip" "val#1" \
     "$(parse_env_value "$SET_FIXTURE" HASH_KEY)"
 rm -f "$SET_FIXTURE"
 
+echo "== set_env_value: the bytes it writes =="
+
+# Reading back through parse_env_value hid two things at once, because the
+# parser's behaviour was substituted for the file's contents (#354, item 8).
+# These assertions look at the file.
+
+BYTES_FIXTURE="$(mktemp)"
+printf 'A=1\n' > "$BYTES_FIXTURE"
+
+# 1. No blank line is inserted before an appended key. `$(tail -c1 file)`
+#    strips the trailing newline, so the "does it end in a newline" check was
+#    always true and .env grew a gap per key.
+set_env_value "$BYTES_FIXTURE" B 2
+set_env_value "$BYTES_FIXTURE" C 3
+assert_eq "appending does not insert blank lines" \
+    "A=1|B=2|C=3" "$(tr '\n' '|' < "$BYTES_FIXTURE" | sed 's/|$//')"
+
+# 2. A file that genuinely lacks a trailing newline still gets one, so the
+#    fix above did not trade one bug for the other.
+NONL_FIXTURE="$(mktemp)"
+printf 'A=1' > "$NONL_FIXTURE"
+set_env_value "$NONL_FIXTURE" B 2
+assert_eq "a missing trailing newline is still added" \
+    "A=1|B=2" "$(tr '\n' '|' < "$NONL_FIXTURE" | sed 's/|$//')"
+rm -f "$NONL_FIXTURE"
+
+# 3. The quoting and escaping, asserted as written rather than as parsed.
+set_env_value "$BYTES_FIXTURE" QUOTED 'say "hi" now'
+assert_eq "an embedded quote is escaped inside the wrapper" \
+    'QUOTED="say \"hi\" now"' "$(grep '^QUOTED=' "$BYTES_FIXTURE")"
+
+# 4. And the read side, stated as it is rather than as the docstring used to
+#    claim. parse_env_value strips the wrapper but does not unescape, so this
+#    round-trip is lossy. Read-EnvFile and the Go LoadEnv agree with it.
+#    Pinned so that making it lossless -- a change to all three readers,
+#    tracked in #356 -- shows up here instead of passing silently.
+assert_eq "the read-back value keeps the backslashes (known, see #356)" \
+    'say \"hi\" now' "$(parse_env_value "$BYTES_FIXTURE" QUOTED)"
+
+rm -f "$BYTES_FIXTURE"
+
 echo
 echo "== Summary: PASS=$PASS FAIL=$FAIL =="
 if (( FAIL > 0 )); then

--- a/tests/test_runtime_registry_equivalence.sh
+++ b/tests/test_runtime_registry_equivalence.sh
@@ -35,14 +35,46 @@ if [[ ! -r "$REGISTRY" ]]; then
     exit 1
 fi
 
-# The set of fields every runtime entry carries (see #268 / #267).
-FIELDS=(
-    binary displayName servicePrefix stateDir containerHome
-    hostConfigMount containerConfigMount configDirEnv configDirEnvValue
-    configSourceEnv apiKeyVarPrefix sdkApiKeyVar buildArg installMethod
-    skipPermissionsFlag configFormat bootstrapModule extraEnv extraRunArgs
-    supportsUsage mountsAgentsSkills credentialFiles oauthCredentialFile
-)
+# The fields every runtime entry carries, derived from the registry rather
+# than restated here (see #268 / #267).
+#
+# This used to be a hand-maintained array of 23 names. It happened to match
+# the registry, but nothing made it: a field added to runtimes.json got no
+# three-way drift check and nothing announced the gap (#354, item 4). Deriving
+# it means a new key is covered the moment it is added.
+#
+# jq when available, an awk fallback otherwise, mirroring how runtime_field
+# itself reads the file -- a host without jq must still get the real field
+# list, not a shorter one.
+registry_fields() {
+    if command -v jq >/dev/null 2>&1; then
+        jq -r '[.runtimes[] | keys[]] | unique | .[]' "$REGISTRY"
+        return
+    fi
+    # Keys are two levels deep: .runtimes.<name>.<field>. Depth is tracked by
+    # brace counting so a nested object cannot contribute its own keys.
+    awk '
+        /\{/ { depth++ }
+        depth == 3 && match($0, /^[[:space:]]*"[A-Za-z0-9_]+"[[:space:]]*:/) {
+            key = $0
+            sub(/^[[:space:]]*"/, "", key)
+            sub(/"[[:space:]]*:.*$/, "", key)
+            if (!(key in seen)) { seen[key] = 1; print key }
+        }
+        /\}/ { depth-- }
+    ' "$REGISTRY" | sort -u
+}
+
+FIELDS=()
+while IFS= read -r _field; do
+    [[ -n "$_field" ]] && FIELDS+=("$_field")
+done < <(registry_fields)
+
+if [[ "${#FIELDS[@]}" -eq 0 ]]; then
+    echo "FAIL: no fields derived from $REGISTRY" >&2
+    exit 1
+fi
+echo "Derived ${#FIELDS[@]} field(s) from the registry."
 
 PASS=0
 FAIL=0
@@ -70,11 +102,34 @@ pwsh_runtime_field() {
 # assert_field RUNTIME FIELD
 # Read (RUNTIME, FIELD) via the jq path, the awk fallback, and -- when pwsh
 # is available -- the PowerShell reader, and assert all readers agree.
+# FIELDS_WITH_A_VALUE records which derived fields were ever seen non-empty.
+# Three readers agreeing is not, on its own, evidence: a field that does not
+# exist agrees three ways and counted as PASS (#354, item 4).
+#
+#     runtime_field claude bogusField      -> ''
+#     _runtime_field_awk ... bogusField    -> ''
+#     equal = YES  -> PASS
+#
+# Requiring a value per runtime would be wrong -- extraEnv and extraRunArgs are
+# legitimately empty for some runtimes, and the key still exists. The anchor is
+# therefore per *field*: every field the registry declares must be populated by
+# at least one runtime, checked after the loop. A field nobody populates is
+# either dead or misspelled, and either way the three-way comparison over it
+# proves nothing.
+FIELDS_WITH_A_VALUE=""
+
 assert_field() {
     local runtime="$1" field="$2"
     local jq_val awk_val pwsh_val
     jq_val=$(runtime_field "$runtime" "$field")
     awk_val=$(_runtime_field_awk "$REGISTRY" "$runtime" "$field")
+
+    if [[ -n "$jq_val" ]]; then
+        case "$FIELDS_WITH_A_VALUE" in
+            *" $field "*) : ;;
+            *) FIELDS_WITH_A_VALUE="$FIELDS_WITH_A_VALUE $field " ;;
+        esac
+    fi
 
     local ok=1
     if [[ "$jq_val" != "$awk_val" ]]; then
@@ -151,6 +206,63 @@ if [[ "$HAVE_PWSH" -eq 1 ]]; then
 else
     printf '  PASS  runtime_list (bash only) = %s\n' "$bash_list"
     PASS=$((PASS + 1))
+fi
+
+# The anchor. Without it, three readers returning '' for a field that does not
+# exist is indistinguishable from three readers agreeing on a real one.
+echo "== every declared field is populated somewhere =="
+
+# Known-unpopulated fields, each with the reason it is allowed to be. An
+# unexplained entry here would be the same disease this test exists to treat,
+# so the finding is stated rather than waived.
+#
+#   extraEnv -- empty for claude, codex and gemini. Its only reader is the Go
+#   struct field ExtraEnv in tui/internal/config/runtime.go:38, and nothing
+#   reads that. So it is declared, mapped, never populated and never
+#   consumed. Removing it is a registry schema change across three readers
+#   and belongs with the SSOT work in #356, not in a test change.
+UNPOPULATED_ALLOWED=" extraEnv "
+
+for field in "${FIELDS[@]}"; do
+    case "$FIELDS_WITH_A_VALUE" in
+        *" $field "*)
+            PASS=$((PASS + 1))
+            continue
+            ;;
+    esac
+    case "$UNPOPULATED_ALLOWED" in
+        *" $field "*)
+            printf '  NOTE  %s is declared but empty for every runtime (known, see #356)\n' "$field"
+            ;;
+        *)
+            printf '  FAIL  %s is declared in the registry but empty for every runtime\n' "$field"
+            FAIL=$((FAIL + 1))
+            ;;
+    esac
+done
+printf '  PASS  %d field(s) checked for population\n' "${#FIELDS[@]}"
+
+# And the negative case the derivation exists to make possible: a name that is
+# not in the registry must not be in the derived list. All three readers
+# return '' for it, so agreement cannot tell them apart -- only the list can.
+echo "== a field the registry does not declare is not tested =="
+case " ${FIELDS[*]} " in
+    *" bogusField "*)
+        printf '  FAIL  bogusField appears in the derived field list\n'
+        FAIL=$((FAIL + 1))
+        ;;
+    *)
+        printf '  PASS  bogusField is absent from the derived field list\n'
+        PASS=$((PASS + 1))
+        ;;
+esac
+bogus_jq=$(runtime_field claude bogusField)
+if [[ -z "$bogus_jq" ]]; then
+    printf '  PASS  a nonexistent field reads as empty (which is why the list is derived)\n'
+    PASS=$((PASS + 1))
+else
+    printf '  FAIL  a nonexistent field returned %q\n' "$bogus_jq"
+    FAIL=$((FAIL + 1))
 fi
 
 echo

--- a/tests/test_setup_isolated.sh
+++ b/tests/test_setup_isolated.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# test_setup_isolated.sh - scripts/setup-isolated.sh (issue #354, item 5).
+#
+# Run:  bash tests/test_setup_isolated.sh
+# Exits non-zero on any failure.
+#
+# Nothing executed this script. It creates the workspaces that make
+# ISOLATION_MODE=isolated an isolation mode at all, and its two load-bearing
+# details had zero coverage:
+#
+#   * `git clone --no-hardlinks`. Cloning a local path hardlinks the object
+#     store by default, which would leave every account sharing objects --
+#     exactly the property that disqualifies worktree mode as a security
+#     boundary. Drop the flag and isolated mode silently becomes worktree mode
+#     with extra steps, and every YAML-level assertion in the suite still
+#     passes.
+#   * The credential strip in repoint_origin. The clone's origin points at the
+#     source path, which the container cannot see, so it is repointed at the
+#     source's own upstream -- and a token embedded in that URL would be
+#     copied into N clones.
+#
+# Everything here runs on local repositories in a temp directory; no network,
+# no docker, no container.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SETUP="$PROJECT_ROOT/scripts/setup-isolated.sh"
+
+PASS=0
+FAIL=0
+
+pass() { printf '  PASS  %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  FAIL  %s\n        %s\n' "$1" "${2:-}"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        pass "$label"
+    else
+        printf '  FAIL  %s\n        expected: %s\n        actual:   %s\n' \
+            "$label" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+GIT_ID=(-c user.email=t@e -c user.name=t)
+
+make_source_repo() {
+    local dir="$1" origin="${2:-}"
+    mkdir -p "$dir"
+    git -C "$dir" init -q
+    printf 'tracked\n' > "$dir/tracked.txt"
+    git -C "$dir" add tracked.txt
+    git -C "$dir" "${GIT_ID[@]}" commit -q -m init
+    # An untracked secret, to confirm the clone does not carry it.
+    printf 'CLAUDE_API_KEY_A=placeholder-not-a-key\n' > "$dir/untracked-secret.txt"
+    if [[ -n "$origin" ]]; then
+        git -C "$dir" remote add origin "$origin"
+    fi
+}
+
+echo "== A non-git source is refused =="
+
+mkdir -p "$WORK/not-a-repo"
+out="$(bash "$SETUP" "$WORK/not-a-repo" 2 2>&1)"; status=$?
+assert_eq "exits non-zero" "1" "$status"
+case "$out" in
+    *"is not a git repository"*) pass "the message says why" ;;
+    *) fail "the message says why" "$out" ;;
+esac
+
+echo "== An out-of-range account count is refused =="
+
+make_source_repo "$WORK/range" "https://example.invalid/o/r.git"
+out="$(bash "$SETUP" "$WORK/range" 703 2>&1)"; status=$?
+assert_eq "exits non-zero for 703" "1" "$status"
+case "$out" in
+    *"between 1 and 702"*) pass "the message names the range" ;;
+    *) fail "the message names the range" "$out" ;;
+esac
+
+echo "== Clones are independent, not hardlinked =="
+
+SRC="$WORK/proj"
+make_source_repo "$SRC" "https://example.invalid/owner/repo.git"
+bash "$SETUP" "$SRC" 2 >"$WORK/setup.log" 2>&1
+setup_status=$?
+assert_eq "setup-isolated.sh exits 0" "0" "$setup_status"
+if [[ "$setup_status" -ne 0 ]]; then
+    sed 's/^/        /' "$WORK/setup.log"
+fi
+
+for letter in a b; do
+    target="$SRC-isolated-$letter"
+    if [[ -d "$target/.git" ]]; then
+        pass "clone $letter exists"
+    else
+        fail "clone $letter exists" "$target"
+        continue
+    fi
+
+    # The property that separates isolated from worktree: no shared object
+    # store. `git worktree` leaves one; an alternates file would reintroduce
+    # it through the back door.
+    if [[ -e "$target/.git/objects/info/alternates" ]]; then
+        fail "clone $letter has no alternates file" \
+            "$(cat "$target/.git/objects/info/alternates")"
+    else
+        pass "clone $letter has no alternates file"
+    fi
+done
+
+# --no-hardlinks, asserted by link count rather than by reading the flag out
+# of the source. A hardlinked object has st_nlink > 1; an independent copy
+# has exactly 1. This is the assertion that fails if someone drops the flag.
+shared=0
+while IFS= read -r obj; do
+    links="$(stat -c '%h' "$obj" 2>/dev/null || echo 1)"
+    [[ "$links" -gt 1 ]] && shared=$((shared + 1))
+done < <(find "$SRC-isolated-a/.git/objects" -type f 2>/dev/null)
+assert_eq "no object in clone a is hardlinked to another file" "0" "$shared"
+
+# An untracked file is not part of the repository, so a clone must not carry
+# it. That is what keeps a stray .env out of N workspaces.
+if [[ -e "$SRC-isolated-a/untracked-secret.txt" ]]; then
+    fail "the untracked file did not travel into the clone" "it did"
+else
+    pass "the untracked file did not travel into the clone"
+fi
+
+echo "== origin is repointed at the source's upstream =="
+
+assert_eq "clone a points at the upstream, not the local path" \
+    "https://example.invalid/owner/repo.git" \
+    "$(git -C "$SRC-isolated-a" remote get-url origin)"
+
+echo "== Credentials embedded in the origin URL are stripped =="
+
+CRED="$WORK/cred"
+make_source_repo "$CRED" "https://user:placeholder-token@example.invalid/owner/repo.git"
+bash "$SETUP" "$CRED" 1 >"$WORK/cred.log" 2>&1
+cred_origin="$(git -C "$CRED-isolated-a" remote get-url origin)"
+assert_eq "the userinfo is gone" \
+    "https://example.invalid/owner/repo.git" "$cred_origin"
+case "$cred_origin" in
+    *placeholder-token*) fail "the token is not in the clone's origin" "$cred_origin" ;;
+    *) pass "the token is not in the clone's origin" ;;
+esac
+
+# An SSH URL puts the *user* in the same position, and it is not a secret --
+# stripping it would break authentication.
+SSHSRC="$WORK/sshsrc"
+make_source_repo "$SSHSRC" "ssh://git@example.invalid/owner/repo.git"
+bash "$SETUP" "$SSHSRC" 1 >"$WORK/ssh.log" 2>&1
+assert_eq "an ssh:// user survives" \
+    "ssh://git@example.invalid/owner/repo.git" \
+    "$(git -C "$SSHSRC-isolated-a" remote get-url origin)"
+
+SCPSRC="$WORK/scpsrc"
+make_source_repo "$SCPSRC" "git@example.invalid:owner/repo.git"
+bash "$SETUP" "$SCPSRC" 1 >"$WORK/scp.log" 2>&1
+assert_eq "an scp-style user survives" \
+    "git@example.invalid:owner/repo.git" \
+    "$(git -C "$SCPSRC-isolated-a" remote get-url origin)"
+
+echo "== A source with no origin is handled, not aborted =="
+
+NOORIGIN="$WORK/noorigin"
+make_source_repo "$NOORIGIN"
+bash "$SETUP" "$NOORIGIN" 1 >"$WORK/noorigin.log" 2>&1
+assert_eq "exits 0 without an origin remote" "0" "$?"
+case "$(cat "$WORK/noorigin.log")" in
+    *"no origin remote"*) pass "the note explains the local-path origin" ;;
+    *) fail "the note explains the local-path origin" "$(cat "$WORK/noorigin.log")" ;;
+esac
+
+echo "== Re-running leaves existing clones alone =="
+
+# Idempotency matters because a re-run must not discard whatever an account
+# has been working on.
+printf 'work in progress\n' > "$SRC-isolated-a/wip.txt"
+bash "$SETUP" "$SRC" 2 >"$WORK/rerun.log" 2>&1
+assert_eq "the re-run exits 0" "0" "$?"
+if [[ -f "$SRC-isolated-a/wip.txt" ]]; then
+    pass "uncommitted work in an existing clone survives"
+else
+    fail "uncommitted work in an existing clone survives" "wip.txt was destroyed"
+fi
+case "$(cat "$WORK/rerun.log")" in
+    *"already a clone, left unchanged"*) pass "the re-run says it skipped" ;;
+    *) fail "the re-run says it skipped" "$(cat "$WORK/rerun.log")" ;;
+esac
+
+echo "== A non-git path in the way is refused, not deleted =="
+
+BLOCKED="$WORK/blocked"
+make_source_repo "$BLOCKED"
+mkdir -p "$BLOCKED-isolated-a"
+printf 'do not delete me\n' > "$BLOCKED-isolated-a/precious.txt"
+out="$(bash "$SETUP" "$BLOCKED" 1 2>&1)"; status=$?
+assert_eq "exits non-zero" "1" "$status"
+if [[ -f "$BLOCKED-isolated-a/precious.txt" ]]; then
+    pass "the pre-existing directory is left untouched"
+else
+    fail "the pre-existing directory is left untouched" "precious.txt is gone"
+fi
+case "$out" in
+    *"never deletes host paths"*) pass "the message says it will not delete" ;;
+    *) fail "the message says it will not delete" "$out" ;;
+esac
+
+echo
+echo "== Summary: PASS=$PASS FAIL=$FAIL =="
+[[ $FAIL -eq 0 ]]

--- a/tests/test_transform_syntax_check.sh
+++ b/tests/test_transform_syntax_check.sh
@@ -1,16 +1,26 @@
 #!/usr/bin/env bash
 # test_transform_syntax_check.sh — Validate the post-transform bash -n -c
-# gate added to scripts/entrypoint.sh by issue #180.
+# gate added by issue #180.
 #
-# The test fabricates a mock container settings file containing a mix of
-# runnable and deliberately broken .command entries, then runs the same
-# `jq ... | bash -n -c` loop the entrypoint uses. Passes when every
-# broken entry is detected and every runnable entry is accepted.
+# The gate moved from scripts/entrypoint.sh into
+# scripts/lib/bootstrap-claude.sh in #269. This test did not move with it,
+# because it never referenced it: it carried its own copy of the jq filter and
+# the `bash -n -c` loop and ran the copy. Deleting the block from the real file
+# left the test green (issue #354, item 2).
+#
+# The fingerprint was visible the whole time -- SCRIPT_DIR was computed here
+# and never used, which is what a test that once intended to read the source
+# looks like. Extending shellcheck over tests/ is what surfaced it.
+#
+# Now the jq filter is read out of the real file and the presence of the gate
+# is asserted, so deleting either fails here.
 #
 # Run: bash tests/test_transform_syntax_check.sh
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BOOTSTRAP="$PROJECT_ROOT/scripts/lib/bootstrap-claude.sh"
 
 PASS=0
 FAIL=0
@@ -30,6 +40,42 @@ check_case() {
         FAIL=$((FAIL + 1))
     fi
 }
+
+assert_true() {
+    local label="$1" cond="$2"
+    if [[ "$cond" == "yes" ]]; then
+        printf '  PASS  %s\n' "$label"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL  %s\n' "$label"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "== The gate exists in the file that runs it =="
+
+if [[ ! -r "$BOOTSTRAP" ]]; then
+    printf '  FAIL  %s is readable\n' "$BOOTSTRAP"
+    FAIL=$((FAIL + 1))
+fi
+
+# The two halves of the gate. Either one deleted means transformed hook
+# commands stop being checked, and the user finds out when a hook misfires
+# instead of at container start.
+assert_true "bootstrap-claude.sh still runs bash -n -c on each command" \
+    "$(grep -q 'bash -n -c "\$_cmd"' "$BOOTSTRAP" && echo yes || echo no)"
+assert_true "bootstrap-claude.sh still warns on a failed check" \
+    "$(grep -q 'failed bash syntax check' "$BOOTSTRAP" && echo yes || echo no)"
+
+# The extractor filter is read from the real file rather than restated here,
+# so a change to it flows into the integration case below instead of leaving
+# the test asserting a filter nobody runs.
+JQ_FILTER="$(sed -n 's/.*< <(jq -r '"'"'\(.*\)'"'"' "\$CONTAINER_SETTINGS".*/\1/p' "$BOOTSTRAP" | head -n 1)"
+assert_true "the extractor filter was recovered from bootstrap-claude.sh" \
+    "$([[ -n "$JQ_FILTER" ]] && echo yes || echo no)"
+if [[ -n "$JQ_FILTER" ]]; then
+    printf '        filter: %s\n' "$JQ_FILTER"
+fi
 
 echo "== Runnable commands (the syntax check must accept) =="
 check_case "trivial shell call"        ok  'echo hello'
@@ -82,7 +128,7 @@ while IFS= read -r cmd; do
     if ! bash -n -c "$cmd" 2>/dev/null; then
         broken_count=$((broken_count + 1))
     fi
-done < <(jq -r '.. | objects | .command? // empty | select(type == "string")' "$TMP")
+done < <(jq -r "$JQ_FILTER" "$TMP")
 rm -f "$TMP"
 
 if [[ "$broken_count" -eq 3 ]]; then

--- a/tests/test_workflow_contracts.sh
+++ b/tests/test_workflow_contracts.sh
@@ -135,6 +135,63 @@ echo "== the workflow serializes on the tag =="
 assert_matches 'release-tui.yml declares a concurrency group' "$RELEASE" \
     '^ +group: release-tui-'
 
+echo "== every test file is registered in a CI matrix =="
+
+# The two matrices are hand-maintained lists with nothing checking that they
+# cover the suite. A test file added and not registered is a file that runs
+# nowhere, and looks exactly like one that passes (#354, item 12).
+#
+# scripts/test-*.sh are entry points rather than tests/ members, so they are
+# listed explicitly here too -- test-concurrent-git.sh was registered nowhere,
+# which is why a defect that made it abort on its first container start went
+# unnoticed.
+# "Registered" means some job runs it, not that it sits in a matrix:
+# test_github_account_selection.ps1 is invoked by a `run:` line in the
+# windows-latest job, which counts.
+#
+# Comment lines are excluded. ci.yml's own prose names several test files --
+# the macOS job explains which ones it leaves out and why -- and a comment
+# mentioning a test is the opposite of that test being run.
+#
+# The comment-stripped file is materialized once and matched with a case glob
+# rather than piped into `grep -q`. Under `set -o pipefail`, grep -q exits on
+# its first match, the upstream grep dies of SIGPIPE (141), and the pipeline
+# status is that 141 -- so every lookup reported "not found".
+CI_CODE="$(grep -vE '^[[:space:]]*#' "$CI")"
+is_registered() {
+    case "$CI_CODE" in
+        *"$1"*) return 0 ;;
+    esac
+    return 1
+}
+
+unregistered=()
+while IFS= read -r f; do
+    rel="tests/$(basename "$f")"
+    is_registered "$rel" || unregistered+=("$rel")
+done < <(find "$PROJECT_ROOT/tests" -maxdepth 1 \( -name '*.sh' -o -name '*.ps1' \) -type f | sort)
+
+if [[ ${#unregistered[@]} -eq 0 ]]; then
+    pass 'every tests/*.sh and tests/*.ps1 appears in a ci.yml matrix'
+else
+    fail 'every tests/*.sh and tests/*.ps1 appears in a ci.yml matrix' \
+        "${unregistered[*]}"
+fi
+
+# And the reverse: a matrix entry naming a file that no longer exists would
+# fail the job with "No such file", but only when that entry runs -- which is
+# after every other job has already spent its time.
+missing=()
+while IFS= read -r rel; do
+    [[ -f "$PROJECT_ROOT/$rel" ]] || missing+=("$rel")
+done < <(grep -oE '^ +- (tests|scripts)/[A-Za-z0-9_.-]+\.(sh|ps1)$' "$CI" | sed 's/^ *- //' | sort -u)
+
+if [[ ${#missing[@]} -eq 0 ]]; then
+    pass 'every matrix entry names a file that exists'
+else
+    fail 'every matrix entry names a file that exists' "${missing[*]}"
+fi
+
 echo "== ci.yml declares a read-only token =="
 
 assert_matches 'ci.yml declares workflow-level permissions' "$CI" \


### PR DESCRIPTION
Closes #354
Relates to #343, #356, #357

All thirteen items. **Item 6 was already resolved by #362**, which made `BuildComposeArgs` refuse a missing mode overlay and rewrote the subtest that had been asserting the fail-open — the issue's "a defect now has a test defending it" case.

## Harness strictness

| # | Was | Now |
|---|---|---|
| 1 | `test-entrypoint-settings.sh` exited 0 having asserted nothing when the fixture was absent — and it is the only test of `generate_container_settings` | Zero assertions is a failure that names what it looked for |
| 4 | Three readers compared to each other with no anchor, so a field that does not exist agreed three ways and counted as PASS | `FIELDS` derived from the registry (jq, awk fallback); every declared field must be populated by some runtime |
| 9 | `Assert-Throws` did not compare the message, so eight cases passed on *any* terminating error including a parameter-binding failure | `-MessageLike` is mandatory; the two hand-written try/catch blocks collapse into it |

**Item 4's anchor found something on its first run**: `extraEnv` is declared in the registry, mapped into the Go struct at `runtime.go:38`, empty for all three runtimes and read by nothing. Removing it is a schema change across three readers, so it is exempted here **with the evidence written down** and left to #356. An unexplained waiver would be the same disease.

## Call the real code

| # | Was | Now |
|---|---|---|
| 2 | The test carried its own copy of the jq filter and the `bash -n -c` loop and ran the copy; the gate moved into `lib/bootstrap-claude.sh` in #269 and the test did not follow | The filter is read out of the real file and the gate's presence is asserted |
| 10 | The pwsh leg grepped `Invoke-Scale`'s source for `$newCount -gt 702` — passes for a body containing the literal but never applying it, fails for a refactor extracting it into a constant | Runs the real entry point, same two cases as the bash leg |
| 13 | `test-concurrent-git.sh` used `PROJECT_DIR` for the repo root and then overwrote it with the compose volume source, so every later `-f "$PROJECT_DIR/docker-compose.yml"` pointed at a temp repo with no compose file — under `set -euo pipefail` it could not run past its first container start | Renamed to `REPO_ROOT` |

## Coverage

**Item 3** — `test_cleanup_backups.sh` gave `cleanup.sh` an empty `FAKE_HOME`, so the state-removal branch was never entered and its exit code was discarded with `|| true`. Now populated from the registry, exit code asserted, each runtime's directory must be gone.

Doing that surfaced why it had never worked: `PROJECT_ROOT_OVERRIDE` pointed `cleanup.sh` at a fixture root with no registry, so `runtime_list` returned nothing, the loop iterated zero times, and the script printed **"State directories removed."** having examined nothing. `cleanup.sh` now refuses that instead of reporting it.

**Item 5** — `scripts/setup-isolated.sh` had no test at all. `tests/test_setup_isolated.sh` (24 assertions) covers the two load-bearing details plus the surrounding behaviour:

- **`--no-hardlinks`, asserted by link count**, not by reading the flag. Cloning a local path hardlinks the object store by default, so dropping the flag turns isolated mode into worktree mode with extra steps *while every YAML-level assertion in the suite still passes*. Verified: removing the flag fails this assertion and nothing else.
- The credential strip in `repoint_origin`: userinfo removed from an `https` URL, and an `ssh://` or scp-style user **left alone**, because that is a username and not a secret.
- Non-git source refused; out-of-range count refused; a source with no origin handled rather than aborted; a re-run leaving an existing clone's uncommitted work intact; a non-git path in the way refused rather than deleted.

**Item 7** — the deny-rule assertion counted `select(test("[*]"))` survivors and required zero, which is the same expression the filter uses to remove them. It states the surviving set now. Verified: neutering the filter to keep everything fails it.

Anchoring it surfaced why that had never mattered: **the fixture was used only when `$GITHUB_ACTIONS` was set**, so a developer with a `claude-config` checkout ran the suite against their own configuration while CI ran it against the fixture. Two different inputs, one of them unreviewable. The fixture is the default now.

**Item 8** — `set_env_value` was checked only by reading back through `parse_env_value`, so the parser's behaviour stood in for the file's contents and hid two things:

- **A blank line appended before every added key.** `$(tail -c1 "$file")` strips trailing newlines, so the "does this end in a newline" test was always true. Fixed with `tail -c1 | wc -l`; both directions asserted.
- **The quote round-trip is lossy.** `say "hi" now` is written as `"say \"hi\" now"` and read back with the backslashes, because no reader unescapes — bash, PowerShell and Go all agree. Making it lossless is a lockstep change to three readers and belongs with #356, so the docstring's "lossless" claim is **corrected rather than left untrue**, and the current behaviour is pinned so the change is visible when it happens.

## CI scope

**Item 11** — shellcheck scans the repository instead of `./scripts`, and PSScriptAnalyzer covers `tests/`. Those files hold the assertion helpers, where a defect presents as "the test passes".

Measured before widening: **three findings, all SC2034**, and one of them was item 2's own fingerprint (`SCRIPT_DIR` computed and never used — a test that once intended to read the source). `tests/` was already PSSA-clean. It also caught a tilde-in-a-label in this very change.

**Item 12** — `test_workflow_contracts.sh` now asserts every `tests/*.sh` and `tests/*.ps1` is run by some CI job, and that no matrix entry names a missing file. Two subtleties: registration means *a job runs it* (`test_github_account_selection.ps1` is invoked by a `run:` line, not a matrix entry), and comment lines do not count — `ci.yml`'s prose names several test files. Verified: an unregistered file fails it.

`scripts/test-concurrent-git.sh` stays unregistered **on purpose**, with the reason in the file: it builds the image and starts N containers, and `isolated-up-smoke` plus the compose suites already cover what it would add. What was wrong was that being unregistered *hid a defect*; the defect is fixed.

## Verification

Every guard added here was checked against a mutation, not just observed passing:

| Guard | Mutation | Result |
|---|---|---|
| item 2 | delete `bash -n -c "$_cmd"` from `bootstrap-claude.sh` | FAIL |
| item 5 | drop `--no-hardlinks` | FAIL, that assertion only |
| item 7 | neuter the glob filter | FAIL with both lists shown |
| item 12 | add an unregistered `tests/*.sh` | FAIL naming it |

Suites: `test_setup_isolated.sh` 24, `test_parse_env.sh` 25, `test_cleanup_backups.sh` 25, `test_workflow_contracts.sh` 16, `test_runtime_registry_equivalence.sh` 94 (was 70), `test_num_accounts_precedence.sh` 54 (was 52), `test_container_memory.ps1` 47, `test_isolation_modes.sh` 65, `test_parse_env_equivalence.sh` 44, `test-entrypoint-settings.sh` 16 — all zero failures. Repo-wide shellcheck clean; PSSA over `scripts, tests` clean.

Verified under WSL Ubuntu 24.04 with shellcheck 0.11, jq 1.8.2 and pwsh 7.6.5 installed locally — which is also why `test_isolation_modes.sh` now reports 65 assertions instead of 19: its resolved-compose leg needs `jq` and had been skipping.
