### PR TITLE
docs: add CONTRIBUTING.md and a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,54 @@
+<!--
+Base this PR on `develop`. `main` takes releases only.
+See CONTRIBUTING.md for the cross-language parity rule these boxes are about.
+-->
+
+## What
+
+<!-- The change, in a sentence or two. -->
+
+## Why
+
+<!--
+The problem it solves. If this is a fix, say what the defect did to a user,
+not only what the code did wrong.
+-->
+
+Closes #
+
+## How
+
+<!-- Anything a reviewer would otherwise have to reconstruct from the diff. -->
+
+## Verification
+
+<!--
+What you ran, and what it said. Paste the failure the fix removes; a claim
+that a test passes is weaker than a quote of it failing before the fix.
+-->
+
+---
+
+### Cross-language parity
+
+Most rules in this repository are implemented more than once. Tick what applies
+and say **not applicable** where it does not — an unticked box with no reason
+reads as an oversight.
+
+- [ ] I changed a rule that exists in more than one of: `scripts/lib/*.sh`,
+      `scripts/*.ps1` / `ClaudeDocker.psm1` / `scripts/lib/index.ps1`,
+      `tui/internal/config`, `scripts/entrypoint.sh` — and **all** the copies
+      move in this PR
+- [ ] Per-runtime values (binary, build arg, state dir, config paths) are read
+      from `tui/internal/config/runtimes.json`, not restated
+- [ ] An equivalence test covers the rule I changed, or this PR adds one
+- [ ] `docker-compose*.yml` regenerated if the generator changed
+      (`rm -f .env && bash scripts/generate-compose.sh`)
+- [ ] `VERSION` bumped if anything the `Dockerfile` `COPY`s changed — without
+      it the change never reaches an existing installation
+
+### Checks
+
+- [ ] The new test fails against the unfixed code (quoted above)
+- [ ] bash changes stay within bash 3.2 (macOS `/bin/bash`)
+- [ ] No secrets, tokens or credentials in the diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,10 @@ jobs:
           # rotation keeps the newest three rather than the newest three from
           # whichever installer used the longer format (#356).
           - tests/test_env_backup_rotation.sh
+          # CONTRIBUTING.md names the equivalence tests and the four
+          # implementation layers, which makes it one more copy that drifts on
+          # a rename. Referential integrity only (#356).
+          - tests/test_contributing_references.sh
           - scripts/test-entrypoint-settings.sh
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,131 @@
+# Contributing to claude-docker
+
+## The one rule this project keeps re-learning
+
+**Every behavioral rule in this repository is implemented more than once, in
+more than one language. A change to one copy is not a change to the rule.**
+
+That is not a design goal — it is the shape of the project. A Windows user and
+a Linux user configure the same repository and must get the same containers,
+the same trust boundary, and the same refusals, so the same logic exists in
+bash, in PowerShell, and sometimes in Go. Nothing in a compiler or a linter
+connects those copies. Only a test does, and only if one exists.
+
+The history is a run of after-the-fact repairs, each one "a change landed on
+one side and the two drifted":
+
+| commit | closes | repair |
+|--------|--------|--------|
+| `d2b966c` | #318 | `generate-compose.ps1` did not honor `NUM_ACCOUNTS`/`IMAGE_TAG` from the environment |
+| `ba5fd88` | #319 | added the bash-vs-PowerShell generator equivalence harness at all |
+| `c5ec02e` | #320, #323, #324, #325 | account-count validation aligned across generators and CLI wrappers |
+| `92a6a41` | #321 | Go default service count aligned with the generator default |
+
+`c5ec02e` is the archetype: it added `normalize_account_count` to
+`scripts/lib/index.sh` and did not touch `scripts/lib/index.ps1`, which
+declares itself a mirror of that file. The drift outlived the commit that
+created it by months.
+
+## The four layers
+
+When you change a rule, ask which of these implement it. Usually more than one.
+
+| Layer | Files | Reads |
+|-------|-------|-------|
+| bash libraries | `scripts/lib/*.sh` | sourced by `scripts/claude-docker`, both installers, both generators, `scripts/entrypoint.sh` |
+| PowerShell | `scripts/*.ps1`, `scripts/ClaudeDocker.psm1`, `scripts/lib/index.ps1` | the Windows-native counterparts of all of the above |
+| Go | `tui/internal/config` | the TUI dashboard, which reads `.env` and the runtime registry itself |
+| container | `scripts/entrypoint.sh`, `scripts/lib/bootstrap-*.sh` | runs inside every container; ships in the image, so a change here needs a `VERSION` bump |
+
+`tui/internal/config/runtimes.json` is the cross-language single source of
+truth for per-runtime values (binary name, build arg, state directory, config
+paths). **Read a runtime value from the registry rather than restating it.**
+All three languages have an accessor.
+
+## The tests that hold the layers together
+
+Each of these compares implementations against each other rather than against
+a fixture, which is what makes them able to notice drift:
+
+| Test | Pins |
+|------|------|
+| `tests/test_parse_env_equivalence.sh` | bash `parse_env_value` vs PowerShell `Get-EnvValue` produce identical output for identical input |
+| `tests/test_compose_generator_equivalence.sh` | `generate-compose.sh` and `generate-compose.ps1` emit byte-identical compose files |
+| `tests/test_runtime_registry_equivalence.sh` | all three registry readers return byte-identical values for every (runtime, field) pair |
+| `tests/test_installer_github_equivalence.sh` | both installers write the same GitHub block into `.env` in per-account mode |
+| `tests/test_isolation_modes.sh` | the shell, PowerShell and compose layers accept and refuse the same `ISOLATION_MODE` values |
+| `tests/test_num_accounts_precedence.sh` | all four shell-side `NUM_ACCOUNTS` readers use one precedence order |
+| `tests/test_bash32_portability.sh` | no bash 4+ construct enters `scripts/` or `tests/` |
+
+The `bash-tests` job in `.github/workflows/ci.yml` is the authoritative list;
+this table is the subset that exists to catch cross-layer drift specifically.
+
+**If you change a rule these tests do not cover, add coverage in the same PR.**
+A rule with copies and no equivalence test is a future repair commit.
+
+## Before you open a PR
+
+### Verification
+
+- **Run the tests, do not reason about them.** The CI matrix is in
+  `.github/workflows/ci.yml`; the bash suite is the `bash-tests` job's list.
+- **A test that passes is not the same as a test that would fail.** Break the
+  thing your test guards and confirm it goes red. If it does not, the test is
+  documentation, not a check.
+- **When you fix a defect, first run the new test against the unfixed code**
+  and quote the failure in the PR. If the test cannot fail against the old
+  code, it is testing something else.
+- Silence is not success: a harness that finds nothing to check reports the
+  same "0 failures" as one that checked everything. Assert your input count.
+
+### Portability
+
+- macOS ships bash 3.2 as `/bin/bash`. No `${var,,}`, no `mapfile`, no
+  associative arrays, no namerefs, no `wait -n`. The full list is in
+  `tests/test_bash32_portability.sh`, which enforces it.
+- Windows PowerShell 5.1 is **not** supported; scripts require `pwsh` 7+.
+- `scripts/lib/*.sh` is sourced by the container entrypoint, so it must not
+  assume anything the Debian image does not have.
+
+### Image content
+
+Anything the `Dockerfile` `COPY`s — itself, `scripts/entrypoint.sh`,
+`scripts/lib/`, `tui/internal/config/runtimes.json` — ships inside the image.
+`docker compose up` reuses a local image already carrying the pinned tag rather
+than rebuilding, so **a change to those paths that leaves `VERSION` alone never
+reaches an existing installation.** Bump `VERSION` and regenerate the compose
+files:
+
+```bash
+rm -f .env && bash scripts/generate-compose.sh
+```
+
+The `Image content changes bump VERSION` job enforces this. Check the paths it
+matches before relying on it: the rule is "anything the Dockerfile `COPY`s",
+and the job's pattern is a hand-maintained approximation of that list — which
+makes it one more copy that can drift from what it describes.
+
+### Generated files
+
+The four `docker-compose*.yml` files are generated and **tracked**. Regenerate
+with no `.env` present, which is what the `Compose files are current` job
+compares against. Do not hand-edit them.
+
+## Conventions
+
+- **Branch from `develop`**, and open PRs against `develop`. `main` takes
+  releases only.
+- **Conventional Commit** subjects: `type(scope): description`, imperative,
+  lowercase, no trailing period.
+- **English** for code, comments, commit messages, issues and PRs.
+- **No AI or tool attribution** in commits, issues or PRs.
+- Explain **why** in comments, not what. A comment that says what the line
+  below does goes stale silently; one that says why it is written that way is
+  what stops the next person from undoing it.
+
+## Where the deeper documents are
+
+- [`README.md`](README.md) — installation, usage, configuration reference
+- [`docs/ISOLATION.md`](docs/ISOLATION.md) — the three workspace isolation
+  modes and exactly what each one does and does not defend against
+- [`docs/PERFORMANCE.md`](docs/PERFORMANCE.md) — benchmark numbers of record

--- a/tests/test_contributing_references.sh
+++ b/tests/test_contributing_references.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# test_contributing_references.sh - every path CONTRIBUTING.md names exists
+# (issue #356, child 1).
+#
+# Run:  bash tests/test_contributing_references.sh
+# Exits non-zero on any failure.
+#
+# CONTRIBUTING.md's argument is that a rule with copies and no check drifts.
+# The document is itself such a copy: it lists the equivalence tests, the four
+# implementation layers and the registry path, and a rename anywhere in the
+# tree leaves it quietly naming something that is gone.
+#
+# Only referential integrity is checked -- that each path resolves. Whether
+# the prose describes the file correctly is a review question, not a
+# machine-checkable one.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DOC="$PROJECT_ROOT/CONTRIBUTING.md"
+TEMPLATE="$PROJECT_ROOT/.github/pull_request_template.md"
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS  $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL  $1"; FAIL=$((FAIL + 1)); }
+
+for required in "$DOC" "$TEMPLATE"; do
+    if [ -f "$required" ]; then
+        pass "$(basename "$required") exists"
+    else
+        fail "$(basename "$required") is missing"
+    fi
+done
+
+if [ ! -f "$DOC" ]; then
+    echo "  ERROR: cannot continue without CONTRIBUTING.md" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== every backticked repository path resolves ==="
+# ---------------------------------------------------------------------------
+#
+# Backticked tokens that look like paths into this repository: they contain a
+# slash and start with a known top-level directory or a tracked filename.
+# Anything with a glob is expanded and required to match at least once, since
+# `scripts/lib/*.sh` naming an empty set is the same failure as a dead path.
+
+paths=$(grep -oE '`(scripts|tests|tui|docs|\.github)/[A-Za-z0-9_./*-]+`' "$DOC" \
+    | tr -d '`' | sort -u)
+
+count=$(printf '%s\n' "$paths" | grep -c '/')
+if [ "$count" -lt 8 ]; then
+    echo "  ERROR: found only $count paths; the check would be vacuous" >&2
+    exit 1
+fi
+echo "  (checking $count referenced paths)"
+
+for p in $paths; do
+    case "$p" in
+        *'*'*)
+            # A glob: at least one match required.
+            # shellcheck disable=SC2086 # reason: deliberate glob expansion
+            matches=$(cd "$PROJECT_ROOT" && ls -d $p 2>/dev/null | wc -l | tr -d ' ')
+            if [ "${matches:-0}" -gt 0 ]; then
+                pass "$p matches $matches file(s)"
+            else
+                fail "$p matches nothing"
+            fi
+            ;;
+        *)
+            if [ -e "$PROJECT_ROOT/$p" ]; then
+                pass "$p exists"
+            else
+                fail "$p does not exist"
+            fi
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== the PR template carries the parity checkbox ==="
+# ---------------------------------------------------------------------------
+
+# A heading, not a mention. The template's own intro comment points at the
+# rule as well, so matching the phrase anywhere in the file would keep passing
+# after the section itself had been deleted.
+if grep -qiE '^#{1,4} .*cross-language parity' "$TEMPLATE"; then
+    pass "template has a cross-language parity section"
+else
+    fail "template has no cross-language parity heading"
+fi
+
+if grep -q 'runtimes.json' "$TEMPLATE"; then
+    pass "template points at the runtime registry"
+else
+    fail "template does not mention runtimes.json"
+fi
+
+if [ "$(grep -c '^- \[ \]' "$TEMPLATE")" -ge 5 ]; then
+    pass "template has the expected checkboxes"
+else
+    fail "template is missing checkboxes"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Results ==="
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
Relates to #356 (child 1 of 6)

First of the six children #356 proposes. It carries none of the nine drift rows — it exists so the other five have a rule to cite. Children 2–6 are independent of each other and of this one, but the issue asks for this to land first, and the reason is in the issue's own history table: every previous consolidation drifted again.

## What

- `CONTRIBUTING.md` — the cross-language parity rule, the four layers, the tests that pin them, and the verification habits
- `.github/pull_request_template.md` — a checkbox for the rule, plus the two consequences that are invisible until much later
- `tests/test_contributing_references.sh` — 46 assertions, `bash-tests` matrix

## Why a document, when the rule is already in the code

It is in the code, and that is the problem. From `ClaudeDocker.psm1:512-515`:

> PowerShell port of `scripts/lib/isolation.sh`. The two must agree on resolution order, accepted names, and which per-account paths each mode requires, because a Windows user and a Linux user configuring the same repository have to get the same trust boundary.

Twenty-four lines below that, `Get-IsolationMode` disagrees with `resolve_isolation_mode` on whitespace — `" "` fails closed on Linux and falls open to `shared` on Windows. `lib/index.ps1:27` likewise calls itself a mirror of `lib/index.sh` and ships no validator.

A rule stated inside the file it governs reaches only a contributor who already opened that file. This repository has no `CONTRIBUTING.md`, no `CLAUDE.md` and no PR template, so there was nowhere else for it to be.

## What the document says

**The four layers** that implement rules more than once: `scripts/lib/*.sh`; `scripts/*.ps1` + `ClaudeDocker.psm1` + `scripts/lib/index.ps1`; `tui/internal/config`; and the container code in `entrypoint.sh` + `bootstrap-*.sh`. Plus: read per-runtime values from `runtimes.json` rather than restating them.

**A table of the seven equivalence tests** and what each one pins — chosen because each compares implementations *against each other* rather than against a fixture, which is what makes them able to notice drift at all.

**The verification habits** this recent run of work actually depended on, stated as instructions rather than as narrative:

- run the new test against the unfixed code first, and quote the failure;
- break what a guard protects and confirm it goes red — a test that passes is not the same as a test that would fail;
- assert the input count, because a harness that found nothing to check reports the same "0 failures" as one that checked everything.

**The image-content rule**, which is the one that costs the most when missed: `docker compose up` reuses a local image already carrying the pinned tag, so a change to anything the Dockerfile `COPY`s that leaves `VERSION` alone never reaches an existing installation.

## The document is itself a copy

`CONTRIBUTING.md` lists paths and test names, which makes it exactly the kind of second copy it warns about: a rename leaves it quietly naming something that is gone. So the same rule is applied to it.

`tests/test_contributing_references.sh` extracts every backticked repository path from the document and requires it to resolve — globs must match at least once, since `scripts/lib/*.sh` naming an empty set is the same failure as a dead path. It also checks the template still has its parity section and its checkboxes.

Referential integrity only. Whether the prose *describes* each file correctly is a review question, not a machine-checkable one, and the test's header says so.

## Verification

`Passed: 46 Failed: 0`. Full `bash-tests` matrix (25 files) — 0 non-passing. shellcheck at CI severity clean; `ci.yml` still parses, 13 jobs.

**Mutation-tested, clean baseline:**

```
=== baseline ===                                          Failed: 0
M1  CONTRIBUTING names a test that no longer exists    -> FAIL tests/test_gone_missing.sh does not exist
M2  scripts/lib moved so the globs match nothing       -> Failed: 5
M3  the parity heading dropped from the template       -> FAIL template has no cross-language parity heading
```

**M3 did not fail on the first attempt, and that was the test's fault.** The assertion was `grep -qi 'cross-language parity'` anywhere in the file — but the template's own intro comment points at the rule too, so deleting the section left the phrase behind in a comment and the check kept passing. It now requires the phrase in a *heading*. The first run of this harness also had a red baseline from an incomplete temp copy; both are fixed and the results above are from the corrected run.

### Deliberately not included

`tests/test_docs_contracts.sh` is not in the test table: it arrives with #360, which is still open. Adding the row here would put a dead reference into the document on the very PR that adds a check against dead references. It should be added when #360 merges.

Likewise, the note about the `Image content changes bump VERSION` job says its pattern is a hand-maintained approximation of the Dockerfile's `COPY` list rather than claiming it covers all of them — on `develop` it matches only `Dockerfile` and `scripts/entrypoint`, and #357 widens it.

## Where

- `CONTRIBUTING.md` (new)
- `.github/pull_request_template.md` (new)
- `tests/test_contributing_references.sh` (new), `.github/workflows/ci.yml`
