### PR TITLE
fix(tui): give the error screen a writer and delete dead paths

### DIFF
--- a/tui/internal/account/account.go
+++ b/tui/internal/account/account.go
@@ -51,19 +51,6 @@ type UsageBucket struct {
 	ResetAt     string
 }
 
-// TokenSummary holds JSONL-derived token counts (fallback when limitline is unavailable).
-type TokenSummary struct {
-	InputTokens  int64
-	OutputTokens int64
-	CacheTokens  int64 // cache_creation + cache_read
-	SessionCount int
-}
-
-// Total returns the total token count.
-func (t TokenSummary) Total() int64 {
-	return t.InputTokens + t.OutputTokens + t.CacheTokens
-}
-
 // Account represents a single agent account with its runtime state.
 type Account struct {
 	Letter          string
@@ -81,16 +68,19 @@ type Account struct {
 	// Claude-only fields. These stay zero/nil for runtimes that do not
 	// expose a Claude-style OAuth usage endpoint; the dashboard then
 	// renders "--" for usage. See #271.
+	//
+	// There was a Tokens *TokenSummary here as well, described as a
+	// "JSONL-derived fallback when limitline is unavailable". The fallback was
+	// never implemented: the field was written on every refresh and read only
+	// by HasUsageData, which had no caller. Filling it walked
+	// ~/.claude-state/account-*/projects/**.jsonl on every refresh and on
+	// every --json invocation, for a value nothing rendered. Removed in #358
+	// (item 14); the dashboard still shows "--" when limitline has no data,
+	// exactly as before.
 	FiveHourUsage  *UsageBucket
 	SevenDayUsage  *UsageBucket
-	Tokens         *TokenSummary // JSONL-derived fallback when limitline is unavailable
-	APIRateLimited bool          // true when usage API returned 429 recently
-	LastAPIStatus  string        // debug: last API status ("200", "429", "err: ...", "skipped (cooldown)", "cached")
-}
-
-// HasUsageData returns true if any usage data is available (limitline or JSONL).
-func (a *Account) HasUsageData() bool {
-	return a.FiveHourUsage != nil || (a.Tokens != nil && a.Tokens.Total() > 0)
+	APIRateLimited bool   // true when usage API returned 429 recently
+	LastAPIStatus  string // debug: last API status ("200", "429", "err: ...", "skipped (cooldown)", "cached")
 }
 
 // IsRunning returns true if the container is running.

--- a/tui/internal/account/list_error_test.go
+++ b/tui/internal/account/list_error_test.go
@@ -1,0 +1,44 @@
+package account
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kcenon/claude-docker/tui/internal/config"
+	"github.com/kcenon/claude-docker/tui/internal/docker"
+)
+
+// TestListAccountsReportsADockerFailure covers #358 item 9 at the source.
+//
+// ListAccounts' only return was `return accounts, nil`, so Model.err had no
+// writer and view.go's error branch was dead. The accounts still come back
+// alongside the error: they were discovered from the state directories and do
+// not depend on docker, so a caller that can show a partial view should.
+func TestListAccountsReportsADockerFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	env := config.NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+	env.Set("NUM_ACCOUNTS", "2")
+	// A project root with no compose file: `docker compose ps` fails at once
+	// rather than reaching a daemon.
+	m := NewManager(env, docker.NewClient(t.TempDir(), env))
+
+	accounts, err := m.ListAccounts()
+
+	if err == nil {
+		t.Fatal("a docker failure must be reported, not swallowed")
+	}
+	if !strings.Contains(err.Error(), "container status unavailable") {
+		t.Errorf("the error should say what is missing, got: %v", err)
+	}
+	if len(accounts) != 2 {
+		t.Errorf("accounts should still be returned alongside the error, got %d", len(accounts))
+	}
+	for _, a := range accounts {
+		if a.ContainerStatus != ContainerNotCreated {
+			t.Errorf("%s: status should be unknown, got %v", a.ServiceName, a.ContainerStatus)
+		}
+	}
+}

--- a/tui/internal/account/manager.go
+++ b/tui/internal/account/manager.go
@@ -11,18 +11,18 @@ import (
 	"github.com/kcenon/claude-docker/tui/internal/auth"
 	"github.com/kcenon/claude-docker/tui/internal/config"
 	"github.com/kcenon/claude-docker/tui/internal/docker"
-	"github.com/kcenon/claude-docker/tui/internal/usage"
 )
 
 // Manager provides CRUD operations on accounts.
+//
+// The usageCache field is gone with the JSONL pipeline it served (#358, item
+// 14). internal/usage is no longer reached from production code; it is kept,
+// still tested and still benchmarked, because docs/PERFORMANCE.md is written
+// about it and it holds the repository's only benchmark. Removing the package
+// is a separate decision from removing the walk.
 type Manager struct {
 	env    *config.Env
 	client *docker.Client
-	// usageCache memoizes parsed JSONL session files across ListAccounts
-	// calls. Unchanged files (same size+mtime) are returned from the cache
-	// instead of being re-read and re-decoded, which keeps refresh cost
-	// proportional to changed data rather than total accumulated history.
-	usageCache *usage.Cache
 	// cooldowns tracks per-account API backoff in memory. It was a file in
 	// each state directory until #358; see apiCooldowns for why that was a
 	// worse place for a 25-second value with no cross-process reader.
@@ -32,10 +32,9 @@ type Manager struct {
 // NewManager creates an account manager.
 func NewManager(env *config.Env, client *docker.Client) *Manager {
 	return &Manager{
-		env:        env,
-		client:     client,
-		usageCache: usage.NewCache(),
-		cooldowns:  newAPICooldowns(),
+		env:       env,
+		client:    client,
+		cooldowns: newAPICooldowns(),
 	}
 }
 
@@ -43,15 +42,30 @@ func NewManager(env *config.Env, client *docker.Client) *Manager {
 //
 // The method is a thin orchestrator over five focused helpers (defined in
 // manager_helpers.go); each helper owns one phase of the listing workflow.
-// Side-effects (cache writes, cooldown writes) and error policy match the
-// previous monolithic impl: non-fatal phases swallow their errors and
-// degrade gracefully.
+// Non-fatal phases still degrade gracefully rather than aborting the listing.
+//
+// It used to return a nil error unconditionally, which is what left
+// Model.err with no writer and the error screen in view.go unreachable
+// (#358, item 9). The docker error is now reported, because the two states it
+// used to collapse together want different responses from the operator:
+//
+//   - docker cannot be reached: nothing is running, `u` will not help, and the
+//     fix is outside the dashboard;
+//   - docker answered and there are no containers: `u` is exactly the fix.
+//
+// Accounts are returned alongside the error rather than instead of them. A
+// caller that can show a partial view should; view.go shows the table with a
+// warning when both are present, and the error screen only when there is
+// nothing else to draw.
 func (m *Manager) ListAccounts() ([]Account, error) {
 	stateDirs, n := m.discoverStateDirs()
-	containerMap := m.fetchContainerStatus()
+	containerMap, dockerErr := m.fetchContainerStatus()
 	accounts := m.buildAccounts(n, stateDirs, containerMap)
 	apiResults := m.enrichAccounts(accounts)
 	m.writeCacheUpdates(accounts, apiResults)
+	if dockerErr != nil {
+		return accounts, fmt.Errorf("container status unavailable: %w", dockerErr)
+	}
 	return accounts, nil
 }
 

--- a/tui/internal/account/manager_helpers.go
+++ b/tui/internal/account/manager_helpers.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kcenon/claude-docker/tui/internal/auth"
 	"github.com/kcenon/claude-docker/tui/internal/config"
 	"github.com/kcenon/claude-docker/tui/internal/docker"
-	"github.com/kcenon/claude-docker/tui/internal/usage"
 )
 
 // ghAuthTimeout bounds the in-container `gh api user` call (#358, item 1).
@@ -58,28 +57,35 @@ func (m *Manager) discoverStateDirs() (map[string]config.StateDir, int) {
 }
 
 // fetchContainerStatus queries docker compose and returns container info
-// keyed by service name. A docker error degrades to an empty map so listing
-// still works when the daemon is unreachable.
-func (m *Manager) fetchContainerStatus() map[string]docker.ContainerInfo {
-	containers, _ := m.client.PS()
+// keyed by service name, plus whatever went wrong.
+//
+// The error is still not fatal -- listing degrades to "no containers" so the
+// dashboard works with an unreachable daemon -- but it is no longer discarded
+// (#358, item 9). Swallowed, a dead docker daemon rendered identically to
+// "the containers have not been created yet", and Model.err had no writer
+// anywhere, so the error screen in view.go was unreachable code.
+func (m *Manager) fetchContainerStatus() (map[string]docker.ContainerInfo, error) {
+	containers, err := m.client.PS()
 	out := make(map[string]docker.ContainerInfo, len(containers))
 	for _, c := range containers {
 		out[c.Service] = c
 	}
-	return out
+	return out, err
 }
 
 // buildAccounts constructs the Account skeletons for indexes 1..n with
-// state-dir resolution, auth type, limitline cache, JSONL token summary,
-// and container status applied.
+// state-dir resolution, auth type, limitline cache, and container status
+// applied.
+//
+// It also used to build a JSONL token summary per account, walking
+// ~/.claude-state/account-*/projects/**.jsonl on every refresh. Nothing read
+// the result -- see the note on Account -- so the walk and its cache are gone
+// (#358, item 14).
 func (m *Manager) buildAccounts(n int, stateDirs map[string]config.StateDir, containerMap map[string]docker.ContainerInfo) []Account {
 	accounts := make([]Account, n)
 	runtime := m.env.AgentRuntime()
 	servicePrefix := m.env.ServicePrefix()
 	claudeUsage := m.env.SupportsClaudeUsage()
-	// Projects trees visited by this refresh. Each scan only prunes inside
-	// its own tree, so accounts that have gone away are released here.
-	scannedRoots := make([]string, 0, n)
 	for i := 1; i <= n; i++ {
 		letter := config.IndexToLetter(i)
 		svcName := servicePrefix + "-" + letter
@@ -99,24 +105,6 @@ func (m *Manager) buildAccounts(n int, stateDirs map[string]config.StateDir, con
 				acct.FiveHourUsage, acct.SevenDayUsage = parseLimitlineCache(sd.LimitlineCachePath())
 			}
 
-			// JSONL token summary (always populated when session data exists).
-			// Uses the manager-scoped cache so unchanged session files are
-			// not re-read and re-decoded on every dashboard refresh.
-			if claudeUsage {
-				projectsDir := sd.ProjectsDir()
-				scannedRoots = append(scannedRoots, projectsDir)
-				if sessions, err := usage.ScanAccountSessionsWithCache(projectsDir, m.usageCache); err == nil && len(sessions) > 0 {
-					opts := usage.AllTimeOptions()
-					tokens := usage.AggregateSessions(sessions, opts)
-					count := usage.CountFilteredSessions(sessions, opts)
-					acct.Tokens = &TokenSummary{
-						InputTokens:  tokens.InputTokens,
-						OutputTokens: tokens.OutputTokens,
-						CacheTokens:  tokens.CacheCreationInputTokens + tokens.CacheReadInputTokens,
-						SessionCount: count,
-					}
-				}
-			}
 		}
 
 		if ci, ok := containerMap[svcName]; ok {
@@ -131,7 +119,6 @@ func (m *Manager) buildAccounts(n int, stateDirs map[string]config.StateDir, con
 
 		accounts[i-1] = acct
 	}
-	m.usageCache.RetainRoots(scannedRoots)
 	return accounts
 }
 

--- a/tui/internal/account/manager_helpers_test.go
+++ b/tui/internal/account/manager_helpers_test.go
@@ -140,16 +140,20 @@ func TestDiscoverStateDirs_GeminiRuntime(t *testing.T) {
 
 // TestFetchContainerStatus confirms the helper returns an empty map when
 // the docker client cannot enumerate containers (no compose project, no
-// daemon). The orchestrator must continue to function in this degraded
-// state, hence the swallowed error.
+// daemon). The orchestrator must continue to function in this degraded state,
+// so the map is still usable -- but the error is now returned alongside it
+// rather than discarded (#358, item 9).
 func TestFetchContainerStatus(t *testing.T) {
 	m := newTestManager(t, nil)
-	got := m.fetchContainerStatus()
+	got, err := m.fetchContainerStatus()
 	if got == nil {
 		t.Fatal("fetchContainerStatus returned nil; want non-nil empty map")
 	}
 	if len(got) != 0 {
 		t.Errorf("fetchContainerStatus len = %d, want 0 (no docker available in test env)", len(got))
+	}
+	if err == nil {
+		t.Error("expected the docker failure to be reported, not swallowed")
 	}
 }
 

--- a/tui/internal/account/no_jsonl_pipeline_test.go
+++ b/tui/internal/account/no_jsonl_pipeline_test.go
@@ -1,0 +1,97 @@
+package account
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kcenon/claude-docker/tui/internal/config"
+	"github.com/kcenon/claude-docker/tui/internal/docker"
+)
+
+// TestProductionCodeDoesNotImportUsage pins the removal in #358 item 14.
+//
+// Account.Tokens was written on every refresh and read only by HasUsageData,
+// which had no caller: the "fallback when limitline is unavailable" the field
+// documented was never implemented. Filling it walked
+// ~/.claude-state/account-*/projects/**.jsonl on every dashboard refresh and
+// every --json invocation, for a value nothing rendered.
+//
+// A structural assertion rather than a behavioral one, because "this work no
+// longer happens" has no output to observe. Test files are excluded on
+// purpose: internal/usage keeps its own tests and its benchmark, which
+// docs/PERFORMANCE.md is written about. What must not come back is the
+// production call path.
+func TestProductionCodeDoesNotImportUsage(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+
+	checked := 0
+	fset := token.NewFileSet()
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		checked++
+		f, err := parser.ParseFile(fset, name, nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, imp := range f.Imports {
+			if strings.Contains(imp.Path.Value, "internal/usage") {
+				t.Errorf("%s imports internal/usage; the JSONL pipeline was removed in #358", name)
+			}
+		}
+	}
+
+	// Guard against the check passing because it found nothing to check.
+	if checked == 0 {
+		t.Fatal("no non-test Go files were examined")
+	}
+}
+
+// TestAccountHasNoTokensField is the compile-time half, expressed as a
+// runtime assertion so it reads as a test rather than as a build error.
+//
+// Constructing an Account with the removed field would not compile, so what
+// is asserted here is the observable consequence: a listing produces accounts
+// whose only usage data comes from limitline, and nothing walks a projects
+// tree to fill anything else in.
+func TestListAccountsDoesNotReadProjectsTrees(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// A state directory with a projects tree that would be walked by the old
+	// pipeline. The file is not valid JSONL; the old parser tolerated that
+	// per-file, so this is not what would have failed -- the point is that
+	// nothing opens it at all now.
+	stateDir := filepath.Join(home, ".claude-state", "account-a")
+	projects := filepath.Join(stateDir, "projects", "some-project")
+	if err := os.MkdirAll(projects, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	sentinel := filepath.Join(projects, "session.jsonl")
+	if err := os.WriteFile(sentinel, []byte("not json at all\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	env := config.NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+	env.Set("NUM_ACCOUNTS", "1")
+	m := NewManager(env, docker.NewClient(t.TempDir(), env))
+
+	accounts, _ := m.ListAccounts()
+	if len(accounts) != 1 {
+		t.Fatalf("expected 1 account, got %d", len(accounts))
+	}
+	// Usage stays nil without a limitline cache, which is the same "--" the
+	// table drew before: removing the pipeline changed no rendered output.
+	if accounts[0].FiveHourUsage != nil || accounts[0].SevenDayUsage != nil {
+		t.Errorf("usage should be nil with no limitline cache: %+v", accounts[0])
+	}
+}

--- a/tui/internal/config/env.go
+++ b/tui/internal/config/env.go
@@ -17,11 +17,18 @@ import (
 const (
 	// DefaultNumAccounts matches the compose generator fallback.
 	DefaultNumAccounts = 2
-	RuntimeClaude      = "claude"
-	RuntimeCodex       = "codex"
-	RuntimeGemini      = "gemini"
-	GHAuthShared       = "shared"
-	GHAuthPerAccount   = "per-account"
+
+	// MaxAccounts is the highest index the Excel-style letter scheme can
+	// name: 702 is "zz". Shared with normalize_account_count in
+	// scripts/lib/index.sh and its PowerShell counterpart, which cap at the
+	// same value; above it IndexToLetter returns "" and every service
+	// collapses onto the same name.
+	MaxAccounts      = 702
+	RuntimeClaude    = "claude"
+	RuntimeCodex     = "codex"
+	RuntimeGemini    = "gemini"
+	GHAuthShared     = "shared"
+	GHAuthPerAccount = "per-account"
 
 	// Isolation modes name the workspace trust boundary a set of accounts
 	// runs under. Kept in lockstep with scripts/lib/isolation.sh and the
@@ -48,6 +55,20 @@ const (
 // Moving the write onto the event loop would not be enough: the refresh Cmd
 // still reads from its own goroutine, so the collision would move rather than
 // go away. The lock covers every reader, present and future.
+//
+// # Nil receiver
+//
+// Every method on *Env is safe to call on a nil receiver and behaves as if
+// the file were empty: readers return their documented defaults, Set is a
+// no-op, and Save returns an error. Model.env can be nil, so this is a
+// property callers rely on rather than a courtesy.
+//
+// Seven methods guarded nil and twelve did not (#358, item 15). Because the
+// twelve were all built on Get, and Get was one of the unguarded ones, the
+// split was not "these are safe and those are not" -- it was that a nil Env
+// panicked on almost everything while looking as though the case had been
+// considered. The guard is on Get, Set and Save now, which is every path that
+// touches the fields; the pre-existing per-method guards are left in place.
 type Env struct {
 	mu      sync.RWMutex
 	path    string
@@ -179,7 +200,17 @@ func (e *Env) CanPersist() bool {
 }
 
 // Get returns the value of a key, or empty string if not set.
+//
+// Nil-safe, which is what makes the contract on Env uniform (#358, item 15):
+// every accessor on this type is built on Get, so guarding here is what lets
+// NumAccounts, IsolationMode, ServicePrefix and the rest answer their
+// documented defaults on a nil receiver instead of each needing its own
+// guard. The seven methods that already had one keep it -- they are correct
+// and cost nothing -- but they are no longer the only ones that are safe.
 func (e *Env) Get(key string) string {
+	if e == nil {
+		return ""
+	}
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 	if i, ok := e.index[key]; ok {
@@ -197,6 +228,12 @@ func (e *Env) Get(key string) string {
 // appends -- and .env.example ships all three token keys commented out, which
 // LoadEnv does not index, so even shared mode appends on the first press.
 func (e *Env) Set(key, value string) {
+	if e == nil {
+		// Nothing to write to and nothing that could later read it. Save on a
+		// nil receiver returns an error, so a lost write here cannot become a
+		// silently successful one.
+		return
+	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if i, ok := e.index[key]; ok {
@@ -212,6 +249,9 @@ func (e *Env) Set(key, value string) {
 // Save writes the env file back to disk, preserving order/comments.
 // Uses atomic rename + 0600 permissions because the file holds secrets.
 func (e *Env) Save() error {
+	if e == nil {
+		return fmt.Errorf("no env loaded")
+	}
 	// Snapshot under the read lock, then write without holding it. The write
 	// includes a temp file, a rename and -- on Windows -- an icacls exec;
 	// holding the lock across that would stall every render for as long as
@@ -330,17 +370,52 @@ func hardenSecretFile(path string) error {
 	return nil
 }
 
-// NumAccounts returns the NUM_ACCOUNTS value from .env (default 2).
+// NumAccounts returns the NUM_ACCOUNTS value from .env (default 2), clamped
+// to the range the letter generator can name.
+//
+// The lower bound was here already; the upper one was not (#358, item 12).
+// IndexToLetter returns "" above MaxAccounts, so NUM_ACCOUNTS=1000 produced
+// accounts 703 and up with an empty letter -- and every one of them then
+// built the same service name, `claude-`, because the name is
+// prefix + "-" + letter. Duplicate service names in a dashboard whose primary
+// action is "attach to the selected one" is worse than refusing the value.
+//
+// Clamped rather than rejected, to match normalize_account_count in
+// scripts/lib/index.sh, which caps at the same 702. NumAccountsWarning
+// reports the clamp; the dashboard renders it in the banner.
 func (e *Env) NumAccounts() int {
+	n, _ := e.numAccounts()
+	return n
+}
+
+// NumAccountsWarning returns a human-readable note when NUM_ACCOUNTS was not
+// usable as written, or "" when it was. Empty for an unset value: the default
+// is not a problem to report.
+func (e *Env) NumAccountsWarning() string {
+	_, warning := e.numAccounts()
+	return warning
+}
+
+func (e *Env) numAccounts() (int, string) {
 	v := e.Get("NUM_ACCOUNTS")
 	if v == "" {
-		return DefaultNumAccounts
+		return DefaultNumAccounts, ""
 	}
 	n, err := strconv.Atoi(v)
-	if err != nil || n < 1 {
-		return DefaultNumAccounts
+	if err != nil {
+		return DefaultNumAccounts, fmt.Sprintf(
+			"NUM_ACCOUNTS=%s is not a number; using %d", v, DefaultNumAccounts)
 	}
-	return n
+	if n < 1 {
+		return DefaultNumAccounts, fmt.Sprintf(
+			"NUM_ACCOUNTS=%d is below 1; using %d", n, DefaultNumAccounts)
+	}
+	if n > MaxAccounts {
+		return MaxAccounts, fmt.Sprintf(
+			"NUM_ACCOUNTS=%d exceeds the %d accounts the letter scheme can name; using %d",
+			n, MaxAccounts, MaxAccounts)
+	}
+	return n, ""
 }
 
 // AgentRuntime returns the selected agent runtime. Claude is the default.
@@ -546,10 +621,10 @@ func IsolationModeTagline(mode string) string {
 // IndexToLetter converts a 1-based account index to its Excel-style
 // letter name: 1 -> "a", 26 -> "z", 27 -> "aa", 52 -> "az", 702 -> "zz".
 // Values 1-26 are bit-for-bit identical to the previous single-letter impl.
-// Returns "" for non-positive input. Upper bound is 702 (zz) to match the
-// bash/PowerShell generators; larger values also return "".
+// Returns "" for non-positive input. Upper bound is MaxAccounts (702, "zz")
+// to match the bash/PowerShell generators; larger values also return "".
 func IndexToLetter(i int) string {
-	if i < 1 || i > 702 {
+	if i < 1 || i > MaxAccounts {
 		return ""
 	}
 	var buf []byte

--- a/tui/internal/config/num_accounts_test.go
+++ b/tui/internal/config/num_accounts_test.go
@@ -1,0 +1,137 @@
+package config
+
+import (
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func envWith(t *testing.T, key, value string) *Env {
+	t.Helper()
+	e := NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+	if value != "" {
+		e.Set(key, value)
+	}
+	return e
+}
+
+// TestNumAccountsBounds covers #358 item 12. The lower bound existed; the
+// upper one did not, and IndexToLetter returns "" above MaxAccounts -- so
+// every account past 702 got an empty letter and therefore the *same* service
+// name, `<prefix>-`, in a dashboard whose primary action is "attach to the
+// selected one".
+func TestNumAccountsBounds(t *testing.T) {
+	cases := []struct {
+		name        string
+		value       string
+		want        int
+		wantWarning string // substring, "" means no warning
+	}{
+		{"unset uses the default", "", DefaultNumAccounts, ""},
+		{"one", "1", 1, ""},
+		{"ordinary", "4", 4, ""},
+		{"exactly the cap", "702", MaxAccounts, ""},
+		{"above the cap", "1000", MaxAccounts, "exceeds"},
+		{"far above the cap", "999999", MaxAccounts, "exceeds"},
+		{"zero", "0", DefaultNumAccounts, "below 1"},
+		{"negative", "-3", DefaultNumAccounts, "below 1"},
+		{"not a number", "many", DefaultNumAccounts, "not a number"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := envWith(t, "NUM_ACCOUNTS", tc.value)
+
+			if got := e.NumAccounts(); got != tc.want {
+				t.Errorf("NumAccounts() = %d, want %d", got, tc.want)
+			}
+
+			warning := e.NumAccountsWarning()
+			if tc.wantWarning == "" {
+				if warning != "" {
+					t.Errorf("unexpected warning: %q", warning)
+				}
+				return
+			}
+			if !strings.Contains(warning, tc.wantWarning) {
+				t.Errorf("warning = %q, want it to mention %q", warning, tc.wantWarning)
+			}
+		})
+	}
+}
+
+// TestEveryAccountIndexHasADistinctLetter is the consequence the bound
+// protects: within the clamped range no two accounts collide, and one past it
+// would.
+func TestEveryAccountIndexHasADistinctLetter(t *testing.T) {
+	e := envWith(t, "NUM_ACCOUNTS", strconv.Itoa(MaxAccounts+50))
+	n := e.NumAccounts()
+
+	seen := make(map[string]int, n)
+	for i := 1; i <= n; i++ {
+		letter := IndexToLetter(i)
+		if letter == "" {
+			t.Fatalf("index %d has no letter, but NumAccounts allowed it", i)
+		}
+		if prev, dup := seen[letter]; dup {
+			t.Fatalf("indexes %d and %d both map to %q", prev, i, letter)
+		}
+		seen[letter] = i
+	}
+
+	// And the first index past the clamp is exactly the one that would break.
+	if IndexToLetter(MaxAccounts+1) != "" {
+		t.Errorf("IndexToLetter(%d) should be empty; the clamp exists because it is",
+			MaxAccounts+1)
+	}
+}
+
+// TestNilEnvIsUniformlySafe covers #358 item 15.
+//
+// Model.env can be nil, and seven of nineteen methods guarded for it. Because
+// the other twelve were all built on Get -- which was not one of the seven --
+// a nil Env panicked on almost everything while looking as though the case
+// had been handled. Every method is called here; the test failing means a
+// panic, and the assertions check the documented defaults.
+func TestNilEnvIsUniformlySafe(t *testing.T) {
+	var e *Env
+
+	if got := e.Get("ANYTHING"); got != "" {
+		t.Errorf("Get = %q, want empty", got)
+	}
+	e.Set("KEY", "value") // must not panic
+	if err := e.Save(); err == nil {
+		t.Error("Save on a nil Env must report an error rather than claim success")
+	}
+	if got := e.NumAccounts(); got != DefaultNumAccounts {
+		t.Errorf("NumAccounts = %d, want %d", got, DefaultNumAccounts)
+	}
+	if got := e.NumAccountsWarning(); got != "" {
+		t.Errorf("NumAccountsWarning = %q, want empty", got)
+	}
+	if got := e.AgentRuntime(); got != RuntimeClaude {
+		t.Errorf("AgentRuntime = %q, want %q", got, RuntimeClaude)
+	}
+	if got := e.IsolationMode(); got != IsolationShared {
+		t.Errorf("IsolationMode = %q, want %q", got, IsolationShared)
+	}
+	if got := e.GitHubAuthMode(); got != GHAuthShared {
+		t.Errorf("GitHubAuthMode = %q, want %q", got, GHAuthShared)
+	}
+
+	// The remaining accessors: no defaults worth pinning individually, but
+	// each one must return rather than panic.
+	_ = e.RuntimeSpec()
+	_ = e.ServicePrefix()
+	_ = e.StateDirName()
+	_ = e.RuntimeBinary()
+	_ = e.SkipPermissionsFlag()
+	_ = e.RuntimeCommandArgs(true)
+	_ = e.SupportsClaudeUsage()
+	_ = e.APIKey("a")
+	_ = e.GHUser("a")
+	_ = e.GHTokenKey("a")
+	_ = e.HasWorktrees()
+	_ = e.UnusedWorkspaceWarnings()
+}

--- a/tui/internal/ui/dashboard/render.go
+++ b/tui/internal/ui/dashboard/render.go
@@ -48,6 +48,15 @@ func renderIsolationBanner(env *config.Env) string {
 	for _, w := range env.UnusedWorkspaceWarnings() {
 		out += "\n" + warnStyle.Render("  Warning: "+w)
 	}
+	// A clamped NUM_ACCOUNTS belongs in the same place and for the same
+	// reason: it is a property of .env rather than of an operation, so it
+	// stays visible for as long as it is true (#358, item 12). Silently
+	// clamping is what the shell generators do; silently clamping with
+	// nothing on screen is what left the dashboard disagreeing with the
+	// number in the file.
+	if w := env.NumAccountsWarning(); w != "" {
+		out += "\n" + warnStyle.Render("  Warning: "+w)
+	}
 
 	return out + "\n\n"
 }

--- a/tui/internal/ui/dashboard/screens_test.go
+++ b/tui/internal/ui/dashboard/screens_test.go
@@ -1,0 +1,130 @@
+package dashboard
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kcenon/claude-docker/tui/internal/account"
+	"github.com/kcenon/claude-docker/tui/internal/config"
+)
+
+func plainView(m Model) string {
+	return ansiEscape.ReplaceAllString(m.View(), "")
+}
+
+// TestThreeDistinctScreens covers #358 item 9.
+//
+// ListAccounts returned a nil error unconditionally, so Model.err had no
+// writer anywhere and view.go's error branch was unreachable code. The
+// consequence on screen: a docker daemon that is down rendered exactly like
+// an install whose containers had simply never been created. The two want
+// opposite responses -- `u` fixes the second and cannot touch the first.
+func TestThreeDistinctScreens(t *testing.T) {
+	env := config.NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+	accounts := []account.Account{
+		{Letter: "a", ServiceName: "claude-a"},
+		{Letter: "b", ServiceName: "claude-b"},
+	}
+	dockerDown := errors.New("container status unavailable: docker compose ps: exec: \"docker\": not found")
+
+	t.Run("docker down with nothing to show", func(t *testing.T) {
+		m := New(nil, nil, env, false)
+		m.loading = false
+		m.err = dockerDown
+		m.SetSize(120, 40)
+
+		got := plainView(m)
+		if !strings.Contains(got, "Error:") {
+			t.Errorf("expected the error screen:\n%s", got)
+		}
+		if !strings.Contains(got, "docker") {
+			t.Errorf("the error should name what failed:\n%s", got)
+		}
+		if strings.Contains(got, "No accounts configured") {
+			t.Errorf("a docker failure must not read as an empty install:\n%s", got)
+		}
+	})
+
+	t.Run("no accounts and docker is fine", func(t *testing.T) {
+		m := New(nil, nil, env, false)
+		m.loading = false
+		m.SetSize(120, 40)
+
+		got := plainView(m)
+		if !strings.Contains(got, "No accounts configured") {
+			t.Errorf("expected the empty-install screen:\n%s", got)
+		}
+		if strings.Contains(got, "Error:") {
+			t.Errorf("an empty install is not an error:\n%s", got)
+		}
+	})
+
+	t.Run("accounts discovered but docker is down", func(t *testing.T) {
+		m := New(nil, nil, env, false)
+		m.loading = false
+		m.err = dockerDown
+		m.accounts = accounts
+		m.SetSize(120, 40)
+
+		got := plainView(m)
+		// The table wins: the accounts came from the state directories and
+		// are worth showing even with an unknown container column.
+		if !strings.Contains(got, "claude-a") || !strings.Contains(got, "SERVICE") {
+			t.Errorf("the table should still render:\n%s", got)
+		}
+		// ...but the reason every STATUS cell reads "--" has to be on screen,
+		// or this is the indistinguishable case again.
+		if !strings.Contains(got, "Warning:") || !strings.Contains(got, "docker") {
+			t.Errorf("the degradation should be named above the table:\n%s", got)
+		}
+		if strings.Contains(got, "Press [r] to retry") {
+			t.Errorf("the full-screen error should not replace a usable table:\n%s", got)
+		}
+	})
+
+	t.Run("everything fine", func(t *testing.T) {
+		m := New(nil, nil, env, false)
+		m.loading = false
+		m.accounts = accounts
+		m.SetSize(120, 40)
+
+		got := plainView(m)
+		if strings.Contains(got, "Warning:") || strings.Contains(got, "Error:") {
+			t.Errorf("a healthy dashboard should say neither:\n%s", got)
+		}
+		if !strings.Contains(got, "claude-b") {
+			t.Errorf("the table should render:\n%s", got)
+		}
+	})
+}
+
+// TestBannerReportsAClampedAccountCount covers #358 item 12's "with a visible
+// message" half. The shell generators clamp silently; the dashboard clamping
+// silently is what would leave it disagreeing with the number in .env with
+// nothing to explain the difference.
+func TestBannerReportsAClampedAccountCount(t *testing.T) {
+	env := config.NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+	env.Set("NUM_ACCOUNTS", "1000")
+
+	got := ansiEscape.ReplaceAllString(renderIsolationBanner(env), "")
+	if !strings.Contains(got, "NUM_ACCOUNTS=1000") {
+		t.Errorf("the banner should quote the configured value:\n%s", got)
+	}
+	if !strings.Contains(got, "702") {
+		t.Errorf("the banner should name the cap:\n%s", got)
+	}
+}
+
+// TestBannerSaysNothingAboutAUsableAccountCount keeps the warning from being
+// permanent furniture.
+func TestBannerSaysNothingAboutAUsableAccountCount(t *testing.T) {
+	env := config.NewEmptyEnv(filepath.Join(t.TempDir(), ".env"))
+	env.Set("NUM_ACCOUNTS", "4")
+
+	got := ansiEscape.ReplaceAllString(renderIsolationBanner(env), "")
+	if strings.Contains(got, "NUM_ACCOUNTS") {
+		t.Errorf("a usable count should produce no warning:\n%s", got)
+	}
+}

--- a/tui/internal/ui/dashboard/view.go
+++ b/tui/internal/ui/dashboard/view.go
@@ -14,7 +14,17 @@ func (m Model) View() string {
 	if m.loading {
 		return "  Loading accounts..."
 	}
-	if m.err != nil {
+	// Three outcomes, three screens (#358, item 9). ListAccounts used to
+	// return a nil error unconditionally, so this branch had no writer and a
+	// dead docker daemon was indistinguishable from an install whose
+	// containers had simply never been created -- two states whose fix is
+	// entirely different.
+	//
+	// The error screen is only for the case with nothing else to draw. When
+	// accounts were discovered from the state directories, they are worth
+	// showing even though their container column is unknown, so the table
+	// wins and the error becomes the banner below it.
+	if m.err != nil && len(m.accounts) == 0 {
 		return fmt.Sprintf("  Error: %v\n\n  Press [r] to retry", m.err)
 	}
 	if len(m.accounts) == 0 {
@@ -28,6 +38,15 @@ func (m Model) View() string {
 	var b strings.Builder
 
 	b.WriteString(renderIsolationBanner(m.env))
+
+	// A degraded listing, drawn above the table it degrades. The STATUS
+	// column reads "--" for every row in this state, which on its own looks
+	// like "not created yet"; this line is what separates the two.
+	if m.err != nil {
+		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("#EF4444")).
+			Render(fmt.Sprintf("  Warning: %v", m.err)) + "\n\n")
+	}
+
 	b.WriteString(renderAccountTable(m.accounts, m.cursor, m.width))
 	b.WriteString("\n")
 

--- a/tui/internal/usage/aggregator.go
+++ b/tui/internal/usage/aggregator.go
@@ -20,12 +20,12 @@ func AllTimeOptions() AggregateOptions {
 	return AggregateOptions{}
 }
 
-// DailyOptions returns options for today's entries (KST local).
-func DailyOptions() AggregateOptions {
-	now := time.Now()
-	start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
-	return AggregateOptions{Since: &start}
-}
+// DailyOptions was removed in #358 (item 13). Its doc comment promised
+// "today's entries (KST local)" while the body used time.Now().Location(),
+// the machine-local zone -- so on any host not set to Asia/Seoul it silently
+// selected a different day than it claimed. It had no caller outside its own
+// test, so there was nothing to make correct: a KST-fixed version would have
+// been dead code that merely told the truth.
 
 // AggregateSessions sums token usage across all entries matching options.
 func AggregateSessions(sessions []Session, opts AggregateOptions) TokenTotals {

--- a/tui/internal/usage/usage_test.go
+++ b/tui/internal/usage/usage_test.go
@@ -16,22 +16,10 @@ func TestAllTimeOptions(t *testing.T) {
 	}
 }
 
-// TestDailyOptions verifies the "today" option sets Since to today's local
-// midnight, so entries from earlier days are excluded.
-func TestDailyOptions(t *testing.T) {
-	opts := DailyOptions()
-	if opts.Since == nil {
-		t.Fatal("DailyOptions().Since = nil, want non-nil")
-	}
-	now := time.Now()
-	want := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
-	if !opts.Since.Equal(want) {
-		t.Errorf("DailyOptions().Since = %v, want %v", *opts.Since, want)
-	}
-	if opts.Since.Hour() != 0 || opts.Since.Minute() != 0 || opts.Since.Second() != 0 {
-		t.Errorf("DailyOptions().Since = %v, want 00:00:00", *opts.Since)
-	}
-}
+// TestDailyOptions is gone with DailyOptions itself (#358, item 13). It
+// asserted the machine-local midnight the body computed, not the KST midnight
+// the doc comment promised -- so it agreed with the code and could never have
+// reported the discrepancy.
 
 // makeEntry builds a SessionEntry with the supplied token counts and timestamp.
 func makeEntry(input, output, cacheCreate, cacheRead int64, ts string) SessionEntry {


### PR DESCRIPTION
Closes #358
Relates to #343, #351, #360

Third and last of three for #358, after [#376](https://github.com/kcenon/claude-docker/pull/376) (hangs and panics) and [#377](https://github.com/kcenon/claude-docker/pull/377) (writes and output). This one is the correctness debt behind them.

**Merge order matters.** B and C both touch `env.go`, `manager.go`, `manager_helpers.go` and `render.go`. They are textually independent but adjacent; merging B first and rebasing C is the cheaper direction.

## What

| # | Defect | Fix |
|---|---|---|
| 9 | `ListAccounts` always returns a nil error, so `Model.err` has no writer and the error screen is dead | report the docker failure; three distinct screens |
| 12 | `NumAccounts` has a lower bound but no upper one | clamp to `MaxAccounts`, report the clamp in the banner |
| 13 | `DailyOptions` promises KST, uses machine-local, has no production caller | deleted |
| 14 | `Account.Tokens` is written every refresh and read by nothing | pipeline deleted |
| 15 | the nil-receiver contract is honored by some methods and not others | guarded at `Get`/`Set`/`Save`, contract documented on the type |

The remaining acceptance criterion — *"`go vet ./...` runs in the `go-test` job and passes"* — is **already satisfied**. It was added along with `-race` under #351 (`ci.yml:134-136`), before this issue was filed. Nothing to do; noting it so the checklist is not left looking unfinished.

## Why each one bites

**#9 is the one with a user-visible consequence.** `ListAccounts`' only return was `return accounts, nil`, which follows the policy its own doc comment states — *"non-fatal phases swallow their errors and degrade gracefully"* — and that policy is right for a dashboard. But it left `Model.err` with no writer anywhere in the program, so `view.go:17-19` was unreachable, and a dead docker daemon rendered identically to "the containers have not been created yet". Those two want opposite responses from the operator: `u` fixes the second and cannot touch the first.

The fix is not "make it fatal". The accounts come from the state directories and do not depend on docker, so they are still returned alongside the error, and the view decides:

| state | screen |
|---|---|
| docker down, no accounts discovered | `Error: ... Press [r] to retry` |
| docker down, accounts discovered | the table, with a red `Warning:` line above it |
| docker fine, no accounts | `No accounts configured` |
| docker fine, accounts | the table |

The middle row is the one that matters: every `STATUS` cell reads `--` in that state, which on its own is exactly what "not created yet" looks like.

**#12.** `IndexToLetter` returns `""` above 702, and a service name is `prefix + "-" + letter`. `NUM_ACCOUNTS=1000` therefore produced 298 accounts all named `claude-`, in a dashboard whose primary action is "attach to the selected one". Clamped rather than rejected, to match `normalize_account_count` in `scripts/lib/index.sh`, which caps at the same value — and the clamp is now *said*, because clamping silently is what would leave the dashboard disagreeing with the number in `.env` with nothing to explain the difference.

**#15.** The split was not "these methods are safe and those are not". All twelve unguarded methods were built on `Get`, and `Get` was one of the unguarded ones — so a nil `Env` panicked on almost everything while the seven scattered guards made it look as though the case had been considered.

## The two decisions the issue left open

Both resolved as **delete**.

**#14.** The field was declared as a "fallback when limitline is unavailable" and that fallback was never implemented. Rendering it would have meant designing a second presentation — a token total is not a percentage of a rate limit and cannot go in the same gauge — which is a feature, not a fix. Deleting removes a directory walk that ran on every refresh (and the tick chain runs every second while any account is rate-limited) for a value nothing displayed. No rendered output changes: the cells that showed `--` still show `--`.

**#13.** A KST-fixed version would have been dead code that merely told the truth. Its test asserted the machine-local midnight the body computed, so it agreed with the implementation and could never have reported the discrepancy — the same shape as the `render_test.go` workaround #376 removed.

### `internal/usage` is left in place, deliberately

After #14 nothing in production reaches that package. Deleting it is a *different* decision than deleting the walk, and a larger one: `docs/PERFORMANCE.md` is written about `usage.Cache` — its measurement procedure, its recorded numbers — and `BenchmarkAlternatingAccountScans` is the repository's only benchmark, which the `go-test` job runs as a dedicated step. Removing the package silently empties that step and invalidates a document that #360 is separately about.

So the package stays, still tested and still benchmarked, and `Manager`'s doc comment says why. If it should go, that is a one-line follow-up plus a docs change, and it should be taken on purpose.

## Verification

`go test -race ./...`, `go vet ./...`, `gofmt -l .` — clean. 4 new test files.

**Mutation-tested, clean baseline, and each mutation is verified applied before its test runs** — a `grep -c` guard, after an earlier run in this series reported `ok` for a mutation whose regex had silently failed to match:

```
=== baseline ===                                   all ok
M1  NumAccounts upper bound removed   -> FAIL TestNumAccountsBounds (2 subtests) + TestEveryAccountIndexHasADistinctLetter
M2  Get loses its nil guard           -> FAIL TestNilEnvIsUniformlySafe
M3  ListAccounts swallows docker err  -> FAIL TestListAccountsReportsADockerFailure
M4  view collapses the error screen   -> FAIL TestThreeDistinctScreens (2 subtests)
M5  banner drops the clamp warning    -> FAIL TestBannerReportsAClampedAccountCount
M6  the JSONL import comes back       -> FAIL TestProductionCodeDoesNotImportUsage
```

Each guard is paired with its negative: `TestThreeDistinctScreens` asserts the healthy dashboard says neither "Warning:" nor "Error:", and `TestBannerSaysNothingAboutAUsableAccountCount` keeps the clamp warning from becoming permanent furniture.

`TestProductionCodeDoesNotImportUsage` is structural — "this work no longer happens" has no output to observe — and it counts the files it examined, so it cannot pass by finding nothing to check. `TestListAccountsDoesNotReadProjectsTrees` stages a `projects/**.jsonl` tree the old pipeline would have walked and asserts the listing is unaffected.

### What is not covered

No live docker daemon: the "docker down" state is produced by pointing the client at a directory with no compose file, which fails before reaching a socket. That is the same substitute the pre-existing dashboard tests use, and it exercises the same error path, but it is not a daemon that died mid-session.

## Where

- `tui/internal/account/manager.go` — `ListAccounts`, `Manager`
- `tui/internal/account/manager_helpers.go` — `fetchContainerStatus`, `buildAccounts`
- `tui/internal/account/account.go` — `TokenSummary`, `Tokens`, `HasUsageData` removed
- `tui/internal/config/env.go` — `MaxAccounts`, `NumAccounts`, `NumAccountsWarning`, nil guards
- `tui/internal/usage/aggregator.go` — `DailyOptions` removed
- `tui/internal/ui/dashboard/view.go`, `render.go`
- new: `num_accounts_test.go`, `screens_test.go`, `no_jsonl_pipeline_test.go`, `list_error_test.go`
