### PR TITLE
fix(tui): bound subprocesses and clamp zero width

### DIFF
--- a/tui/internal/account/gh_auth_timeout_test.go
+++ b/tui/internal/account/gh_auth_timeout_test.go
@@ -1,0 +1,112 @@
+package account
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/kcenon/claude-docker/tui/internal/config"
+	"github.com/kcenon/claude-docker/tui/internal/docker"
+)
+
+// dockerShim installs an executable named `docker` on PATH that answers
+// `compose ... ps` with one running container and hangs forever on `exec`.
+//
+// That split is the point. A shim that hangs on everything never reaches
+// enrichGHAuth, because with no container reported running there is nothing to
+// check the login of -- so it would exercise the PS deadline a second time
+// instead of the `docker exec` one.
+func dockerShim(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH shim needs a POSIX shell; the TUI's CI runs on Linux")
+	}
+	body := "#!/bin/sh\n" +
+		"for a in \"$@\"; do\n" +
+		"  if [ \"$a\" = \"exec\" ]; then sleep 300; fi\n" +
+		"done\n" +
+		`echo '{"ID":"abc123","Service":"claude-a","State":"running","Status":"Up"}'` + "\n"
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "docker"), []byte(body), 0o755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestListAccountsReturnsWhenGHAuthHangs is the acceptance criterion for
+// #358 item 1: a child that never exits must not take ListAccounts with it.
+//
+// Before the fix, the goroutine at manager_helpers.go:157 never returned,
+// enrichAccounts' wg.Wait() blocked forever, and ListAccounts never returned.
+// The dashboard consequence is that m.loading or m.refreshing stays true and
+// `r` is rejected by its own guard, so the operator has no way back. This test
+// would not have failed against that code -- it would have hung until the
+// package timeout, which is the same symptom.
+func TestListAccountsReturnsWhenGHAuthHangs(t *testing.T) {
+	dockerShim(t)
+
+	restore := ghAuthTimeout
+	ghAuthTimeout = 500 * time.Millisecond
+	defer func() { ghAuthTimeout = restore }()
+
+	env := config.NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+	env.Set("NUM_ACCOUNTS", "1")
+	// Point state discovery at an empty HOME so the developer's real
+	// ~/.claude-state cannot make this test depend on their machine.
+	t.Setenv("HOME", t.TempDir())
+
+	mgr := NewManager(env, docker.NewClient(t.TempDir(), env))
+
+	type result struct {
+		accounts []Account
+		err      error
+	}
+	done := make(chan result, 1)
+	start := time.Now()
+	go func() {
+		a, err := mgr.ListAccounts()
+		done <- result{a, err}
+	}()
+
+	select {
+	case r := <-done:
+		elapsed := time.Since(start)
+		if elapsed > 20*time.Second {
+			t.Errorf("ListAccounts took %s; the deadline did not bound it", elapsed)
+		}
+		if r.err != nil {
+			t.Fatalf("ListAccounts: %v", r.err)
+		}
+		if len(r.accounts) != 1 {
+			t.Fatalf("expected 1 account, got %d", len(r.accounts))
+		}
+		// The container is reported running, so the check ran and timed out.
+		// A timeout degrades the same way a failure does.
+		a := r.accounts[0]
+		if a.ContainerStatus != ContainerRunning {
+			t.Fatalf("shim should have reported the container running, got %v", a.ContainerStatus)
+		}
+		if a.GHAuthOK {
+			t.Error("a timed-out gh check must not report the login as verified")
+		}
+		if a.GHLogin != "" {
+			t.Errorf("a timed-out gh check must not invent a login, got %q", a.GHLogin)
+		}
+	case <-time.After(60 * time.Second):
+		t.Fatal("ListAccounts never returned; the whole dashboard would be stuck here")
+	}
+}
+
+// TestGHAuthResultTreatsTimeoutLikeAnyFailure states the degradation contract
+// directly, without a subprocess: ghAuthResult is what turns the error into
+// display state, and it must not distinguish a deadline from a refusal.
+func TestGHAuthResultTreatsTimeoutLikeAnyFailure(t *testing.T) {
+	login, ok, mismatch := ghAuthResult(nil, context.DeadlineExceeded, "someone")
+	if login != "" || ok || mismatch {
+		t.Errorf("got (%q, %v, %v), want (\"\", false, false)", login, ok, mismatch)
+	}
+}

--- a/tui/internal/account/manager_helpers.go
+++ b/tui/internal/account/manager_helpers.go
@@ -1,17 +1,40 @@
 package account
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/kcenon/claude-docker/tui/internal/auth"
 	"github.com/kcenon/claude-docker/tui/internal/config"
 	"github.com/kcenon/claude-docker/tui/internal/docker"
 	"github.com/kcenon/claude-docker/tui/internal/usage"
 )
+
+// ghAuthTimeout bounds the in-container `gh api user` call (#358, item 1).
+//
+// The call reaches api.github.com from inside the container, so a DNS
+// blackhole, a stale connection after host sleep, or a container in the middle
+// of stopping hangs it. Unbounded, that goroutine never returns,
+// enrichAccounts' wg.Wait() blocks forever, and ListAccounts never returns --
+// which leaves m.loading or m.refreshing stuck true, and `r` is rejected by
+// its own guard, so there is no way back except killing the process. Every
+// tick, every finished session and every docker op then starts another
+// Refresh, accumulating hung goroutines and `docker exec` children.
+//
+// A package-level var rather than a const so tests can shorten it. Unexported,
+// so only this package can; the tests that do are not parallel.
+var ghAuthTimeout = 10 * time.Second
+
+// ghAuthKillGrace is the window between killing a timed-out `docker exec` and
+// abandoning its output pipes. `docker exec` hands stdout to a process inside
+// the container, and killing the local client does not close that pipe, so
+// Output() would block past the deadline without this.
+const ghAuthKillGrace = 2 * time.Second
 
 // Helpers for ListAccounts. The orchestrator in manager.go calls these in
 // sequence; each helper owns one phase of the listing workflow and is
@@ -154,8 +177,16 @@ func (m *Manager) enrichGHAuth(a *Account, wg *sync.WaitGroup) {
 	a.GHExpectedLogin = m.env.GHUser(a.Letter)
 	go func() {
 		defer wg.Done()
-		cmd := exec.Command("docker", "exec", a.ContainerID, "gh", "api", "user", "--jq", ".login")
+		ctx, cancel := context.WithTimeout(context.Background(), ghAuthTimeout)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "docker", "exec", a.ContainerID,
+			"gh", "api", "user", "--jq", ".login")
+		cmd.WaitDelay = ghAuthKillGrace
 		out, err := cmd.Output()
+		// A timeout degrades exactly as a failure already does: ghAuthResult
+		// maps any non-nil error to ("", false, false), which the table draws
+		// as FAIL. That is the honest reading -- the check did not confirm the
+		// login -- and it needs no new state to carry.
 		a.GHLogin, a.GHAuthOK, a.GHLoginMismatch = ghAuthResult(out, err, a.GHExpectedLogin)
 	}()
 }

--- a/tui/internal/auth/claude_usage_api.go
+++ b/tui/internal/auth/claude_usage_api.go
@@ -13,7 +13,10 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 )
 
 const usageAPIURL = "https://api.anthropic.com/api/oauth/usage"
@@ -75,9 +78,17 @@ func ReadOAuthToken(credentialsPath string) (string, error) {
 // On 429, returns *RateLimitError immediately so the caller can back off.
 // The caller (TUI auto-retry loop) handles retry cadence externally.
 func FetchUsage(accessToken string) (*UsageAPIResponse, error) {
+	return fetchUsageFrom(usageAPIURL, accessToken)
+}
+
+// fetchUsageFrom is FetchUsage with the endpoint as a parameter, so tests can
+// point it at an httptest server. Splitting the URL out this way keeps
+// usageAPIURL a const; the alternative -- making it a mutable package var --
+// would let any future code in this package repoint the production endpoint.
+func fetchUsageFrom(endpoint, accessToken string) (*UsageAPIResponse, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
 
-	req, err := http.NewRequest("GET", usageAPIURL, nil)
+	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -93,14 +104,26 @@ func FetchUsage(accessToken string) (*UsageAPIResponse, error) {
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
-
+	// 429 is decided by the status alone, so the body is never read for it.
 	if resp.StatusCode == 429 {
 		return nil, &RateLimitError{Attempts: 1}
 	}
 
+	// Bounded read. A valid usage response is well under a kilobyte; anything
+	// larger is a proxy's HTML error page or a captive portal, and the whole of
+	// it used to become the error string, which reaches a.LastAPIStatus and is
+	// drawn per account in the table (#358, item 3).
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxUsageBodyBytes))
+	if readErr != nil {
+		// Previously discarded, so a truncated body went on to json.Unmarshal
+		// and resurfaced as "parse usage response" -- a decoding complaint
+		// about what was actually a connection that dropped mid-read.
+		return nil, fmt.Errorf("read usage response: %w", readErr)
+	}
+
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("usage API returned %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("usage API returned %d: %s",
+			resp.StatusCode, summarizeBody(body))
 	}
 
 	var result UsageAPIResponse
@@ -109,4 +132,52 @@ func FetchUsage(accessToken string) (*UsageAPIResponse, error) {
 	}
 
 	return &result, nil
+}
+
+// maxUsageBodyBytes caps what FetchUsage will read from the response.
+const maxUsageBodyBytes = 64 * 1024
+
+// maxErrorBodyRunes caps how much of a non-200 body reaches the error string.
+const maxErrorBodyRunes = 200
+
+// summarizeBody reduces a response body to something that fits one table cell:
+// newlines, tabs and other control characters collapse to spaces, runs of
+// whitespace collapse to one, and the result is truncated with an ellipsis.
+//
+// The destination is a.LastAPIStatus, which view.go renders per account. A raw
+// HTML error page there does not just look bad -- its newlines break the table
+// apart, and --json output carrying literal control characters is not valid
+// JSON for anything downstream to parse.
+func summarizeBody(body []byte) string {
+	if len(body) == 0 {
+		return "(empty body)"
+	}
+
+	var b strings.Builder
+	b.Grow(len(body))
+	lastWasSpace := false
+	for _, r := range string(body) {
+		if r == utf8.RuneError {
+			r = '?'
+		}
+		if unicode.IsSpace(r) || unicode.IsControl(r) {
+			if !lastWasSpace {
+				b.WriteByte(' ')
+				lastWasSpace = true
+			}
+			continue
+		}
+		b.WriteRune(r)
+		lastWasSpace = false
+	}
+
+	out := strings.TrimSpace(b.String())
+	if out == "" {
+		return "(no printable content)"
+	}
+	runes := []rune(out)
+	if len(runes) > maxErrorBodyRunes {
+		return string(runes[:maxErrorBodyRunes]) + "..."
+	}
+	return out
 }

--- a/tui/internal/auth/gh_timeout_test.go
+++ b/tui/internal/auth/gh_timeout_test.go
@@ -1,0 +1,115 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeGHShim installs an executable named `gh` on PATH for this test.
+func writeGHShim(t *testing.T, body string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH shim needs a POSIX shell; the TUI's CI runs on Linux")
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "gh"), []byte(body), 0o755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func withShortGHTimeout(t *testing.T) {
+	t.Helper()
+	restore := ghTimeout
+	ghTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { ghTimeout = restore })
+}
+
+// TestHostGHTokenTimesOutOnAuthStatus covers gh_token.go:20 (#358, item 2).
+//
+// startGHAuth sets m.busy before dispatching this, and update.go rejects every
+// key while busy is set, so an unbounded hang here leaves the dashboard
+// answering only to quit.
+func TestHostGHTokenTimesOutOnAuthStatus(t *testing.T) {
+	writeGHShim(t, "#!/bin/sh\nsleep 300\n")
+	withShortGHTimeout(t)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := HostGHToken("")
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected an error from a gh that never exits")
+		}
+		if !strings.Contains(err.Error(), "timed out") {
+			t.Errorf("a deadline should not be reported as an auth failure, got: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("HostGHToken never returned")
+	}
+}
+
+// TestHostGHTokenTimesOutOnTokenFetch covers gh_token.go:32. A non-empty user
+// skips the `auth status` probe, so this reaches the second call site with the
+// first one never running.
+func TestHostGHTokenTimesOutOnTokenFetch(t *testing.T) {
+	writeGHShim(t, "#!/bin/sh\nsleep 300\n")
+	withShortGHTimeout(t)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := HostGHToken("someuser")
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected an error from a gh that never exits")
+		}
+		if !strings.Contains(err.Error(), "auth token timed out") {
+			t.Errorf("error should name the token fetch, got: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("HostGHToken never returned")
+	}
+}
+
+// TestHostGHTokenSucceedsAgainstAPromptGH keeps the two timeout tests from
+// passing by way of a gh that can never work.
+func TestHostGHTokenSucceedsAgainstAPromptGH(t *testing.T) {
+	writeGHShim(t, "#!/bin/sh\ncase \"$1\" in\n  \"auth\")\n    case \"$2\" in\n      \"status\") exit 0 ;;\n      \"token\") echo gho_testtoken ;;\n    esac ;;\nesac\n")
+
+	token, err := HostGHToken("")
+	if err != nil {
+		t.Fatalf("HostGHToken: %v", err)
+	}
+	if token != "gho_testtoken" {
+		t.Errorf("token = %q, want gho_testtoken", token)
+	}
+}
+
+// TestHostGHTokenReportsAuthFailureAsAuthFailure pins the other side of the
+// distinction: a gh that exits non-zero quickly is not a timeout.
+func TestHostGHTokenReportsAuthFailureAsAuthFailure(t *testing.T) {
+	writeGHShim(t, "#!/bin/sh\necho 'not logged in' >&2\nexit 1\n")
+
+	_, err := HostGHToken("")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if strings.Contains(err.Error(), "timed out") {
+		t.Errorf("a fast failure must not be reported as a timeout, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "not authenticated") {
+		t.Errorf("error should name the auth failure, got: %v", err)
+	}
+}

--- a/tui/internal/auth/gh_token.go
+++ b/tui/internal/auth/gh_token.go
@@ -2,14 +2,37 @@ package auth
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 )
+
+// ghTimeout bounds both host `gh` invocations (#358, item 2).
+//
+// `gh auth status` contacts github.com, and both calls may consult an OS
+// credential store -- macOS Keychain and Windows Credential Manager can each
+// block on a UI prompt that never appears when the dashboard owns the
+// terminal. startGHAuth sets m.busy before dispatching and update.go rejects
+// every key while it is set, so a hang here leaves the dashboard responding
+// only to quit, with nothing on screen explaining why.
+//
+// A package-level var rather than a const so tests can shorten it. Unexported,
+// so only this package can; the tests that do are not parallel.
+var ghTimeout = 15 * time.Second
+
+// ghKillGrace is the window between killing a timed-out `gh` and abandoning
+// its output pipes, so a child that outlives the kill cannot hold Run() or
+// Output() open past the deadline.
+const ghKillGrace = 2 * time.Second
 
 // HostGHToken returns the GitHub token from the host's gh CLI. A non-empty
 // user selects that stored github.com account explicitly without changing the
 // active host account. An empty user preserves the legacy active-account flow.
+//
+// Both invocations are bounded; a deadline is reported as a timeout rather
+// than as an authentication failure, because the two call for different fixes.
 func HostGHToken(user string) (string, error) {
 	if _, err := exec.LookPath("gh"); err != nil {
 		return "", fmt.Errorf("gh CLI not found on host (install via https://cli.github.com)")
@@ -17,9 +40,15 @@ func HostGHToken(user string) (string, error) {
 
 	if user == "" {
 		var stderr bytes.Buffer
-		check := exec.Command("gh", "auth", "status")
+		ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
+		defer cancel()
+		check := exec.CommandContext(ctx, "gh", "auth", "status")
+		check.WaitDelay = ghKillGrace
 		check.Stderr = &stderr
 		if err := check.Run(); err != nil {
+			if ctx.Err() == context.DeadlineExceeded {
+				return "", fmt.Errorf("gh auth status timed out after %s", ghTimeout)
+			}
 			msg := strings.TrimSpace(stderr.String())
 			if msg == "" {
 				msg = err.Error()
@@ -28,9 +57,16 @@ func HostGHToken(user string) (string, error) {
 		}
 	}
 
+	tokenCtx, tokenCancel := context.WithTimeout(context.Background(), ghTimeout)
+	defer tokenCancel()
 	args := ghTokenArgs(user)
-	out, err := exec.Command("gh", args...).Output()
+	tokenCmd := exec.CommandContext(tokenCtx, "gh", args...)
+	tokenCmd.WaitDelay = ghKillGrace
+	out, err := tokenCmd.Output()
 	if err != nil {
+		if tokenCtx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("gh auth token timed out after %s", ghTimeout)
+		}
 		return "", fmt.Errorf("gh auth token: %w", err)
 	}
 	token := strings.TrimSpace(string(out))

--- a/tui/internal/auth/usage_body_test.go
+++ b/tui/internal/auth/usage_body_test.go
@@ -1,0 +1,148 @@
+package auth
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestSummarizeBody covers the reduction applied to a non-200 body before it
+// becomes an error string (#358, item 3). The destination is
+// a.LastAPIStatus, which view.go draws per account, so a newline in it does
+// not just look wrong -- it breaks the table apart -- and a control character
+// in it makes `claude-docker-tui --json` unparseable.
+func TestSummarizeBody(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", "(empty body)"},
+		{"whitespace only", "\n\t  \r\n", "(no printable content)"},
+		{"single line passes through", "upstream rejected", "upstream rejected"},
+		{"newlines collapse", "line one\nline two\nline three", "line one line two line three"},
+		{"tabs and CR collapse", "a\tb\r\nc", "a b c"},
+		{"runs of whitespace collapse", "a     b", "a b"},
+		{"control characters collapse", "a\x00\x07b", "a b"},
+		{"surrounding whitespace is trimmed", "  hello  ", "hello"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := summarizeBody([]byte(tc.in)); got != tc.want {
+				t.Errorf("summarizeBody(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSummarizeBodyTruncates(t *testing.T) {
+	got := summarizeBody([]byte(strings.Repeat("x", 5000)))
+	if len([]rune(got)) > maxErrorBodyRunes+3 {
+		t.Errorf("summary is %d runes, want at most %d", len([]rune(got)), maxErrorBodyRunes+3)
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Error("a truncated summary should say so")
+	}
+}
+
+// TestFetchUsageBoundsAProxyErrorPage is the end-to-end shape: a proxy answers
+// 502 with a full HTML page, and the whole of it used to become the error.
+func TestFetchUsageBoundsAProxyErrorPage(t *testing.T) {
+	page := "<html>\n<head><title>502 Bad Gateway</title></head>\n<body>\n" +
+		strings.Repeat("<p>the upstream server did not respond</p>\n", 500) +
+		"</body>\n</html>\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(page))
+	}))
+	defer srv.Close()
+
+	_, err := fetchUsageFrom(srv.URL, "token")
+	if err == nil {
+		t.Fatal("expected an error for 502")
+	}
+	msg := err.Error()
+
+	if strings.ContainsAny(msg, "\n\r\t") {
+		t.Errorf("error string must be one line, got:\n%q", msg)
+	}
+	if len(msg) > 400 {
+		t.Errorf("error string is %d bytes; the whole page reached it", len(msg))
+	}
+	if !strings.Contains(msg, "502") {
+		t.Errorf("error should name the status, got: %q", msg)
+	}
+}
+
+// TestFetchUsageOn429IsARateLimitError pins that the rate-limit verdict is the
+// status alone; RateLimitError carries no body.
+func TestFetchUsageOn429IsARateLimitError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte("slow down\nplease\n"))
+	}))
+	defer srv.Close()
+
+	_, err := fetchUsageFrom(srv.URL, "token")
+	var rl *RateLimitError
+	if !errors.As(err, &rl) {
+		t.Fatalf("expected *RateLimitError, got %T: %v", err, err)
+	}
+}
+
+// TestFetchUsageParsesAGoodResponse keeps the bounding from passing by
+// rejecting everything.
+func TestFetchUsageParsesAGoodResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"five_hour":{"utilization":42.0,"resets_at":"2026-08-17T12:00:00Z"}}`))
+	}))
+	defer srv.Close()
+
+	resp, err := fetchUsageFrom(srv.URL, "token")
+	if err != nil {
+		t.Fatalf("fetchUsageFrom: %v", err)
+	}
+	if resp.FiveHour == nil || int(resp.FiveHour.Utilization) != 42 {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+// TestFetchUsageReportsAReadErrorAsARead pins the other half of item 3: a
+// connection that drops mid-body used to reach json.Unmarshal and resurface
+// as "parse usage response", blaming the decoder for a transport failure.
+//
+// Content-Length promises more than the handler writes, then the connection is
+// hijacked and closed, so io.ReadAll returns io.ErrUnexpectedEOF.
+func TestFetchUsageReportsAReadErrorAsARead(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Error("ResponseWriter is not a Hijacker")
+			return
+		}
+		conn, buf, err := hj.Hijack()
+		if err != nil {
+			t.Errorf("hijack: %v", err)
+			return
+		}
+		_, _ = buf.WriteString("HTTP/1.1 200 OK\r\nContent-Length: 4096\r\n\r\n")
+		_, _ = buf.WriteString(`{"five_hour":`)
+		_ = buf.Flush()
+		_ = conn.Close()
+	}))
+	defer srv.Close()
+
+	_, err := fetchUsageFrom(srv.URL, "token")
+	if err == nil {
+		t.Fatal("expected an error from a truncated body")
+	}
+	if strings.Contains(err.Error(), "parse usage response") {
+		t.Errorf("a transport failure must not be reported as a parse failure, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "read usage response") {
+		t.Errorf("error should name the read, got: %v", err)
+	}
+}

--- a/tui/internal/docker/client.go
+++ b/tui/internal/docker/client.go
@@ -2,13 +2,37 @@ package docker
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/kcenon/claude-docker/tui/internal/config"
 )
+
+// psTimeout bounds `docker compose ps` (#358, item 1).
+//
+// Every dashboard refresh blocks on this call, and an unbounded one leaves
+// ListAccounts with no return path: m.refreshing never clears, so the `r` key
+// is rejected by its own guard and the operator cannot recover without killing
+// the process. A daemon that is starting, a socket that is not answering, or a
+// context switch to an unreachable remote all reach the same state.
+//
+// A package-level var rather than a const so tests can shorten it. Unexported,
+// so only this package can; the tests that do are not parallel.
+var psTimeout = 10 * time.Second
+
+// killGrace is how long a timed-out child gets between SIGKILL and giving up
+// on its output pipes.
+//
+// exec.CommandContext kills the process when the context expires, but Output()
+// waits for the pipes to close, and `docker exec` hands its stdout to a
+// grandchild inside the container. Killing the local docker client does not
+// close that pipe, so without WaitDelay the read blocks anyway and the timeout
+// buys nothing.
+const killGrace = 2 * time.Second
 
 // Client wraps docker compose invocations.
 type Client struct {
@@ -37,9 +61,17 @@ func (c *Client) PS() ([]ContainerInfo, error) {
 		return nil, err
 	}
 	args := append(base, "ps", "--format", "json", "--all")
-	cmd := exec.Command("docker", args...)
+	ctx, cancel := context.WithTimeout(context.Background(), psTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.WaitDelay = killGrace
 	out, err := cmd.Output()
 	if err != nil {
+		// Report the deadline as a deadline. Wrapping the raw "signal: killed"
+		// would tell the operator their docker client crashed.
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("docker compose ps timed out after %s", psTimeout)
+		}
 		return nil, fmt.Errorf("docker compose ps: %w", err)
 	}
 	return parseComposePS(string(out))
@@ -77,6 +109,11 @@ func parseComposePS(out string) ([]ContainerInfo, error) {
 }
 
 // Up starts all services detached.
+//
+// Deliberately unbounded, unlike PS. `up -d` legitimately runs for minutes
+// when it has to pull or build, and a deadline here would abort a working
+// operation partway. It is also operator-initiated with a toast explaining
+// the wait, where PS runs on every refresh with nothing on screen to say so.
 func (c *Client) Up() error {
 	base, err := BuildComposeArgs(c.projectRoot, c.env)
 	if err != nil {

--- a/tui/internal/docker/ps_timeout_test.go
+++ b/tui/internal/docker/ps_timeout_test.go
@@ -1,0 +1,91 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kcenon/claude-docker/tui/internal/config"
+)
+
+// writeShim puts an executable script named `name` in a fresh directory and
+// prepends that directory to PATH for the duration of the test.
+//
+// A shim is used rather than a mock because the defect is in how the process
+// is launched, not in what is done with its output: only a real child that
+// really does not exit can show that the deadline reaches it.
+func writeShim(t *testing.T, name, body string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH shim needs a POSIX shell; the TUI's CI runs on Linux")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestPSTimesOutOnAHangingDocker pins issue #358 item 1 for the PS call site.
+//
+// Before the fix this test would not fail -- it would hang until `go test`
+// killed the whole package after its 10-minute default timeout, which is the
+// dashboard's symptom in miniature.
+func TestPSTimesOutOnAHangingDocker(t *testing.T) {
+	writeShim(t, "docker", "#!/bin/sh\nsleep 300\n")
+
+	restore := psTimeout
+	psTimeout = 300 * time.Millisecond
+	defer func() { psTimeout = restore }()
+
+	env := config.NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+	client := NewClient(t.TempDir(), env)
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		_, err := client.PS()
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		elapsed := time.Since(start)
+		if err == nil {
+			t.Fatal("PS returned nil error against a docker that never exits")
+		}
+		if !strings.Contains(err.Error(), "timed out") {
+			t.Errorf("error should name the deadline, got: %v", err)
+		}
+		// Generous: the assertion is "bounded", not "bounded precisely". The
+		// bound that matters is that it is not 300 seconds.
+		if elapsed > 10*time.Second {
+			t.Errorf("PS took %s, expected roughly %s", elapsed, psTimeout)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("PS never returned; the deadline did not reach the child")
+	}
+}
+
+// TestPSSucceedsAgainstAPromptDocker keeps the timeout from passing by
+// rejecting everything: a docker that answers is still parsed normally.
+func TestPSSucceedsAgainstAPromptDocker(t *testing.T) {
+	writeShim(t, "docker",
+		"#!/bin/sh\n"+
+			`echo '{"ID":"abc123","Service":"claude-a","State":"running","Status":"Up 2 hours"}'`+"\n")
+
+	env := config.NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+	client := NewClient(t.TempDir(), env)
+
+	infos, err := client.PS()
+	if err != nil {
+		t.Fatalf("PS: %v", err)
+	}
+	if len(infos) != 1 || infos[0].Service != "claude-a" || infos[0].State != "running" {
+		t.Fatalf("unexpected parse: %+v", infos)
+	}
+}

--- a/tui/internal/ui/dashboard/render.go
+++ b/tui/internal/ui/dashboard/render.go
@@ -52,6 +52,24 @@ func renderIsolationBanner(env *config.Env) string {
 	return out + "\n\n"
 }
 
+// ruleWidth returns how many rule characters fit under the header, never
+// fewer than zero.
+//
+// 76 is the width of the six header columns; 4 is the two-space indent on each
+// side. A width the model has not been told about yet is 0, which made the
+// subtraction negative.
+func ruleWidth(width int) int {
+	const (
+		maxRule = 76
+		margin  = 4
+	)
+	n := min(maxRule, width-margin)
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
 func renderAccountTable(accounts []account.Account, cursor int, width int) string {
 	var b strings.Builder
 
@@ -74,8 +92,15 @@ func renderAccountTable(accounts []account.Account, cursor int, width int) strin
 	b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#9CA3AF")).
 		Render(header) + "\n")
 
+	// strings.Repeat panics on a negative count, and min(76, width-4) is -4 at
+	// width 0 (#358, item 4). bubbletea returns early from checkResize when
+	// p.ttyOutput is nil (tty.go:121-125), so a non-TTY stdout --
+	// `claude-docker-tui | tee log.txt` -- never delivers a WindowSizeMsg and
+	// the model keeps its zero width. The rule is clamped rather than the
+	// terminal defaulted, because this is the only arithmetic on width in the
+	// package and a default would have to be re-justified everywhere else.
 	b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("#374151")).
-		Render("  "+strings.Repeat("─", min(76, width-4))) + "\n")
+		Render("  "+strings.Repeat("─", ruleWidth(width))) + "\n")
 
 	// Styles
 	styleGreen := lipgloss.NewStyle().Foreground(lipgloss.Color("#22C55E"))

--- a/tui/internal/ui/dashboard/render_test.go
+++ b/tui/internal/ui/dashboard/render_test.go
@@ -147,12 +147,12 @@ func TestDashboardRendersGeminiAccounts(t *testing.T) {
 	mgr := account.NewManager(env, client)
 
 	model := New(mgr, client, env, false)
-	// The size is applied before the program starts as well as on the
-	// WindowSizeMsg teatest sends, because that message races the initial
-	// load command: renderAccountTable computes strings.Repeat("-", width-4)
-	// and would panic on a zero width if accounts arrived first.
-	model.SetSize(renderTermWidth, renderTermHeight-4)
-
+	// No pre-emptive SetSize. It used to be applied here as well as on the
+	// WindowSizeMsg teatest sends, because that message races the initial load
+	// command and renderAccountTable panicked on a zero width if accounts
+	// arrived first -- a live bug neutralized inside the test. ruleWidth
+	// clamps at the call site now, and TestViewAtZeroWidthDoesNotPanic covers
+	// the case directly.
 	tm := teatest.NewTestModel(t, testApp{dash: model},
 		teatest.WithInitialTermSize(renderTermWidth, renderTermHeight))
 

--- a/tui/internal/ui/dashboard/zero_width_test.go
+++ b/tui/internal/ui/dashboard/zero_width_test.go
@@ -1,0 +1,123 @@
+package dashboard
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kcenon/claude-docker/tui/internal/account"
+	"github.com/kcenon/claude-docker/tui/internal/config"
+)
+
+// TestRuleWidth states the clamp directly (#358, item 4). 76 is the width of
+// the six header columns and 4 is the indent on each side, so the interesting
+// values are the ones where width-4 goes negative.
+func TestRuleWidth(t *testing.T) {
+	cases := []struct {
+		width int
+		want  int
+	}{
+		{0, 0},   // never sized: strings.Repeat panicked on -4
+		{1, 0},   // still negative
+		{4, 0},   // exactly the margin
+		{5, 1},   // first positive
+		{40, 36}, // narrow terminal, rule shrinks with it
+		{80, 76}, // the cap
+		{200, 76},
+		{-10, 0}, // defensive: a width no caller should produce
+	}
+	for _, tc := range cases {
+		if got := ruleWidth(tc.width); got != tc.want {
+			t.Errorf("ruleWidth(%d) = %d, want %d", tc.width, got, tc.want)
+		}
+	}
+}
+
+// TestViewAtZeroWidthDoesNotPanic is the acceptance criterion: View() with
+// accounts loaded and no SetSize must return.
+//
+// The path is real, not theoretical. bubbletea v1.3.10 returns early from
+// checkResize when p.ttyOutput is nil (tty.go:121-125), so a non-TTY stdout --
+// `claude-docker-tui | tee log.txt` -- never delivers a WindowSizeMsg and the
+// model keeps the zero width it was constructed with.
+//
+// render_test.go used to work around this with a pre-emptive SetSize before
+// starting the program, with a comment saying why; that workaround is gone.
+func TestViewAtZeroWidthDoesNotPanic(t *testing.T) {
+	env := config.NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+
+	m := New(nil, nil, env, false)
+	m.loading = false
+	m.accounts = []account.Account{
+		{Letter: "a", ServiceName: "claude-a", ContainerStatus: account.ContainerRunning, ContainerID: "abc"},
+		{Letter: "b", ServiceName: "claude-b"},
+	}
+
+	if m.width != 0 {
+		t.Fatalf("precondition: width should be 0, got %d", m.width)
+	}
+
+	out := m.View() // panicked here before the clamp
+	if !strings.Contains(out, "claude-a") {
+		t.Errorf("the table should still render its rows at width 0:\n%s", out)
+	}
+}
+
+// TestViewAtZeroWidthWithStatusDetail exercises the branch that also draws the
+// per-account API status lines, since those are appended after the table.
+func TestViewAtZeroWidthWithStatusDetail(t *testing.T) {
+	env := config.NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+
+	m := New(nil, nil, env, false)
+	m.loading = false
+	m.refreshing = true
+	m.accounts = []account.Account{
+		{Letter: "a", ServiceName: "claude-a", APIRateLimited: true, LastAPIStatus: "HTTP 429 (rate limited)"},
+	}
+
+	out := m.View()
+	if !strings.Contains(out, "HTTP 429") {
+		t.Errorf("expected the API status line:\n%s", out)
+	}
+}
+
+// TestRefreshCompletionClearsRefreshing is the second half of the item 1
+// acceptance criterion: once ListAccounts returns, the dashboard has to be
+// usable again. The timeout makes the message arrive; this is what the
+// message does when it does.
+func TestRefreshCompletionClearsRefreshing(t *testing.T) {
+	env := config.NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+
+	m := New(nil, nil, env, false)
+	m.refreshing = true
+	m.loading = true
+
+	m, _ = m.Update(accountsLoadedMsg{
+		accounts: []account.Account{{Letter: "a", ServiceName: "claude-a"}},
+	})
+
+	if m.refreshing {
+		t.Error("refreshing should clear when the load completes")
+	}
+	if m.loading {
+		t.Error("loading should clear when the load completes")
+	}
+}
+
+// TestErrorFromRefreshReachesTheModel guards the degradation path the timeout
+// opened up: PS now returns a deadline error instead of hanging, and that
+// error has to be visible rather than swallowed into an empty table.
+func TestErrorFromRefreshReachesTheModel(t *testing.T) {
+	env := config.NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+
+	m := New(nil, nil, env, false)
+	m.loading = true
+
+	m, _ = m.Update(accountsLoadedMsg{err: errors.New("docker compose ps timed out after 10s")})
+
+	out := m.View()
+	if !strings.Contains(out, "timed out") {
+		t.Errorf("the deadline should reach the screen:\n%s", out)
+	}
+}


### PR DESCRIPTION
Relates to #358 (items 1-4), #343, #351

First of three PRs for #358. The issue has 15 items and 18 acceptance criteria across 16 files; this is the subset with **user-visible consequences**. B (state writes, JSON output, project root) and C (correctness debt) follow.

## What

| # | Defect | Consequence |
|---|---|---|
| 1 | `manager_helpers.go:157` — `docker exec ... gh api user` unbounded | the dashboard deadlocks permanently, with no key that recovers it |
| 2 | `gh_token.go:20,32` — host `gh` unbounded | every key except quit stops working, with nothing on screen saying why |
| 3 | `claude_usage_api.go:96,103` — response body read unbounded and used whole as the error | a proxy's HTML error page is printed into the account table |
| 4 | `render.go:66` — `strings.Repeat` with a negative count | panic at `width == 0` |

`docker/client.go:36` (`PS`) had the same unbounded shape as #1 and is fixed with it.

## Why each one bites

**#1 is the worst of the four.** `ListAccounts` has no return path once that goroutine hangs: `enrichAccounts`' `wg.Wait()` blocks forever. Downstream, whichever of `m.loading` / `m.refreshing` was set stays set — and `r` is rejected by `if m.refreshing { return m, nil }`, so manual recovery is impossible. An active tick chain reschedules every second against the stuck refresh, and `sessionFinishedMsg` and `dockerOpDoneMsg` each start another `Refresh`, so hung goroutines and `docker exec` children accumulate for as long as the process lives.

**#3 has two halves.** The error string reaches `a.LastAPIStatus` and is rendered per account at `view.go:92-97`, so an HTML page there does not merely look wrong — its newlines break the table apart, and control characters in it make `--json` output unparseable. Separately, the discarded read error meant a body truncated by a dropped connection went on to `json.Unmarshal` and came back as `parse usage response`: a decoding complaint about a transport failure.

**#4 was already known.** It was discovered while authoring `render_test.go` and neutralized *inside the test* rather than at the call site:

```go
// The size is applied before the program starts as well as on the
// WindowSizeMsg teatest sends, because that message races the initial
// load command: renderAccountTable computes strings.Repeat("-", width-4)
// and would panic on a zero width if accounts arrived first.
model.SetSize(renderTermWidth, renderTermHeight-4)
```

That workaround is deleted in this PR, which is the acceptance criterion.

## How

`exec.CommandContext` with a bounded deadline at all four sites, **plus `cmd.WaitDelay`**. The context alone is not enough: it kills the process, but `Output()` waits for the pipes to close, and `docker exec` hands its stdout to a process *inside* the container. Killing the local docker client does not close that pipe, so without `WaitDelay` the read blocks past the deadline and the timeout buys nothing.

A timed-out `gh api user` degrades exactly as a failed one already does — `ghAuthResult` maps any non-nil error to `("", false, false)`, which the table draws as `FAIL`. That is the honest reading (the check did not confirm the login) and it needs no new state.

Deadlines are reported as deadlines, not as the failure they superficially resemble: `gh auth status` timing out is not "not authenticated", and `docker compose ps` timing out is not "your docker client crashed". They call for different fixes.

Timeouts are unexported package **vars** rather than consts so tests can shorten them; the tests that do are not parallel.

`ruleWidth` clamps at the call site rather than defaulting `Model.width` to 80 in `New`, because this is the only arithmetic on width in the package and a default would have to be re-justified at every other reader.

`Up` and `Down` are left unbounded **on purpose**, with a comment saying so: they legitimately run for minutes when they pull or build, they are operator-initiated with a toast explaining the wait, and a deadline would abort a working operation partway. `PS` is the opposite on every count.

## Verification

`go test -race ./...`, `go vet ./...`, `gofmt -l .` — all clean. 5 new test files, 24 new assertions.

**Mutation-tested, one revert per fix.** Red-first by re-running is not available here: against the unfixed code these tests do not fail, they *hang* — which is the defect. So each fix is reverted individually in a temp copy and the matching test is run under `-timeout 40s`:

```
=== baseline ===                                     all ok
M1  PS back to exec.Command          -> FAIL: TestPSTimesOutOnAHangingDocker (30.02s)
M2  gh api user back to exec.Command -> panic: test timed out after 40s
M3  gh auth status back to exec.Command -> FAIL: TestHostGHTokenTimesOutOnAuthStatus (30.01s)
M4  error body unbounded again       -> FAIL: TestFetchUsageBoundsAProxyErrorPage
M5  read error discarded again       -> FAIL: TestFetchUsageReportsAReadErrorAsARead
M6  rule width unclamped again       -> FAIL: TestViewAtZeroWidthDoesNotPanic
```

M2 is worth reading literally: `panic: test timed out` **is** the bug. The goroutine never returns, so the test process has to be killed — the dashboard in miniature.

Every timeout test is paired with a success-path test, so none of them can pass by rejecting everything:

- `TestPSSucceedsAgainstAPromptDocker` — a docker that answers is still parsed
- `TestHostGHTokenSucceedsAgainstAPromptGH` — a working gh still yields its token
- `TestHostGHTokenReportsAuthFailureAsAuthFailure` — a fast non-zero exit is *not* reported as a timeout
- `TestFetchUsageParsesAGoodResponse` — a valid body still decodes

The subprocess tests use real PATH shims rather than mocks: the defect is in how the process is launched, so only a child that really does not exit can show the deadline reaching it. They skip on Windows (the shim needs a POSIX shell); the `go-test` job runs on ubuntu.

### What is not covered

No live container and no real GitHub call. `TestListAccountsReturnsWhenGHAuthHangs` drives the whole `ListAccounts` path against a shim that answers `compose ps` with a running container and hangs on `exec` — that split is deliberate, because a shim that hangs on everything never reaches `enrichGHAuth` at all and would just exercise the `PS` deadline twice.

## Where

- `tui/internal/account/manager_helpers.go` — `enrichGHAuth`
- `tui/internal/auth/gh_token.go` — `HostGHToken`, both call sites
- `tui/internal/auth/claude_usage_api.go` — `FetchUsage`, new `fetchUsageFrom` and `summarizeBody`
- `tui/internal/docker/client.go` — `PS`
- `tui/internal/ui/dashboard/render.go` — new `ruleWidth`
- `tui/internal/ui/dashboard/render_test.go` — the `SetSize` workaround, removed
- new: `ps_timeout_test.go`, `gh_timeout_test.go`, `usage_body_test.go`, `gh_auth_timeout_test.go`, `zero_width_test.go`
