### PR TITLE
docs: reconcile README, ISOLATION.md and .env.example with the code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,37 @@
 # ==== Required ====
 PROJECT_DIR=/absolute/path/to/your/project
 
+# ==== Container mount point for PROJECT_DIR (optional) ====
+# Where PROJECT_DIR appears inside the container, and the working directory
+# each session starts in. Defaults to /project. The per-account equivalents for
+# worktree and isolated mode are further down.
+# CONTAINER_PROJECT_DIR=/project
+
+# ==== Account count (optional) ====
+# How many accounts the generators emit services for. Defaults to 2; the
+# supported range is 1..702, the span the Excel-style letter suffixes cover
+# (a..zz). Regenerate compose files after changing it, or use
+# `scripts/claude-docker scale N`, which does both.
+#
+# Note that this is a floor for the TUI rather than an exact count: the
+# dashboard also lists any account state directory it finds on disk.
+# NUM_ACCOUNTS=2
+
+# ==== Container timezone (optional) ====
+# Passed straight through to each container as TZ. Defaults to UTC, so
+# container timestamps are UTC unless this is set. Affects log and transcript
+# timestamps inside the container, nothing on the host.
+# TZ=Asia/Seoul
+
+# ==== Image tag (optional) ====
+# The tag the generated compose files pin for claude-code-base. Defaults to the
+# contents of the repo-root VERSION file, and install.sh seeds it from there.
+#
+# `docker compose up` reuses a local image already carrying this tag instead of
+# rebuilding, so pinning an old tag here keeps an old image indefinitely. Change
+# it only to pin a specific build deliberately; regenerate compose afterwards.
+# IMAGE_TAG=2026.08.17
+
 # ==== Workspace isolation (optional) ====
 # Declares the trust boundary every account runs under. Shared is the
 # backward-compatible default; leaving this unset behaves exactly as an
@@ -134,12 +165,47 @@ PROJECT_DIR=/absolute/path/to/your/project
 # container the kernel OOM-kills under load.
 # CONTAINER_NODE_HEAP_MB=3072
 
-# ==== Linux: UID/GID (auto-set by install.sh) ====
+# ==== Host config source override (optional) ====
+# Where the container reads the runtime's shared configuration from. Unset, it
+# is the read-only mount of the host's ~/.claude (or ~/.codex, ~/.gemini).
+# Point it at a path inside the project bind mount to iterate on config without
+# re-running the host bootstrap:
+# CLAUDE_CONFIG_SOURCE=/project/claude-config/global
+#
+# WARNING: an explicit source is treated as WRITABLE. On every container start
+# the entrypoint rewrites the .sh files under it in place, stripping CRLF line
+# endings. If the source is inside your repository, those rewrites show up as
+# host-side git changes. The default read-only mount is never modified.
+
+# ==== Project script CRLF normalization (opt-in) ====
+# Set to 1 to have the entrypoint strip CRLF from *.sh files under /project on
+# every start, up to three directory levels deep. Off by default, because
+# /project is a bind mount and rewriting host files can surprise an editor,
+# show up in `git status`, or race a concurrent host write. Typical use: a
+# Windows host with a CRLF-default editor and no enforcing .gitattributes.
+# CLAUDE_NORMALIZE_CRLF=1
+
+# ==== Codex agents/skills directory (optional; codex runtime only) ====
+# Host directory bind-mounted read-only at /home/node/.agents/skills for the
+# codex runtime. Only codex mounts it; claude gets skills through its host
+# config mount and gemini through its own. Defaults to ~/.agents/skills.
+# AGENTS_SKILLS_DIR=/absolute/path/to/agents/skills
+
+# ==== Linux: UID/GID (auto-set by install.sh on native Linux) ====
+# install.sh writes these only when it classifies the platform as `linux`.
+# WSL2 is classified separately, so a WSL2 install does not get them -- which
+# matters only if you invoke `docker compose` directly with
+# docker-compose.linux.yml, whose `user: "${UID}:${GID}"` has no fallback and
+# resolves to ":" when they are unset. Going through scripts/claude-docker is
+# unaffected; it exports both itself.
 # UID=1000
 # GID=1000
 
-# ==== Tier B: Git Worktree Paths (set by setup-worktrees.sh) ====
+# ==== Tier B: Git Worktree Paths (printed by setup-worktrees.sh) ====
 # Required when ISOLATION_MODE=worktree -- one entry per configured account.
+# setup-worktrees.sh creates the worktrees and prints these lines; copying them
+# in here is a manual step. Without them the worktree overlay has nothing to
+# bind and the accounts stay on the shared PROJECT_DIR mount.
 # Setting these without an explicit ISOLATION_MODE still selects worktree mode,
 # which is how installs predating that key are kept working unchanged.
 # PROJECT_DIR_A=/path/to/worktree-a
@@ -150,8 +216,10 @@ PROJECT_DIR=/absolute/path/to/your/project
 # CONTAINER_PROJECT_DIR_A=/project-a
 # CONTAINER_PROJECT_DIR_B=/project-b
 
-# ==== Isolated: Independent Clone Paths (set by setup-isolated.sh) ====
+# ==== Isolated: Independent Clone Paths (printed by setup-isolated.sh) ====
 # Required when ISOLATION_MODE=isolated -- one entry per configured account.
+# As with the worktree block above, setup-isolated.sh prints these lines; it
+# does not write them.
 # Unlike PROJECT_DIR_A above, setting these does NOT select isolated mode on
 # their own: nothing predates this key, so an undeclared mode is a mistake to
 # report rather than a legacy layout to honor. Declare ISOLATION_MODE=isolated

--- a/.env.example
+++ b/.env.example
@@ -177,6 +177,19 @@ PROJECT_DIR=/absolute/path/to/your/project
 # endings. If the source is inside your repository, those rewrites show up as
 # host-side git changes. The default read-only mount is never modified.
 
+# ==== Start anyway with degraded settings (escape hatch) ====
+# Set to 1 to let the container start even when bootstrap could not fully
+# prepare the runtime's settings. Without it the entrypoint refuses, because
+# starting silently degraded is worse than not starting: in every blocking
+# case the raw host settings.json ends up in use, and its hook commands are
+# pwsh invocations that do not exist on Linux, so the hooks quietly never fire.
+#
+# The blocking cases are: jq is not installed so no transformation ran; the
+# transformation failed; it produced invalid JSON; or the transformed hook
+# commands did not pass a bash syntax check. Advisory degradations are printed
+# but never block, with or without this variable.
+# CLAUDE_ALLOW_DEGRADED_SETTINGS=1
+
 # ==== Project script CRLF normalization (opt-in) ====
 # Set to 1 to have the entrypoint strip CRLF from *.sh files under /project on
 # every start, up to three directory levels deep. Off by default, because

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,11 @@ jobs:
           # *means*: base-10 parsing, casing, and whether whitespace counts as
           # unset (#356).
           - tests/test_env_value_semantics.sh
+          # Enumeration checks only: every tracked compose file is listed where
+          # README enumerates them, every ${VAR} the base compose reads is in
+          # .env.example. Prose correctness is not machine-checkable; these are
+          # the lists that went stale when isolated mode landed (#360).
+          - tests/test_docs_contracts.sh
           - scripts/test-entrypoint-settings.sh
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/README.md
+++ b/README.md
@@ -762,12 +762,22 @@ No `.git/index.lock` contention.
 
 ```bash
 scripts/setup-worktrees.sh ~/work/project    # Create worktrees
+# add the printed PROJECT_DIR_* lines to .env
 scripts/claude-docker up                     # Selects the worktree overlay
 ```
 
+The middle step is not optional. `setup-worktrees.sh` creates the worktrees and
+**prints** the `PROJECT_DIR_<X>` lines; it does not write them anywhere. With
+neither those paths nor an explicit `ISOLATION_MODE` in `.env`, the mode
+resolves to `shared`, the worktree overlay is never composed, and `up` starts
+every container on the one Tier A mount — silently, because that is a valid
+shared install and nothing distinguishes it from an intended one. (Declaring
+`ISOLATION_MODE=worktree` *and* omitting the paths is refused outright; it is
+the inferred case that passes quietly.) Tier C below has the same shape.
+
 On native Windows, use
-`.\scripts\setup-worktrees.ps1 C:\path\to\project`, then start with
-`.\scripts\claude-docker.ps1 up`.
+`.\scripts\setup-worktrees.ps1 C:\path\to\project`, add the printed lines to
+`.env`, then start with `.\scripts\claude-docker.ps1 up`.
 
 Setting `PROJECT_DIR_A` selects worktree mode on its own, which is how installs
 predating `ISOLATION_MODE` keep working unchanged. Setting the key explicitly
@@ -867,10 +877,27 @@ volumes. The selected runtime determines the account and host-config paths:
 | Gemini | `~/.gemini-state/account-a/` | `/home/node/.gemini/` | `~/.gemini/` -> `/home/node/.gemini-host/` |
 
 Mutable credentials, sessions, logs, and runtime history stay in the account
-state mount. Bootstrap modules deliberately exclude known credential and
-session files when they copy or link selected host configuration. That selected
-configuration is still visible to the container, so do not embed secrets in it.
-Other persistent mounts are:
+state mount. When the bootstrap modules **copy or link** host configuration into
+that account state directory, they select specific entries and leave known
+credential and session files out of the selection.
+
+That exclusion is about what gets copied. It is not a statement about what the
+container can reach, and the two are different:
+
+> **The host config mount is the whole directory.** `docker-compose.yml` binds
+> `${HOME}/.claude` (and the codex/gemini equivalents) entire, not the six
+> entries the entrypoint consumes. Inside it are the runtime's OAuth credential
+> file — `.credentials.json`, `auth.json`, `oauth_creds.json` by runtime — and
+> `projects/`, the session transcripts. The container runs as the host user, so
+> the file's `0600` does not withhold it: **every account container can read
+> the host's credentials and transcripts, and therefore each other's.** The
+> mount is read-only, so nothing can be written back through it.
+>
+> `ISOLATION_MODE=isolated` is the only mode that removes the mount. See
+> [`docs/ISOLATION.md`](docs/ISOLATION.md#interaction-with-the-shared-runtime-configuration-mount).
+
+Do not embed secrets in the selected configuration either — it is visible to the
+container by the same route. Other persistent mounts are:
 
 | Data | Host/source | Container destination | Mode |
 |------|-------------|-----------------------|------|
@@ -896,6 +923,7 @@ environment:
 | `NUM_ACCOUNTS` | `2` | `scripts/generate-compose.sh` default |
 | `AGENT_RUNTIME` | `claude` | `scripts/lib/runtime.sh` default |
 | `IMAGE_TAG` | contents of `VERSION` | repo-root `VERSION` file |
+| `ISOLATION_MODE` | `shared` | `scripts/lib/isolation.sh` default |
 
 The `Compose files are current` CI job regenerates under exactly those defaults
 and fails on any difference. Regenerating with your own `.env` during local work
@@ -1245,10 +1273,6 @@ claude-docker/
     +-- env_fixtures/
     +-- entrypoint_fixtures/
 ```
-
-`sources/` contains local nested working directories that are gitignored
-and never copied into the Docker image. They can be removed safely if not
-in use.
 
 ## License
 

--- a/docs/ISOLATION.md
+++ b/docs/ISOLATION.md
@@ -90,7 +90,7 @@ tool call, a compromised dependency's postinstall script.
 | Account A edits account B's working tree | No | Yes | Yes |
 | Account A reads account B's working tree | No | Yes | Yes |
 | Account A rewrites shared git history (`.git`) | No | **No** | Yes |
-| Account A reads the shared host configuration | No | No | Yes |
+| Account A reads the shared host configuration, including the runtime credential file and `projects/` transcripts (see [the mount section](#interaction-with-the-shared-runtime-configuration-mount)) | No | No | Yes |
 | Container root filesystem is read-only | No | No | Yes |
 | Capabilities dropped and privilege escalation blocked | No | No | Yes |
 | Account A holds account B's GitHub credential | No | No | Yes |
@@ -180,11 +180,26 @@ Exactly one mode overlay is ever composed. Composing two would let the later
 one replace the volume list again, which is how a boundary could be undone by
 an ordering accident rather than a code change.
 
-**The overlay order settles the `user` question.** Both the base stack and
-`docker-compose.linux.yml` declare `user: "${UID:-1000}:${GID:-1000}"`, and the
-mode overlay is appended **after** both, so an isolated stack could override the
-field outright — Compose lets a later `-f` win. It deliberately does not; see
+**The overlay order settles the `user` question.** The base stack declares
+`user: "${UID:-1000}:${GID:-1000}"` and `docker-compose.linux.yml` declares
+`user: "${UID}:${GID}"` — no defaults, which is the difference that matters
+below — and the mode overlay is appended **after** both, so an isolated stack
+could override the field outright; Compose lets a later `-f` win. It
+deliberately does not; see
 [Why the host user, not `node`](#why-the-host-user-not-node).
+
+Because the Linux overlay has no fallback, composing it with `UID`/`GID` unset
+resolves to `user: ":"` and the daemon rejects the project. Nothing that goes
+through `scripts/claude-docker` can hit that — `build_compose_cmd` exports both
+variables itself before invoking Compose — but a raw `docker compose -f ... -f
+docker-compose.linux.yml` invocation can, and `scripts/install.sh` writes the
+pair into `.env` only when it classifies the platform as `linux`. **WSL2 is
+classified as `wsl2`, so a WSL2 install has no `UID`/`GID` in `.env`.** Add them
+by hand if you invoke Compose directly there:
+
+```bash
+printf 'UID=%s\nGID=%s\n' "$(id -u)" "$(id -g)" >> .env
+```
 
 ## The hardened container profile
 
@@ -281,8 +296,12 @@ should be configured with per-account authentication rather than handed the
 shared token — that is what #331 exists for, and this mode reuses its contract
 unchanged rather than growing a second mechanism.
 
-Provider API keys were already per-account (`ANTHROPIC_API_KEY_<X>` and the
-equivalents for other runtimes) and are unaffected. `GIT_USER_NAME` and
+Provider API keys were already per-account and are unaffected. The variable you
+set in `.env` is `CLAUDE_API_KEY_<X>` (`CODEX_API_KEY_<X>`, `GEMINI_API_KEY_<X>`
+for the other runtimes); the generator reads only that prefixed form and emits
+the SDK's own name — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY` —
+into the container. Both halves come from `apiKeyVarPrefix` and `sdkApiKeyVar`
+in `tui/internal/config/runtimes.json`. `GIT_USER_NAME` and
 `GIT_USER_EMAIL` are still passed through: they are committer identity, they
 name the human rather than an account, and an isolated account still has to be
 able to commit.
@@ -347,6 +366,28 @@ Every service mounts the host's `~/.claude/` read-only at
 in [`docs/CLAUDE_DOCKER_CONTRACT.md`](https://github.com/kcenon/claude-config/blob/develop/docs/CLAUDE_DOCKER_CONTRACT.md)
 in `kcenon/claude-config`, and the entrypoint depends on its directory layout,
 hook command grammar, and settings transform.
+
+**The mount is the whole directory, not the parts the entrypoint reads.**
+`bootstrap-claude.sh` consumes a finite list — `hooks/`, `scripts/`, `skills/`,
+`commands/`, `ccstatusline/` and `settings.json` — but `docker-compose.yml`
+binds `${HOME}/.claude` entire. Two things inside it are worth naming, because
+neither is obvious from "shared host configuration":
+
+- the runtime's OAuth credential file — `.credentials.json` for claude,
+  `auth.json` for codex, `oauth_creds.json` for gemini;
+- `projects/`, which holds session transcripts.
+
+The container runs as the host user (`user: "${UID:-1000}:${GID:-1000}"`), so
+the host's own `0600` on the credential file does not withhold it: every
+account container can read both, and read each other's by extension. The mount
+is read-only, so nothing can be modified through it.
+
+This is a property of `shared` and `worktree` alike — it is a host-home
+surface, not a workspace one, which is why the workspace table above does not
+capture it. `isolated` is the only mode that removes it, by not creating the
+mount at all (`generate-compose.sh` gates it on the mode). Choosing between the
+modes therefore includes choosing whether accounts can read one another's
+credentials and transcripts.
 
 **As shipped, `isolated` takes the absent-by-default half of that requirement.**
 An isolated service receives no `~/.claude` mount, no agents/skills mount and

--- a/scripts/claude-docker
+++ b/scripts/claude-docker
@@ -60,15 +60,11 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 # Populates the COMPOSE_CMD array with the full `docker compose ...` invocation.
 # Array-based so paths containing whitespace survive argument parsing.
 #
-# Overlay selection logic:
-# 1. Base docker-compose.yml is always included
-# 2. docker-compose.linux.yml is added on Linux hosts when the file exists
-# 3. The overlay named by the resolved ISOLATION_MODE is added:
-#    docker-compose.worktree.yml for worktree, docker-compose.isolated.yml for
-#    isolated, none for shared (lib/isolation.sh). A mode whose overlay is
-#    missing is refused rather than silently downgraded.
-#
-# build_compose_cmd() itself lives in lib/build-compose-cmd.sh (sourced above).
+# build_compose_cmd() itself lives in lib/build-compose-cmd.sh (sourced above),
+# which is labelled canonical and carries the overlay-selection rules. This
+# comment used to restate that list, which is how the two fell out of step when
+# isolated mode added a fourth compose file: the executable copy was updated
+# because it runs, and the prose copy was not (#360). Read the rules there.
 COMPOSE_CMD=()
 COMPOSE_CMD_INITIALIZED=0
 

--- a/tests/test_docs_contracts.sh
+++ b/tests/test_docs_contracts.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# test_docs_contracts.sh - documentation claims that the tree can falsify
+# (issue #360).
+#
+# Run:  bash tests/test_docs_contracts.sh
+# Exits non-zero on any failure.
+#
+# Two invariants, both chosen because they are the ones that actually went
+# stale. Isolated mode landed across #336-#341 and added a fourth compose file;
+# the documents that *enumerate* the repository were not extended with it, and
+# nothing noticed because prose has no compiler. `.env.example` drifted the
+# other way: six keys in real use appeared in it zero times, while README tells
+# the reader to `cp .env.example .env` as the complete manual path.
+#
+#   1. Every git-tracked docker-compose*.yml appears in README's Project
+#      Structure tree, in the recovery command, and in the overlay table.
+#   2. Every ${VAR} the base compose file reads appears in .env.example.
+#
+# What this deliberately does not do is check prose for correctness. It checks
+# enumerations -- the places where a list in a document is supposed to mirror a
+# list in the tree, and where "someone added a file" is the failure mode.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+README="$PROJECT_ROOT/README.md"
+ENV_EXAMPLE="$PROJECT_ROOT/.env.example"
+BASE_COMPOSE="$PROJECT_ROOT/docker-compose.yml"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS  $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL  $1"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+echo "=== every generated compose file is enumerated in README ==="
+# ---------------------------------------------------------------------------
+
+# git ls-files rather than a glob: an untracked docker-compose.override.yml a
+# developer left in their checkout is not something README should have to list,
+# and Glob would report it.
+compose_files=$(git -C "$PROJECT_ROOT" ls-files 'docker-compose*.yml' | sort)
+
+count=$(printf '%s\n' "$compose_files" | grep -c 'docker-compose')
+if [ "$count" -lt 2 ]; then
+    echo "  ERROR: found $count tracked compose files; the check would be vacuous" >&2
+    exit 1
+fi
+echo "  (checking $count tracked compose files)"
+
+# The recovery command README gives for restoring the committed copies. It has
+# to name every generated file, or following it leaves one modified and the
+# `Compose files are current` job still failing.
+recovery_line=$(grep -n 'git checkout -- docker-compose' "$README" | head -1)
+if [ -z "$recovery_line" ]; then
+    fail "README has no 'git checkout -- docker-compose' recovery command"
+    recovery_line=""
+fi
+
+# The Project Structure tree.
+tree_block=$(awk '/^## Project Structure/,/^## License/' "$README")
+if [ -z "$tree_block" ]; then
+    echo "  ERROR: could not locate the Project Structure section" >&2
+    exit 1
+fi
+
+# The overlay table: rows begin with | `docker-compose...
+overlay_rows=$(grep -E '^\| `docker-compose[^`]*\.yml`' "$README")
+
+for f in $compose_files; do
+    if printf '%s' "$tree_block" | grep -qF "$f"; then
+        pass "$f is in the Project Structure tree"
+    else
+        fail "$f is missing from the Project Structure tree"
+    fi
+
+    if [ -n "$recovery_line" ]; then
+        if printf '%s' "$recovery_line" | grep -qF "$f"; then
+            pass "$f is in the recovery command"
+        else
+            fail "$f is missing from the recovery command"
+        fi
+    fi
+
+    if printf '%s' "$overlay_rows" | grep -qF "$f"; then
+        pass "$f has an overlay-table row"
+    else
+        fail "$f has no overlay-table row"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== every variable docker-compose.yml reads is in .env.example ==="
+# ---------------------------------------------------------------------------
+#
+# README presents `cp .env.example .env` as the complete manual path, so a
+# variable the compose file reads and the template never mentions is a setting
+# the user cannot discover from the documented workflow.
+
+# Extract ${NAME} and ${NAME:-default}. The name is the leading run of
+# [A-Za-z_][A-Za-z0-9_]*; anything after : or } is the default and not a name.
+compose_vars=$(grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*' "$BASE_COMPOSE" \
+    | sed 's/^\${//' | sort -u)
+
+var_count=$(printf '%s\n' "$compose_vars" | grep -c '.')
+if [ "$var_count" -lt 5 ]; then
+    echo "  ERROR: extracted only $var_count variables; the check would be vacuous" >&2
+    exit 1
+fi
+echo "  (checking $var_count variables read by docker-compose.yml)"
+
+# Names the compose file reads that .env.example has no reason to carry.
+#
+# HOME, UID and GID come from the invoking shell rather than from .env -- UID
+# and GID are documented there anyway, because install.sh writes them on Linux,
+# but HOME is never a .env key.
+#
+# The per-account suffixed forms are generated from a base name that IS in the
+# template (PROJECT_DIR_A from the PROJECT_DIR_<X> block, and so on); listing
+# every letter would make the template unreadable without telling the reader
+# anything new.
+skip_var() {
+    case "$1" in
+        HOME) return 0 ;;
+        # <BASE>_<LETTER>: covered by the base name's block.
+        *_[A-Z]|*_[A-Z][A-Z]) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+for v in $compose_vars; do
+    if skip_var "$v"; then
+        continue
+    fi
+    # Matched anywhere in the template, commented or not: these are optional
+    # settings, so the documented form is a commented example.
+    if grep -qE "(^|[^A-Za-z0-9_])${v}([^A-Za-z0-9_]|$)" "$ENV_EXAMPLE"; then
+        pass "$v is documented in .env.example"
+    else
+        fail "$v is read by docker-compose.yml but absent from .env.example"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Results ==="
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+
+if [ "$PASS" -eq 0 ]; then
+    echo "  ERROR: no assertions ran" >&2
+    exit 1
+fi
+
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
Closes #360
Relates to #357, #353

## What

Nine documented statements that do not match the code they describe. **Six are still present on develop; three had already been fixed** as isolated mode settled, and are recorded below rather than re-fixed.

| # | Claim in the issue | Status |
|---|---|---|
| 9 | mount understated | **real** — corrected in both documents |
| 1 | `ISOLATION.md:284` says `ANTHROPIC_API_KEY_<X>` | **real** |
| 2 | `.env.example` missing six keys | **real** — and a seventh, found by the new test |
| 5 | `ISOLATION.md:184` vs `docker-compose.linux.yml:7` | **real**, plus the WSL2 gap behind it |
| 7 | Tier B procedure omits writing the printed values | **real** |
| 8 | stale `sources/` paragraph | **real** |
| 3 | recovery command omits `docker-compose.isolated.yml` | **already fixed** — `README.md:857` lists all four |
| 6 | `scripts/claude-docker` overlay comment omits isolated | **already fixed** — it names isolated |
| 4 | Project Structure tree omits five entries | **already fixed** for all five; only the defaults table row was missing |

I verified each against the tree rather than taking the issue's word for it; the three already-fixed rows are why. The line numbers in the issue have also drifted (852 → 857), which is consistent with edits landing after it was filed.

## The one with a security-communication consequence

`docker-compose.yml:23` binds the **whole** host runtime config directory:

```yaml
- ${HOME}/.claude:/home/node/.claude-host:ro
```

The entrypoint consumes six entries from it. The mount is the entire tree, and it contains two things neither document named:

- the runtime's OAuth credential file — `.credentials.json`, `auth.json`, `oauth_creds.json` by runtime;
- `projects/`, the session transcripts.

The container runs as the host user (`user: "${UID:-1000}:${GID:-1000}"`), so the host's `0600` on the credential file does not withhold it. Every account container can read the host's credentials and transcripts, and each other's by extension.

**This is intended layering, not a defect.** `ISOLATION.md` already lists "Account A reads the shared host configuration" as a non-defense of `shared` and `worktree`, and `isolated` is the sanctioned removal path. What was wrong is the precision: a reader weighing `shared` against `isolated` could not see that the choice includes credentials and transcripts.

The README sentence was the sharper problem:

> Bootstrap modules deliberately exclude known credential and session files when they copy or link selected host configuration.

True of the copy/link selection, and it reads as a statement about what the container can reach. It is now scoped to the selection it governs, with the mount stated separately as a block quote.

Hardening the mount is explicitly out of scope per the issue, and I have not touched it.

## The others

**#2 is larger than filed.** The new test found `CONTAINER_PROJECT_DIR` — read by the base compose for the Tier A mount point, documented nowhere — on top of the six the issue lists. That is the test doing its job on its first run.

**#5 sits on a behavioral gap.** `docker-compose.linux.yml` has `user: "${UID}:${GID}"` with no fallback, so composing it with those unset resolves to `user: ":"` and the daemon rejects the project. `install.sh:791` writes the pair into `.env` only when the platform is `linux`, and `detect_platform` classifies WSL2 as `wsl2`. Anything going through `scripts/claude-docker` is fine — `build_compose_cmd` exports both itself — but the raw invocation the overlay's own header advertises is not. Documented in `ISOLATION.md` and `.env.example`, with the one-line remedy.

**#7 is silent when it bites.** `setup-worktrees.sh` prints the `PROJECT_DIR_<X>` lines and writes nothing. With neither those paths nor an explicit `ISOLATION_MODE`, the mode resolves to `shared`, the worktree overlay is never composed, and every container starts on the one Tier A mount — indistinguishable from an intended shared install. (Declaring `ISOLATION_MODE=worktree` *and* omitting the paths **is** refused; I checked, because the parenthetical would otherwise be a guess:

```
$ ISOLATION_MODE=worktree require_supported_isolation_mode 2
Error: PROJECT_DIR_A is required when ISOLATION_MODE=worktree
       Create the worktrees with scripts/setup-worktrees.sh, which prints the paths to add.
exit=1
```

It is the *inferred* case that passes quietly.) Both `.env.example` headings say "printed by" instead of "set by".

**#6, since it was already correct.** The comment now defers to `build-compose-cmd.sh` rather than restating its list. Restating it is what let the two fall out of step when isolated mode landed: the executable copy was updated because it runs, the prose copy was not. Deleting the duplicate is the fix that survives the next mode.

## Verification

`tests/test_docs_contracts.sh` (new, 25 assertions, `bash-tests` matrix) — `Passed: 25 Failed: 0`.

**Red first** for the half that was actually stale:

```
$ git archive origin/develop | tar -x -C tmp && bash tmp/tests/test_docs_contracts.sh
  FAIL  CLAUDE_CONFIG_SOURCE is read by docker-compose.yml but absent from .env.example
  FAIL  CLAUDE_NORMALIZE_CRLF ...
  FAIL  CONTAINER_PROJECT_DIR ...
  FAIL  IMAGE_TAG ...
  FAIL  TZ ...
  Passed: 20  Failed: 5
```

The compose-enumeration half passes on develop too, because rows 3, 4 and 6 were already repaired. It is a regression guard there, not a demonstration — stated plainly rather than presented as a catch.

Both halves assert their input count is non-zero and exit 1 otherwise, so neither can pass by finding nothing to check. `git ls-files` rather than a glob, so an untracked `docker-compose.override.yml` in a developer's checkout is not something README is required to list.

Full `bash-tests` matrix and shellcheck at CI severity: clean.

### What this test does not do

It checks **enumerations**, not prose. "Every tracked compose file appears where README lists compose files" is machine-checkable; "this paragraph describes the mount accurately" is not. Rows 1, 5, 7, 8 and 9 are therefore verified by hand — each one measured against the tree, quoted above where the measurement was not obvious — and are not protected against future drift by anything but review.

## Where

- `README.md` — mount block quote, bootstrap sentence scoped, Tier B step, defaults table, `sources/` paragraph removed
- `docs/ISOLATION.md` — mount section, trust-boundary row, API key variable, `user:` line and the WSL2 case
- `.env.example` — seven keys added, two headings corrected
- `scripts/claude-docker` — overlay comment defers to the canonical list
- `tests/test_docs_contracts.sh` (new), `.github/workflows/ci.yml`
