### PR TITLE
fix(tui): make state writes safe and output well formed

### DIFF
--- a/tui/internal/account/manager.go
+++ b/tui/internal/account/manager.go
@@ -5,8 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
+	"sync"
 	"time"
 
 	"github.com/kcenon/claude-docker/tui/internal/auth"
@@ -24,11 +23,20 @@ type Manager struct {
 	// instead of being re-read and re-decoded, which keeps refresh cost
 	// proportional to changed data rather than total accumulated history.
 	usageCache *usage.Cache
+	// cooldowns tracks per-account API backoff in memory. It was a file in
+	// each state directory until #358; see apiCooldowns for why that was a
+	// worse place for a 25-second value with no cross-process reader.
+	cooldowns *apiCooldowns
 }
 
 // NewManager creates an account manager.
 func NewManager(env *config.Env, client *docker.Client) *Manager {
-	return &Manager{env: env, client: client, usageCache: usage.NewCache()}
+	return &Manager{
+		env:        env,
+		client:     client,
+		usageCache: usage.NewCache(),
+		cooldowns:  newAPICooldowns(),
+	}
 }
 
 // ListAccounts returns all configured accounts with enriched runtime status.
@@ -142,8 +150,11 @@ func isResetPassed(resetAt string, now time.Time) bool {
 	return now.After(t)
 }
 
-// writeLimitlineCache writes API response to disk in the same format as claude-limitline.
-func writeLimitlineCache(path string, resp *auth.UsageAPIResponse) {
+// writeLimitlineCache writes API response to disk in the same format as
+// claude-limitline. Returns an error so the caller can decide; the write is
+// still best-effort, but "best-effort" now means a caller chose to ignore it
+// rather than the function having nothing to report.
+func writeLimitlineCache(path string, resp *auth.UsageAPIResponse) error {
 	cache := map[string]interface{}{
 		"timestamp": time.Now().UnixMilli(),
 		"usage": map[string]interface{}{
@@ -172,41 +183,110 @@ func writeLimitlineCache(path string, resp *auth.UsageAPIResponse) {
 
 	data, err := json.Marshal(cache)
 	if err != nil {
-		return
+		return fmt.Errorf("marshal limitline cache: %w", err)
 	}
-	os.WriteFile(path, data, 0644)
+	return writeFileAtomic(path, data)
 }
 
-const apiCooldownFile = ".tui-api-cooldown"
+// writeFileAtomic writes data to path through a temp file in the same
+// directory, chmods it 0600, and renames it into place (#358, item 5).
+//
+// Two reasons, both real for limitline-usage-cache.json:
+//
+//   - The host's claude-limitline tool writes the same file. os.WriteFile
+//     truncates and then writes, so a read interleaved with it sees a
+//     truncated document; parseLimitlineCache returns (nil, nil) for that and
+//     the dashboard draws "--" with nothing said about why. A rename is
+//     atomic, so a reader sees either the old file or the new one.
+//   - 0644 made a file describing an account's API usage world-readable. 0600
+//     matches what Env.Save already does for .env, and what install.sh sets
+//     for the credentials file next to it.
+//
+// The sequence is Env.Save's; it existed in-tree and was simply not applied
+// here.
+func writeFileAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create tmp: %w", err)
+	}
+	tmpName := tmp.Name()
+	// Removes the temp file on every failure path below; a no-op once the
+	// rename has consumed it.
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close tmp: %w", err)
+	}
+	if err := os.Chmod(tmpName, 0600); err != nil {
+		return fmt.Errorf("chmod tmp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}
+
 const apiCooldownDuration = 25 * time.Second
 
-// isAPICooldownActive returns true if the API was recently rate-limited
-// and we should skip retrying for this account.
-func isAPICooldownActive(stateDirPath string) bool {
-	data, err := os.ReadFile(filepath.Join(stateDirPath, apiCooldownFile))
-	if err != nil {
-		return false
-	}
-	ts, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
-	if err != nil {
-		return false
-	}
-	return time.Since(time.UnixMilli(ts)) < apiCooldownDuration
+// apiCooldowns records, per account letter, when the usage API last returned
+// 429 (#358, item 5).
+//
+// This used to be a .tui-api-cooldown file in each account state directory.
+// Nothing else in the repository reads that file -- no script, no other Go
+// package -- and the value lives for 25 seconds, so the filesystem bought
+// nothing and cost two things: a read-only state directory made every write
+// fail with no signal at all, and the stale files outlived the process that
+// wrote them.
+//
+// Guarded by its own mutex because enrichAPIUsage records a 429 from a
+// per-account goroutine while the others are still running.
+type apiCooldowns struct {
+	mu sync.Mutex
+	at map[string]time.Time
 }
 
-// writeAPICooldown records that the API returned 429 for this account.
-func writeAPICooldown(stateDirPath string) {
-	ts := fmt.Sprintf("%d", time.Now().UnixMilli())
-	os.WriteFile(filepath.Join(stateDirPath, apiCooldownFile), []byte(ts), 0644)
+func newAPICooldowns() *apiCooldowns {
+	return &apiCooldowns{at: make(map[string]time.Time)}
 }
 
-// ClearAPICooldowns removes all API cooldown files so the next refresh retries the API.
+// active reports whether this account is still inside its backoff window.
+func (c *apiCooldowns) active(letter string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	t, ok := c.at[letter]
+	return ok && time.Since(t) < apiCooldownDuration
+}
+
+// record marks this account as rate-limited as of now.
+func (c *apiCooldowns) record(letter string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.at[letter] = time.Now()
+}
+
+// clearExpired drops only the entries whose window has elapsed.
+func (c *apiCooldowns) clearExpired() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for letter, t := range c.at {
+		if time.Since(t) >= apiCooldownDuration {
+			delete(c.at, letter)
+		}
+	}
+}
+
+// ClearAPICooldowns drops expired cooldowns so the next refresh retries the
+// API for those accounts.
+//
+// Expired ones only. The `r` key called this unconditionally, which cleared a
+// cooldown recorded a second ago and re-issued the call the 429 was telling us
+// to stop making -- the 25s backoff existed but any keypress skipped it
+// (#358, item 10 is the same defect seen from update.go).
 func (m *Manager) ClearAPICooldowns() {
-	if m.env != nil && !m.env.SupportsClaudeUsage() {
-		return
-	}
-	stateDirs, _ := config.DiscoverStateDirsForRuntime(config.RuntimeClaude)
-	for _, sd := range stateDirs {
-		os.Remove(filepath.Join(sd.Path, apiCooldownFile))
-	}
+	m.cooldowns.clearExpired()
 }

--- a/tui/internal/account/manager_helpers.go
+++ b/tui/internal/account/manager_helpers.go
@@ -189,7 +189,7 @@ func (m *Manager) enrichAPIUsage(a *Account, results map[string]apiResult, mu *s
 		a.LastAPIStatus = "cached (fresh)"
 		return
 	}
-	if isAPICooldownActive(a.StateDirPath) {
+	if m.cooldowns.active(a.Letter) {
 		a.APIRateLimited = true
 		a.LastAPIStatus = "skipped (cooldown active)"
 		return
@@ -208,7 +208,7 @@ func (m *Manager) enrichAPIUsage(a *Account, results map[string]apiResult, mu *s
 		if err != nil {
 			var rlErr *auth.RateLimitError
 			if errors.As(err, &rlErr) {
-				writeAPICooldown(a.StateDirPath)
+				m.cooldowns.record(a.Letter)
 				a.APIRateLimited = true
 				a.LastAPIStatus = "HTTP 429 (rate limited)"
 			} else {
@@ -239,15 +239,24 @@ func (m *Manager) enrichAPIUsage(a *Account, results map[string]apiResult, mu *s
 
 // writeCacheUpdates persists successful API responses to disk so the next
 // listing can read from the limitline cache instead of hitting the API.
-// Failures here are intentionally swallowed: cache writes are best-effort
-// and must not fail the listing.
+//
+// A failure must not fail the listing -- the dashboard is still correct
+// without the cache, it just re-fetches next time -- but it is no longer
+// silent. A read-only state directory used to produce no output at all, which
+// is indistinguishable from a cache that is working.
 func (m *Manager) writeCacheUpdates(accounts []Account, results map[string]apiResult) {
-	for _, a := range accounts {
+	for i := range accounts {
+		a := &accounts[i]
 		r, ok := results[a.Letter]
 		if !ok {
 			continue
 		}
 		sd := config.StateDir{Letter: a.Letter, Path: r.stateDirPath}
-		writeLimitlineCache(sd.LimitlineCachePath(), r.resp)
+		if err := writeLimitlineCache(sd.LimitlineCachePath(), r.resp); err != nil {
+			// LastAPIStatus is the per-account diagnostic line the dashboard
+			// already renders, so the report lands next to the account it
+			// concerns rather than on a stderr nobody is watching.
+			a.LastAPIStatus += " (cache write failed)"
+		}
 	}
 }

--- a/tui/internal/account/manager_helpers_test.go
+++ b/tui/internal/account/manager_helpers_test.go
@@ -275,6 +275,10 @@ func TestEnrichAPIUsage_CachedFresh(t *testing.T) {
 
 // TestEnrichAPIUsage_CooldownActive verifies that an account inside the
 // per-account cooldown window is marked rate-limited and skips the API.
+//
+// The cooldown moved from a .tui-api-cooldown file in the state directory to
+// manager-scoped memory (#358, item 5), so this stages it through the manager
+// rather than by writing a file.
 func TestEnrichAPIUsage_CooldownActive(t *testing.T) {
 	m := newTestManager(t, nil)
 	results := make(map[string]apiResult)
@@ -282,11 +286,7 @@ func TestEnrichAPIUsage_CooldownActive(t *testing.T) {
 	var wg sync.WaitGroup
 
 	dir := t.TempDir()
-	cooldownPath := filepath.Join(dir, apiCooldownFile)
-	now := time.Now().UnixMilli()
-	if err := os.WriteFile(cooldownPath, []byte(fmt.Sprintf("%d", now)), 0644); err != nil {
-		t.Fatalf("write cooldown: %v", err)
-	}
+	m.cooldowns.record("a")
 
 	acct := &Account{Letter: "a", AuthType: AuthOAuth, StateDirPath: dir}
 	m.enrichAPIUsage(acct, results, &mu, &wg)

--- a/tui/internal/account/state_write_test.go
+++ b/tui/internal/account/state_write_test.go
@@ -1,0 +1,313 @@
+package account
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kcenon/claude-docker/tui/internal/auth"
+)
+
+func sampleResponse() *auth.UsageAPIResponse {
+	return &auth.UsageAPIResponse{
+		FiveHour: &auth.UsageBucket{
+			Utilization: 17,
+			ResetsAt:    time.Now().Add(time.Hour).Format(time.RFC3339),
+		},
+		SevenDay: &auth.UsageBucket{
+			Utilization: 63,
+			ResetsAt:    time.Now().Add(48 * time.Hour).Format(time.RFC3339),
+		},
+	}
+}
+
+// TestLimitlineCacheIsWrittenOwnerOnly covers the permission half of #358
+// item 5. The file describes an account's API usage and was 0644.
+func TestLimitlineCacheIsWrittenOwnerOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix mode bits are not meaningful against NTFS")
+	}
+	path := filepath.Join(t.TempDir(), "limitline-usage-cache.json")
+	if err := writeLimitlineCache(path, sampleResponse()); err != nil {
+		t.Fatalf("writeLimitlineCache: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("mode = %04o, want 0600", perm)
+	}
+}
+
+// TestLimitlineCacheLeavesNoTempFiles pins that the rename consumed the temp
+// file. A leaked <name>.tmp-* per refresh would be the codex hooks.stale bug
+// in a different directory.
+func TestLimitlineCacheLeavesNoTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "limitline-usage-cache.json")
+	for i := 0; i < 3; i++ {
+		if err := writeLimitlineCache(path, sampleResponse()); err != nil {
+			t.Fatalf("writeLimitlineCache: %v", err)
+		}
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp-") {
+			t.Errorf("temp file left behind: %s", e.Name())
+		}
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected exactly one file, got %d", len(entries))
+	}
+}
+
+// TestWriteFileAtomicIsNeverPartiallyVisible is the atomicity claim (#358
+// item 5). The host's claude-limitline tool writes the same path, so a reader
+// can land between an os.WriteFile truncate and its write;
+// parseLimitlineCache returns (nil, nil) for a truncated document and the
+// dashboard draws "--" with nothing said about why.
+//
+// The payload is deliberately large. A real cache document is a few hundred
+// bytes, which the kernel writes in one go, so the torn window is too small to
+// observe and the same test against os.WriteFile passes -- proving nothing.
+// At four megabytes the window is wide enough that a non-atomic writer is
+// caught on the first round; the mutation run confirms it is.
+//
+// A writer and a reader run concurrently. Every read must see either nothing
+// or a complete document, never a partial one.
+func TestWriteFileAtomicIsNeverPartiallyVisible(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.json")
+
+	// Valid JSON whose length makes the write observable.
+	payload := []byte(`{"filler":"` + strings.Repeat("x", 4*1024*1024) + `"}`)
+
+	const rounds = 20
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	var partial int
+	var mu sync.Mutex
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			data, err := os.ReadFile(path)
+			if err != nil || len(data) == 0 {
+				continue // not created yet
+			}
+			var probe map[string]any
+			if err := json.Unmarshal(data, &probe); err != nil {
+				mu.Lock()
+				partial++
+				mu.Unlock()
+			}
+		}
+	}()
+
+	for i := 0; i < rounds; i++ {
+		if err := writeFileAtomic(path, payload); err != nil {
+			t.Fatalf("writeFileAtomic: %v", err)
+		}
+	}
+	close(stop)
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if partial != 0 {
+		t.Errorf("%d reads saw a truncated document; the write is not atomic", partial)
+	}
+}
+
+// TestLimitlineCacheIsNeverPartiallyVisible is the same check at the real
+// call site and the real payload size. It cannot discriminate on its own --
+// see the note above -- but it does confirm the cache writer routes through
+// the atomic primitive and produces a document that parses every time.
+func TestLimitlineCacheIsNeverPartiallyVisible(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "limitline-usage-cache.json")
+
+	const rounds = 300
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	var partial int
+	var mu sync.Mutex
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			data, err := os.ReadFile(path)
+			if err != nil || len(data) == 0 {
+				continue // not created yet, or caught between rename calls
+			}
+			var probe map[string]any
+			if err := json.Unmarshal(data, &probe); err != nil {
+				mu.Lock()
+				partial++
+				mu.Unlock()
+			}
+		}
+	}()
+
+	for i := 0; i < rounds; i++ {
+		if err := writeLimitlineCache(path, sampleResponse()); err != nil {
+			t.Fatalf("writeLimitlineCache: %v", err)
+		}
+	}
+	close(stop)
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if partial != 0 {
+		t.Errorf("%d reads saw a truncated document; the write is not atomic", partial)
+	}
+}
+
+// TestLimitlineCacheReportsAFailure covers the third part of item 5: the
+// errors were discarded, so a read-only state directory produced no signal at
+// all -- indistinguishable from a cache that is working.
+func TestLimitlineCacheReportsAFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory mode is not enforced the same way on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; a read-only directory would not stop the write")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	err := writeLimitlineCache(filepath.Join(dir, "limitline-usage-cache.json"), sampleResponse())
+	if err == nil {
+		t.Fatal("a write into a read-only directory must be reported")
+	}
+}
+
+// TestWriteCacheUpdatesSurfacesAFailure pins that the report reaches the
+// per-account line the dashboard already renders, rather than stderr.
+func TestWriteCacheUpdatesSurfacesAFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory mode is not enforced the same way on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; a read-only directory would not stop the write")
+	}
+	m := newTestManager(t, nil)
+
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	accounts := []Account{{Letter: "a", ServiceName: "claude-a", LastAPIStatus: "HTTP 200 (fresh)"}}
+	m.writeCacheUpdates(accounts, map[string]apiResult{
+		"a": {stateDirPath: dir, resp: sampleResponse()},
+	})
+
+	if !strings.Contains(accounts[0].LastAPIStatus, "cache write failed") {
+		t.Errorf("LastAPIStatus = %q, expected it to mention the failed write", accounts[0].LastAPIStatus)
+	}
+}
+
+// TestCooldownExpiry covers the in-memory replacement for .tui-api-cooldown
+// and the expiry check that `r` used to skip (#358, items 5 and 10).
+func TestCooldownExpiry(t *testing.T) {
+	c := newAPICooldowns()
+
+	if c.active("a") {
+		t.Error("a letter that was never recorded must not be in cooldown")
+	}
+
+	c.record("a")
+	if !c.active("a") {
+		t.Error("a just-recorded letter must be in cooldown")
+	}
+	if c.active("b") {
+		t.Error("the cooldown is per account")
+	}
+
+	// clearExpired must leave a live cooldown alone. This is the defect seen
+	// from update.go as item 10: `r` cleared everything unconditionally, so
+	// the 25s backoff after a 429 existed but any keypress skipped it and
+	// re-issued the call the 429 was telling us to stop making.
+	c.clearExpired()
+	if !c.active("a") {
+		t.Error("clearExpired must not drop a cooldown that has not expired")
+	}
+
+	// Age it past the window.
+	c.mu.Lock()
+	c.at["a"] = time.Now().Add(-apiCooldownDuration - time.Second)
+	c.mu.Unlock()
+
+	if c.active("a") {
+		t.Error("an aged-out cooldown must not report active")
+	}
+	c.clearExpired()
+	c.mu.Lock()
+	_, present := c.at["a"]
+	c.mu.Unlock()
+	if present {
+		t.Error("clearExpired must drop an expired entry")
+	}
+}
+
+// TestClearAPICooldownsKeepsLiveEntries is the Manager-level statement of the
+// same rule, since that is what the `r` handler calls.
+func TestClearAPICooldownsKeepsLiveEntries(t *testing.T) {
+	m := newTestManager(t, nil)
+	m.cooldowns.record("a")
+
+	m.ClearAPICooldowns()
+
+	if !m.cooldowns.active("a") {
+		t.Error("pressing r must not clear a cooldown recorded a moment ago")
+	}
+}
+
+// TestCooldownIsRuntimeAgnostic covers item 11 from the other side: the file
+// implementation scanned the claude state directories with a hardcoded
+// RuntimeClaude, so a codex or gemini install cleared nothing. Keyed by
+// letter in manager-scoped memory, there is no runtime in the path at all.
+func TestCooldownIsRuntimeAgnostic(t *testing.T) {
+	m := newTestManager(t, nil)
+	m.cooldowns.record("a")
+
+	m.cooldowns.mu.Lock()
+	m.cooldowns.at["a"] = time.Now().Add(-apiCooldownDuration - time.Second)
+	m.cooldowns.mu.Unlock()
+
+	m.ClearAPICooldowns()
+
+	m.cooldowns.mu.Lock()
+	n := len(m.cooldowns.at)
+	m.cooldowns.mu.Unlock()
+	if n != 0 {
+		t.Errorf("expected the expired entry to be cleared regardless of runtime, %d left", n)
+	}
+}

--- a/tui/internal/config/env.go
+++ b/tui/internal/config/env.go
@@ -52,6 +52,9 @@ type Env struct {
 	path    string
 	entries []entry
 	index   map[string]int // key -> entries[i]
+	// loadErr is non-nil when this Env stands in for a .env that could not be
+	// read. Reads answer with defaults; Save refuses. See NewUnloadableEnv.
+	loadErr error
 }
 
 type entry struct {
@@ -99,6 +102,34 @@ func NewEmptyEnv(path string) *Env {
 	return &Env{path: path, index: make(map[string]int)}
 }
 
+// NewUnloadableEnv returns an Env that answers reads with their defaults but
+// refuses to Save (#358, item 7).
+//
+// main.go falls back to an empty Env when LoadEnv fails, which is right for
+// reading -- the dashboard should still start and show what it can. It is
+// wrong for writing: the file on disk may be perfectly good and merely
+// unreadable by this process, and Save writes only the entries the Env holds.
+// A `g` press against that empty Env would replace the user's whole .env with
+// a single token line, silently destroying every key in it.
+//
+// The refusal lives in Save rather than at each caller so a future writer
+// cannot miss it.
+func NewUnloadableEnv(path string, cause error) *Env {
+	return &Env{path: path, index: make(map[string]int), loadErr: cause}
+}
+
+// CanPersist reports whether Save can write this Env. False when the file
+// could not be read, so callers can refuse before doing work whose only
+// outcome would be a failed write.
+func (e *Env) CanPersist() bool {
+	if e == nil {
+		return false
+	}
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.loadErr == nil
+}
+
 // Get returns the value of a key, or empty string if not set.
 func (e *Env) Get(key string) string {
 	e.mu.RLock()
@@ -139,9 +170,18 @@ func (e *Env) Save() error {
 	// the slowest of them.
 	e.mu.RLock()
 	path := e.path
+	loadErr := e.loadErr
 	snapshot := make([]entry, len(e.entries))
 	copy(snapshot, e.entries)
 	e.mu.RUnlock()
+
+	// Refuse rather than replace a file we could not read. Save writes only
+	// the entries this Env holds, and an Env standing in for an unreadable
+	// .env holds none of the user's (#358, item 7).
+	if loadErr != nil {
+		return fmt.Errorf("refusing to write %s: it could not be read (%v), "+
+			"so writing would discard whatever it contains", path, loadErr)
+	}
 
 	if path == "" {
 		return fmt.Errorf("env path not set")
@@ -160,7 +200,7 @@ func (e *Env) Save() error {
 	w := bufio.NewWriter(tmp)
 	for _, ent := range snapshot {
 		if ent.key != "" {
-			if _, err := fmt.Fprintf(w, "%s=%s\n", ent.key, ent.value); err != nil {
+			if _, err := fmt.Fprintf(w, "%s=%s\n", ent.key, formatEnvValue(ent.value)); err != nil {
 				tmp.Close()
 				return fmt.Errorf("write: %w", err)
 			}
@@ -188,6 +228,38 @@ func (e *Env) Save() error {
 		return err
 	}
 	return nil
+}
+
+// formatEnvValue restores the quoting LoadEnv strips, so a value survives the
+// round trip through this writer and back out through any of the three
+// readers (#358, item 8).
+//
+// LoadEnv strips surrounding quotes at env.go:87 and Save used to write the
+// bare value back, so `FOO="a # b"` became `FOO=a # b`. The Go reader would
+// still return `a # b`, but parse_env.sh strips an inline comment introduced
+// by whitespace-then-hash, so bash -- which is what every container actually
+// gets its environment from -- read `a`. Pressing `g` was enough to truncate
+// an unrelated value.
+//
+// The rule is set_env_value's, verbatim (scripts/lib/parse_env.sh:128-137):
+// quote when the value contains whitespace or '#', or begins with a quote
+// character; escape embedded double quotes inside the wrapper. Matching it
+// exactly is the point -- the two writers target the same file, and a value
+// written by one is read back by the other.
+//
+// Not lossless for a value containing a double quote, and deliberately so:
+// the readers strip the wrapper without unescaping, so `say "hi"` reads back
+// as `say \"hi\"`. All three implementations agree on that, and changing it
+// means changing all three in lockstep, which is #356's SSOT work.
+func formatEnvValue(value string) string {
+	needsQuote := strings.ContainsAny(value, " \t\n\r\v\f#")
+	if !needsQuote && value != "" && (value[0] == '"' || value[0] == '\'') {
+		needsQuote = true
+	}
+	if !needsQuote {
+		return value
+	}
+	return `"` + strings.ReplaceAll(value, `"`, `\"`) + `"`
 }
 
 // hardenSecretFile preserves the Unix 0600 contract and applies the Windows

--- a/tui/internal/config/env_quoting_test.go
+++ b/tui/internal/config/env_quoting_test.go
@@ -1,0 +1,153 @@
+package config
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// quotingCases are the inputs that separate the writers. Each `want` is the
+// exact byte sequence set_env_value writes for the same value; the last test
+// in this file proves that claim rather than asserting it.
+var quotingCases = []struct {
+	name  string
+	value string
+	want  string
+}{
+	{"plain", "abc", "abc"},
+	{"empty", "", ""},
+	{"space", "a b", `"a b"`},
+	{"tab", "a\tb", "\"a\tb\""},
+	{"hash with no space", "a#b", `"a#b"`},
+	{"space then hash", "a # b", `"a # b"`},
+	{"trailing hash", "abc #", `"abc #"`},
+	{"leading double quote", `"abc`, `"\"abc"`},
+	{"leading single quote", "'abc", `"'abc"`},
+	{"embedded double quote", `say "hi" now`, `"say \"hi\" now"`},
+	{"token, nothing special", "gho_abc123", "gho_abc123"},
+	{"path", "/home/node/project", "/home/node/project"},
+}
+
+// TestFormatEnvValue pins the quoting Save restores (#358, item 8).
+//
+// LoadEnv strips surrounding quotes, and Save used to write the bare value
+// back, so `FOO="a # b"` was rewritten as `FOO=a # b` by any press of `g` --
+// which rewrites the whole file, not just the key it changed.
+func TestFormatEnvValue(t *testing.T) {
+	for _, tc := range quotingCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatEnvValue(tc.value); got != tc.want {
+				t.Errorf("formatEnvValue(%q) = %q, want %q", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSaveRewritesAValueUnchanged is the `g`-press scenario end to end: load a
+// .env that already contains a quoted value, change an unrelated key, save,
+// and require the original line to come back byte for byte.
+func TestSaveRewritesAValueUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	original := "# a comment\n" +
+		"NUM_ACCOUNTS=2\n" +
+		"NOTE=\"a # b\"\n" +
+		"\n" +
+		"PROJECT_DIR=/home/node/project\n"
+	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	env, err := LoadEnv(path)
+	if err != nil {
+		t.Fatalf("LoadEnv: %v", err)
+	}
+	env.Set("GH_TOKEN", "gho_written_by_g")
+	if err := env.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	got := string(after)
+
+	if !strings.Contains(got, "NOTE=\"a # b\"\n") {
+		t.Errorf("the quoted value did not survive:\n%s", got)
+	}
+	if strings.Contains(got, "NOTE=a # b\n") {
+		t.Errorf("the value was written unquoted, which truncates it for bash:\n%s", got)
+	}
+	if !strings.Contains(got, "GH_TOKEN=gho_written_by_g\n") {
+		t.Errorf("the new key is missing:\n%s", got)
+	}
+	if !strings.Contains(got, "# a comment\n") {
+		t.Errorf("comments should be preserved:\n%s", got)
+	}
+	// A token has nothing special in it and must not acquire quotes: the
+	// container reads GH_TOKEN through compose, and a literal quote in the
+	// value would be part of the token.
+	if strings.Contains(got, `GH_TOKEN="`) {
+		t.Errorf("an ordinary value must not be quoted:\n%s", got)
+	}
+}
+
+// TestFormatEnvValueMatchesSetEnvValue is the cross-implementation assertion:
+// the bytes this writer produces are the bytes scripts/lib/parse_env.sh's
+// set_env_value produces, for the same input.
+//
+// The two writers target the same file. Asserting the Go side against a table
+// I wrote would only prove I am consistent with myself; running the shell
+// function is what makes the table a claim about the other implementation.
+//
+// NOTE ON THE READER: this pins the *writers*. The bash reader currently
+// mis-parses what the bash writer produces here, because parse_env_value
+// strips an inline comment before it unquotes -- so `FOO="a # b"` reads back
+// as `"a`, quote included. That predates both writers, affects the shell path
+// with no TUI involved, and fixing it means moving parse_env_value,
+// load_env_file, Read-EnvFile and LoadEnv in lockstep, which is the ".env
+// value parsing" child of #356. What this PR guarantees is narrower and still
+// worth having: pressing `g` no longer changes such a line at all.
+func TestFormatEnvValueMatchesSetEnvValue(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("needs a POSIX shell to source parse_env.sh")
+	}
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available")
+	}
+	// tui/internal/config -> repo root
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	lib := filepath.Join(repoRoot, "scripts", "lib", "parse_env.sh")
+	if _, err := os.Stat(lib); err != nil {
+		t.Skipf("parse_env.sh not found at %s", lib)
+	}
+
+	for _, tc := range quotingCases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := filepath.Join(t.TempDir(), ".env")
+			script := ". \"$1\"; set_env_value \"$2\" FOO \"$3\""
+			cmd := exec.Command(bash, "-c", script, "bash", lib, out, tc.value)
+			if b, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("set_env_value: %v\n%s", err, b)
+			}
+			data, err := os.ReadFile(out)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			shellLine := strings.TrimRight(string(data), "\n")
+			goLine := "FOO=" + formatEnvValue(tc.value)
+			if shellLine != goLine {
+				t.Errorf("writers disagree for %q:\n  shell: %s\n  go:    %s",
+					tc.value, shellLine, goLine)
+			}
+		})
+	}
+}

--- a/tui/internal/config/env_unloadable_test.go
+++ b/tui/internal/config/env_unloadable_test.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestUnloadableEnvRefusesToSave is the data-loss guard for #358 item 7.
+//
+// main.go falls back to an empty Env when LoadEnv fails, which is right for
+// reading. It was also writable, and Save writes only the entries the Env
+// holds -- so one `g` press against that fallback replaced a .env full of
+// keys with a single GH_TOKEN line.
+func TestUnloadableEnvRefusesToSave(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	original := "NUM_ACCOUNTS=2\nPROJECT_DIR=/home/node/project\nCLAUDE_API_KEY_A=sk-ant-secret\n"
+	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	env := NewUnloadableEnv(path, errors.New("permission denied"))
+
+	if env.CanPersist() {
+		t.Error("CanPersist should be false for an Env that stands in for an unreadable file")
+	}
+
+	env.Set("GH_TOKEN", "gho_would_have_clobbered")
+	err := env.Save()
+	if err == nil {
+		t.Fatal("Save must refuse")
+	}
+	if !strings.Contains(err.Error(), "refusing to write") {
+		t.Errorf("the refusal should say what it is refusing, got: %v", err)
+	}
+
+	after, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("read back: %v", readErr)
+	}
+	if string(after) != original {
+		t.Errorf("the file was modified despite the refusal:\nwant:\n%s\ngot:\n%s", original, after)
+	}
+}
+
+// TestLoadedEnvCanPersist keeps the refusal from applying to everything.
+func TestLoadedEnvCanPersist(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte("NUM_ACCOUNTS=2\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	env, err := LoadEnv(path)
+	if err != nil {
+		t.Fatalf("LoadEnv: %v", err)
+	}
+	if !env.CanPersist() {
+		t.Error("a loaded Env must be persistable")
+	}
+	if err := env.Save(); err != nil {
+		t.Errorf("Save: %v", err)
+	}
+}
+
+// TestEmptyEnvCanPersist pins that the plain empty Env -- used by every test
+// and by a genuinely absent .env -- is still writable. The refusal is
+// specifically about standing in for a file that exists and could not be read.
+func TestEmptyEnvCanPersist(t *testing.T) {
+	env := NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+	if !env.CanPersist() {
+		t.Error("an empty Env must be persistable")
+	}
+	if err := env.Save(); err != nil {
+		t.Errorf("Save: %v", err)
+	}
+}
+
+// TestNilEnvCannotPersist covers the nil receiver, which CanPersist has to
+// answer for because Model.env can be nil.
+func TestNilEnvCannotPersist(t *testing.T) {
+	var env *Env
+	if env.CanPersist() {
+		t.Error("a nil Env must not claim to be persistable")
+	}
+}

--- a/tui/internal/ui/dashboard/gh_auth_guard_test.go
+++ b/tui/internal/ui/dashboard/gh_auth_guard_test.go
@@ -1,0 +1,96 @@
+package dashboard
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kcenon/claude-docker/tui/internal/account"
+	"github.com/kcenon/claude-docker/tui/internal/config"
+	"github.com/kcenon/claude-docker/tui/internal/docker"
+)
+
+// TestGHAuthRefusesWhenEnvCannotPersist covers #358 item 7's second half.
+//
+// main.go falls back to an Env that holds none of the user's keys when .env
+// cannot be read. Pressing `g` against that used to fetch a live GitHub token
+// and then hand it to Save, which wrote the fallback's single entry over the
+// whole file.
+//
+// The refusal is checked before the token is fetched, so hostGHToken is
+// stubbed to fail the test if it is reached at all.
+func TestGHAuthRefusesWhenEnvCannotPersist(t *testing.T) {
+	called := false
+	restore := hostGHToken
+	hostGHToken = func(user string) (string, error) {
+		called = true
+		return "gho_should_never_be_fetched", nil
+	}
+	defer func() { hostGHToken = restore }()
+
+	env := config.NewUnloadableEnv(filepath.Join(t.TempDir(), ".env"), errors.New("permission denied"))
+	m := New(nil, nil, env, false)
+	m.loading = false
+	m.accounts = []account.Account{{Letter: "a", ServiceName: "claude-a"}}
+
+	m, _ = m.startGHAuth()
+
+	if called {
+		t.Error("a token must not be fetched for a write that cannot happen")
+	}
+	if m.busy {
+		t.Error("the model must not be left busy after refusing")
+	}
+	if !strings.Contains(m.statusText, "could not be read") {
+		t.Errorf("the toast should explain why, got %q", m.statusText)
+	}
+	if m.statusLevel != statusErr {
+		t.Errorf("statusLevel = %v, want statusErr", m.statusLevel)
+	}
+}
+
+// TestGHAuthProceedsWithALoadedEnv keeps the guard from refusing everything.
+func TestGHAuthProceedsWithALoadedEnv(t *testing.T) {
+	called := false
+	restore := hostGHToken
+	hostGHToken = func(user string) (string, error) {
+		called = true
+		return "gho_testtoken", nil
+	}
+	defer func() { hostGHToken = restore }()
+
+	env := config.NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+	// A real client pointed at a directory with no compose file: the command
+	// below asks it whether any container is running, and `docker compose ps`
+	// fails immediately instead of reaching a daemon. Same degraded path
+	// render_test.go relies on.
+	client := docker.NewClient(t.TempDir(), env)
+	m := New(nil, client, env, false)
+	m.loading = false
+	m.accounts = []account.Account{{Letter: "a", ServiceName: "claude-a"}}
+
+	m, cmd := m.startGHAuth()
+	if cmd == nil {
+		t.Fatal("expected a command for a loadable .env")
+	}
+	if !m.busy {
+		t.Error("the model should be busy while gh-auth runs")
+	}
+
+	// Running the returned command is what performs the fetch and the write.
+	msg := cmd()
+	if !called {
+		t.Error("the token should have been fetched")
+	}
+	applied, ok := msg.(ghAuthAppliedMsg)
+	if !ok {
+		t.Fatalf("unexpected message type %T", msg)
+	}
+	if applied.err != nil {
+		t.Errorf("gh-auth reported: %v", applied.err)
+	}
+	if got := env.Get("GH_TOKEN"); got != "gho_testtoken" {
+		t.Errorf("GH_TOKEN = %q, want the fetched token", got)
+	}
+}

--- a/tui/internal/ui/dashboard/helpers.go
+++ b/tui/internal/ui/dashboard/helpers.go
@@ -19,6 +19,14 @@ func (m Model) startGHAuth() (Model, tea.Cmd) {
 		m = m.toast("gh-auth: .env not loaded", statusErr)
 		return m, m.toastExpireCmd()
 	}
+	// Refuse before fetching a token. Save would refuse anyway, but reaching
+	// it means a live GitHub token was pulled onto this machine for a write
+	// that cannot happen -- and the user would read the failure as a gh
+	// problem rather than a .env one (#358, item 7).
+	if !m.env.CanPersist() {
+		m = m.toast("gh-auth: .env could not be read; fix it and restart", statusErr)
+		return m, m.toastExpireCmd()
+	}
 	mode := m.env.GitHubAuthMode()
 	if mode != config.GHAuthShared && mode != config.GHAuthPerAccount {
 		m = m.toast("gh-auth: GH_AUTH_MODE must be shared or per-account", statusErr)

--- a/tui/main.go
+++ b/tui/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -48,8 +50,12 @@ func main() {
 	envPath := filepath.Join(projectRoot, ".env")
 	env, err := config.LoadEnv(envPath)
 	if err != nil {
+		// Read-only fallback. The dashboard still starts and shows what it
+		// can, but Save refuses: writing an Env that holds none of the user's
+		// keys would replace the file rather than update it (#358, item 7).
 		fmt.Fprintf(os.Stderr, "warning: cannot load .env: %v\n", err)
-		env = config.NewEmptyEnv(envPath)
+		fmt.Fprintf(os.Stderr, "warning: gh-auth is disabled until it loads\n")
+		env = config.NewUnloadableEnv(envPath, err)
 	}
 
 	composeClient := docker.NewClient(projectRoot, env)
@@ -101,9 +107,31 @@ func resolveProjectRoot() (string, error) {
 	return "", fmt.Errorf("docker-compose.yml not found in any parent directory")
 }
 
+// projectMarkers are the paths a directory must contain to be this project's
+// root (#358, item 7).
+//
+// docker-compose.yml alone is not a marker -- it is one of the most common
+// filenames on a developer's disk. resolveProjectRoot walks up from the
+// executable and then from the cwd, so running the TUI from inside any
+// unrelated compose project claimed that project as the root. That is not only
+// a wrong dashboard: `g` writes a GitHub token into `<root>/.env`, and an
+// unrelated directory has no reason to be gitignoring it.
+//
+// scripts/claude-docker is the disambiguator. It ships with the repository,
+// it is the entry point every documented workflow uses, and it is not a name
+// another project is likely to have next to a compose file.
+var projectMarkers = []string{
+	"docker-compose.yml",
+	filepath.Join("scripts", "claude-docker"),
+}
+
 func isProjectRoot(dir string) bool {
-	_, err := os.Stat(filepath.Join(dir, "docker-compose.yml"))
-	return err == nil
+	for _, marker := range projectMarkers {
+		if _, err := os.Stat(filepath.Join(dir, marker)); err != nil {
+			return false
+		}
+	}
+	return true
 }
 
 func runJSON() error {
@@ -125,36 +153,66 @@ func runJSON() error {
 		return fmt.Errorf("cannot list accounts: %w", err)
 	}
 
-	fmt.Printf("{\n")
-	fmt.Printf("  \"project_root\": %q,\n", projectRoot)
-	fmt.Printf("  \"runtime\": %q,\n", env.AgentRuntime())
-	fmt.Printf("  \"num_accounts\": %d,\n", len(accounts))
-	fmt.Printf("  \"accounts\": [\n")
-	for i, a := range accounts {
-		comma := ","
-		if i == len(accounts)-1 {
-			comma = ""
+	return writeJSONReport(os.Stdout, projectRoot, env.AgentRuntime(), accounts)
+}
+
+// jsonReport is the --json document (#358, item 6).
+//
+// It exists because the previous implementation hand-assembled the same
+// document with fmt.Printf and %q. %q is Go quoting, not JSON quoting: they
+// agree on the common cases and diverge on the ones that matter here. A
+// LastAPIStatus carrying a control character -- which it can, since it is
+// built from an upstream error string -- is emitted by %q as \x00, which is
+// not a JSON escape, so the output stops being parseable. The struct also
+// removes the hand-tracked trailing comma and the "null" string literals.
+type jsonReport struct {
+	ProjectRoot string        `json:"project_root"`
+	Runtime     string        `json:"runtime"`
+	NumAccounts int           `json:"num_accounts"`
+	Accounts    []jsonAccount `json:"accounts"`
+}
+
+// jsonAccount keeps the field names and the omission rules of the original
+// output, so existing consumers see the same document.
+type jsonAccount struct {
+	Service        string `json:"service"`
+	State          string `json:"state"`
+	Auth           string `json:"auth"`
+	FiveHour       *int   `json:"5h"`
+	SevenDay       *int   `json:"7d"`
+	APIRateLimited bool   `json:"api_rate_limited,omitempty"`
+	LastAPIStatus  string `json:"last_api_status,omitempty"`
+}
+
+func writeJSONReport(w io.Writer, projectRoot, runtime string, accounts []account.Account) error {
+	report := jsonReport{
+		ProjectRoot: projectRoot,
+		Runtime:     runtime,
+		NumAccounts: len(accounts),
+		// Never nil: an install with no accounts should emit [], not null.
+		Accounts: make([]jsonAccount, 0, len(accounts)),
+	}
+
+	for _, a := range accounts {
+		ja := jsonAccount{
+			Service:        a.ServiceName,
+			State:          a.ContainerStatus.String(),
+			Auth:           a.AuthType.String(),
+			APIRateLimited: a.APIRateLimited,
+			LastAPIStatus:  a.LastAPIStatus,
 		}
-		fiveH := "null"
-		sevenD := "null"
 		if a.FiveHourUsage != nil {
-			fiveH = fmt.Sprintf("%d", a.FiveHourUsage.PercentUsed)
+			v := a.FiveHourUsage.PercentUsed
+			ja.FiveHour = &v
 		}
 		if a.SevenDayUsage != nil {
-			sevenD = fmt.Sprintf("%d", a.SevenDayUsage.PercentUsed)
+			v := a.SevenDayUsage.PercentUsed
+			ja.SevenDay = &v
 		}
-		rateLimited := ""
-		if a.APIRateLimited {
-			rateLimited = ", \"api_rate_limited\": true"
-		}
-		lastStatus := ""
-		if a.LastAPIStatus != "" {
-			lastStatus = fmt.Sprintf(", \"last_api_status\": %q", a.LastAPIStatus)
-		}
-		fmt.Printf("    {\"service\": %q, \"state\": %q, \"auth\": %q, \"5h\": %s, \"7d\": %s%s%s}%s\n",
-			a.ServiceName, a.ContainerStatus, a.AuthType, fiveH, sevenD, rateLimited, lastStatus, comma)
+		report.Accounts = append(report.Accounts, ja)
 	}
-	fmt.Printf("  ]\n")
-	fmt.Printf("}\n")
-	return nil
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(report)
 }

--- a/tui/main_test.go
+++ b/tui/main_test.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kcenon/claude-docker/tui/internal/account"
+)
+
+// TestIsProjectRootRequiresMoreThanACompseFile covers #358 item 7.
+//
+// resolveProjectRoot walks up from the executable and then from the cwd, so
+// with docker-compose.yml as the only marker, running the TUI anywhere inside
+// an unrelated compose project claimed that project as the root -- and `g`
+// writes a GitHub token into <root>/.env, which an unrelated directory has no
+// reason to be gitignoring.
+func TestIsProjectRootRequiresMoreThanAComposeFile(t *testing.T) {
+	t.Run("an unrelated compose project is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "docker-compose.yml"), "services: {}\n")
+
+		if isProjectRoot(dir) {
+			t.Error("a directory holding only docker-compose.yml must not be the project root")
+		}
+	})
+
+	t.Run("scripts/claude-docker alone is not enough either", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(dir, "scripts"), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		writeFile(t, filepath.Join(dir, "scripts", "claude-docker"), "#!/usr/bin/env bash\n")
+
+		if isProjectRoot(dir) {
+			t.Error("the compose file is still required")
+		}
+	})
+
+	t.Run("both markers present", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "docker-compose.yml"), "services: {}\n")
+		if err := os.MkdirAll(filepath.Join(dir, "scripts"), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		writeFile(t, filepath.Join(dir, "scripts", "claude-docker"), "#!/usr/bin/env bash\n")
+
+		if !isProjectRoot(dir) {
+			t.Error("a real checkout must be recognized")
+		}
+	})
+
+	t.Run("the repository this test lives in", func(t *testing.T) {
+		// The strongest available check that the markers were not chosen to
+		// fit the test: the actual checkout has to satisfy them.
+		root, err := filepath.Abs("..")
+		if err != nil {
+			t.Fatalf("abs: %v", err)
+		}
+		if !isProjectRoot(root) {
+			t.Errorf("the claude-docker checkout at %s is not recognized as a project root", root)
+		}
+	})
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestWriteJSONReportIsValidJSON covers #358 item 6.
+//
+// runJSON hand-assembled the document with fmt.Printf and %q. %q is Go
+// quoting: a control character becomes \x00, which is not a JSON escape, so
+// the whole document stops parsing. LastAPIStatus is built from an upstream
+// error string, so it can carry one.
+func TestWriteJSONReportIsValidJSON(t *testing.T) {
+	pct := func(v int) *account.UsageBucket { return &account.UsageBucket{PercentUsed: v} }
+
+	accounts := []account.Account{
+		{
+			ServiceName:     "claude-a",
+			ContainerStatus: account.ContainerRunning,
+			AuthType:        account.AuthOAuth,
+			FiveHourUsage:   pct(42),
+			SevenDayUsage:   pct(7),
+		},
+		{
+			ServiceName:     "claude-b",
+			ContainerStatus: account.ContainerNotCreated,
+			AuthType:        account.AuthNone,
+			APIRateLimited:  true,
+			// The hostile case: a NUL, a bell, a newline, a tab, a quote and a
+			// backslash, all of which reached this field verbatim before.
+			LastAPIStatus: "err: \x00bad\x07\nresponse\t\"quoted\" C:\\path",
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := writeJSONReport(&buf, "/home/node/claude-docker", "claude", accounts); err != nil {
+		t.Fatalf("writeJSONReport: %v", err)
+	}
+
+	var back map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &back); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
+	}
+
+	if back["project_root"] != "/home/node/claude-docker" {
+		t.Errorf("project_root = %v", back["project_root"])
+	}
+	if back["runtime"] != "claude" {
+		t.Errorf("runtime = %v", back["runtime"])
+	}
+	if back["num_accounts"] != float64(2) {
+		t.Errorf("num_accounts = %v", back["num_accounts"])
+	}
+
+	list, ok := back["accounts"].([]any)
+	if !ok || len(list) != 2 {
+		t.Fatalf("accounts = %v", back["accounts"])
+	}
+
+	first, _ := list[0].(map[string]any)
+	if first["service"] != "claude-a" || first["state"] != "running" || first["auth"] != "OAuth" {
+		t.Errorf("first account = %v", first)
+	}
+	if first["5h"] != float64(42) || first["7d"] != float64(7) {
+		t.Errorf("usage fields = %v / %v", first["5h"], first["7d"])
+	}
+	// omitempty: an account that is not rate-limited says nothing about it,
+	// which is what the previous output did too.
+	if _, present := first["api_rate_limited"]; present {
+		t.Error("api_rate_limited should be omitted when false")
+	}
+
+	second, _ := list[1].(map[string]any)
+	if second["api_rate_limited"] != true {
+		t.Errorf("api_rate_limited = %v", second["api_rate_limited"])
+	}
+	// The control characters survive as data rather than breaking the syntax.
+	if second["last_api_status"] != accounts[1].LastAPIStatus {
+		t.Errorf("last_api_status did not round-trip:\n want %q\n got  %v",
+			accounts[1].LastAPIStatus, second["last_api_status"])
+	}
+	// A missing usage bucket is JSON null, not the string "null".
+	if second["5h"] != nil {
+		t.Errorf("5h = %v, want null", second["5h"])
+	}
+}
+
+// TestGoQuotingIsNotJSONQuoting demonstrates the premise the item-6 fix rests
+// on, rather than leaving it as an assertion in a comment.
+//
+// %q produces a Go string literal. For the printable ASCII that dominates
+// real values it is byte-identical to a JSON string, which is why the
+// hand-assembled output worked for years. It diverges on exactly the input
+// that reaches LastAPIStatus from an upstream error: \x00 is a valid Go escape
+// and not a valid JSON one.
+func TestGoQuotingIsNotJSONQuoting(t *testing.T) {
+	const hostile = "err: \x00bad"
+
+	goQuoted := []byte(`{"x": ` + fmt.Sprintf("%q", hostile) + `}`)
+	var sink map[string]any
+	if err := json.Unmarshal(goQuoted, &sink); err == nil {
+		t.Fatalf("premise is wrong: %%q output parsed as JSON: %s", goQuoted)
+	}
+
+	// The encoder handles the same string.
+	encoded, err := json.Marshal(map[string]string{"x": hostile})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := json.Unmarshal(encoded, &sink); err != nil {
+		t.Fatalf("encoder output does not parse: %v", err)
+	}
+	if sink["x"] != hostile {
+		t.Errorf("round trip changed the value: %q", sink["x"])
+	}
+}
+
+// TestWriteJSONReportEmptyAccounts pins that no accounts yields [] rather than
+// null, so a consumer can iterate without a nil check.
+func TestWriteJSONReportEmptyAccounts(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJSONReport(&buf, "/root", "codex", nil); err != nil {
+		t.Fatalf("writeJSONReport: %v", err)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte(`"accounts": []`)) {
+		t.Errorf("expected an empty array:\n%s", buf.String())
+	}
+	var back map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &back); err != nil {
+		t.Fatalf("not valid JSON: %v", err)
+	}
+}


### PR DESCRIPTION
Relates to #358 (items 5, 6, 7, 8 — and 10, 11 as a consequence)

Second of three PRs for #358. [#376](https://github.com/kcenon/claude-docker/pull/376) covered the four defects a user hits in a normal session; this one covers the writes and the outputs. C follows with the remaining correctness debt.

## What

| # | Defect | Consequence |
|---|---|---|
| 5 | state files written `0644`, non-atomically, all errors discarded | a concurrent host write leaves truncated JSON and the dashboard silently draws `--`; a read-only state dir fails invisibly |
| 6 | `runJSON` hand-serializes with `fmt.Printf` and `%q` | one control character in `LastAPIStatus` makes `--json` unparseable |
| 7 | `isProjectRoot` accepts any dir with a `docker-compose.yml`; `g` then writes a token into it | a GitHub token lands in an unrelated project that has no reason to gitignore `.env` |
| 8 | `Env.Save` does not restore the quoting `LoadEnv` stripped | pressing `g` rewrites `FOO="a # b"` as `FOO=a # b`, and bash then reads `a` |

Items **10** and **11** are fixed here rather than in C, because both are properties of the cooldown file that item 5 removes. Leaving them would have meant writing the same two defects into the replacement.

## Why each one bites

**#5.** `limitline-usage-cache.json` has a second writer — the host's `claude-limitline` tool. `os.WriteFile` truncates and then writes, so a read can land in between; `parseLimitlineCache` returns `(nil, nil)` for a truncated document and the table draws `--` with no stated cause. `Env.Save` already had CreateTemp → write → chmod 0600 → rename. The pattern existed two packages away and was simply not applied.

`0644` also made a file describing an account's API usage world-readable, next to a credentials file the installer sets to 0600.

**#7 has two halves and the second is the dangerous one.** `resolveProjectRoot` walks up from the executable *and* from the cwd, so the wrong root is easy to reach. A wrong dashboard is recoverable; `g` writing `GH_TOKEN=gho_...` into a stranger's repo is not.

The other half: when `LoadEnv` fails, `main.go` falls back to `NewEmptyEnv` — correct for reading, because the dashboard should still start. But that Env was writable, and `Save` writes **only the entries the Env holds**. One `g` press against it would have replaced a `.env` full of keys with a single token line.

**#8.** `Save` rewrites the whole file, not just the key that changed, so a single `g` press reformats every value in it.

## The `#` case is not fully fixed, and here is the measurement

The acceptance criterion asks that a value containing ` #` survive a `g` press *and a subsequent bash read* unchanged. The writer half is done. The reader half is not, and it is not the TUI's:

```
$ set_env_value .env FOO 'a # b'    # the bash writer
$ cat .env
FOO="a # b"
$ parse_env_value .env FOO          # the bash reader
"a
```

`parse_env_value` strips an inline comment **before** it unquotes, so the shell writer's own output comes back wrong, quote included. That predates both writers, affects the shell path with no TUI involved, and fixing it means moving `parse_env_value`, `load_env_file`, `Read-EnvFile` and `LoadEnv` in lockstep — which is exactly the "unify `.env` value parsing" child already scoped under #356. Pulling it in here would duplicate that work and put a four-implementation change inside a TUI PR.

What this PR does guarantee is narrower and still the thing that was broken: **pressing `g` no longer changes such a line at all.** Before, `FOO="a # b"` came back as `FOO=a # b` and bash read `a`. Now the line is byte-identical after the write.

## How

`formatEnvValue` implements `set_env_value`'s rule verbatim — quote when the value contains whitespace or `#`, or begins with a quote character; escape embedded double quotes. Asserting that against a table I wrote would only prove I am self-consistent, so the test **runs the shell function** and compares bytes.

The cooldown moves into `apiCooldowns`, a mutex-guarded map keyed by account letter. `record` on a 429, `active` to check, `clearExpired` for the `r` key. There is no runtime in the path any more, which is item 11, and `clearExpired` only drops elapsed entries, which is item 10.

The `.env` refusal lives in `Save` rather than at each caller, so a future writer cannot miss it; `startGHAuth` checks `CanPersist()` as well, so no live GitHub token is fetched for a write that cannot happen.

## Verification

`go test -race ./...`, `go vet ./...`, `gofmt -l .` — clean. 5 new test files.

**Mutation-tested, one revert per fix, clean baseline:**

```
=== baseline ===                                       all ok
M1  Save writes the bare value again        -> FAIL TestSaveRewritesAValueUnchanged
M2  quoting rule drops the '#' trigger      -> FAIL TestFormatEnvValue + the shell cross-check
M3  unloadable Env is writable again        -> FAIL TestUnloadableEnvRefusesToSave
M4  root marker back to compose file only   -> FAIL TestIsProjectRoot (2 subtests)
M5  JSON back to %q                         -> FAIL TestWriteJSONReportIsValidJSON
M6  cache back to os.WriteFile 0644         -> FAIL TestLimitlineCacheIsWrittenOwnerOnly
M7  ClearAPICooldowns clears everything     -> FAIL TestCooldownExpiry + KeepsLiveEntries
M8  gh-auth guard removed                   -> FAIL TestGHAuthRefusesWhenEnvCannotPersist
```

The first run of this harness had a **red baseline** — the temp copy held only `tui/`, so `TestIsProjectRoot`'s "the repository this test lives in" case failed for a reason unrelated to any mutation, and M5's patch did not compile so it tested nothing. Both are fixed above; the results quoted are from the corrected run.

### The atomicity test needed enlarging to mean anything

M6 tripped the *mode* assertion but not the atomicity one. At a real payload — a few hundred bytes — the kernel writes in one go, so the torn window is unobservable and the same test passes against `os.WriteFile`. `TestWriteFileAtomicIsNeverPartiallyVisible` therefore exercises the primitive with a 4 MB payload, where a non-atomic writer is caught on the first round:

```
$ sed -i 's|^func writeFileAtomic(...) error {|&\n\treturn os.WriteFile(path, data, 0600) // MUTATED|'
$ grep -c MUTATED internal/account/manager.go
1
--- FAIL: TestWriteFileAtomicIsNeverPartiallyVisible (0.07s)
```

The small-payload test is kept alongside it, labelled for what it is: confirmation that the cache writer routes through the primitive, not an atomicity proof.

Every guard is paired with a success-path test — `TestLoadedEnvCanPersist`, `TestEmptyEnvCanPersist`, `TestGHAuthProceedsWithALoadedEnv`, `TestWriteJSONReportEmptyAccounts`, and the "both markers present" and "the repository this test lives in" cases — so none of them can pass by refusing everything. `TestGoQuotingIsNotJSONQuoting` demonstrates the `%q` premise directly rather than leaving it as a claim in a comment.

### What is not covered

No live container and no second real writer. The concurrency test runs both writer and reader in-process, which is the same race the two tools have through the filesystem but not literally two processes.

## Where

- `tui/internal/config/env.go` — `formatEnvValue`, `NewUnloadableEnv`, `CanPersist`, `Save`
- `tui/internal/account/manager.go` — `writeFileAtomic`, `writeLimitlineCache`, `apiCooldowns`, `ClearAPICooldowns`
- `tui/internal/account/manager_helpers.go` — cooldown call sites, `writeCacheUpdates`
- `tui/internal/ui/dashboard/helpers.go` — `startGHAuth` guard
- `tui/main.go` — `projectMarkers`, `isProjectRoot`, `jsonReport`, `writeJSONReport`
- new: `env_quoting_test.go`, `env_unloadable_test.go`, `state_write_test.go`, `gh_auth_guard_test.go`, `main_test.go`
