### PR TITLE
fix(scripts): resolve the runtime binary and build arg from the registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,10 @@ jobs:
           # Runs both account-index implementations and diffs the answers,
           # rather than grepping either for a literal (#356).
           - tests/test_account_index_equivalence.sh
+          # Per-runtime values (buildArg, binary, servicePrefix) come from the
+          # registry in all three languages, not from a hand-typed constant
+          # that happens to match for the runtimes registered today (#356).
+          - tests/test_runtime_buildarg_binary.sh
           - scripts/test-entrypoint-settings.sh
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/scripts/ClaudeDocker.psm1
+++ b/scripts/ClaudeDocker.psm1
@@ -512,6 +512,27 @@ function Get-PrimaryService {
     return "$(Get-ServicePrefix -ProjectRoot $ProjectRoot)-a"
 }
 
+function Get-AgentBinary {
+    <#
+    .SYNOPSIS
+    The executable name to run inside the container for the active runtime.
+    .DESCRIPTION
+    Mirrors agent_binary in scripts/lib/runtime.sh, which reads the registry's
+    `binary` field.
+
+    Invoke-Update used to run Get-AgentRuntime -- the registry *key* -- as the
+    command inside the container (#356, row 3). It works today only because
+    key and binary are the same string for all three registered runtimes, so a
+    runtime whose CLI is named differently from its key would exec something
+    that does not exist. The bash wrapper has always used agent_binary here.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$ProjectRoot)
+
+    $runtime = Get-AgentRuntime -ProjectRoot $ProjectRoot
+    return Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $runtime -Field 'binary'
+}
+
 function Get-AgentStateRoot {
     [CmdletBinding()]
     param([Parameter(Mandatory)][string]$ProjectRoot)
@@ -1282,6 +1303,7 @@ Export-ModuleMember -Function @(
     'Get-CleanupDecision', 'Test-FileAgeExceedsDays',
     # Accounts
     'Get-NumAccounts', 'Get-AgentRuntime', 'Get-ServicePrefix',
+    'Get-AgentBinary',
     'Get-PrimaryService', 'Get-AgentStateRoot', 'Get-ServiceNames',
     'Get-AccountLetter',
     'Get-AccountLetterUpper',

--- a/scripts/claude-docker.ps1
+++ b/scripts/claude-docker.ps1
@@ -675,7 +675,10 @@ function Invoke-Build {
 }
 
 function Invoke-Update {
-    $binary = Get-AgentRuntime -ProjectRoot $ProjectRoot
+    # The registry's `binary` field, not the runtime key: this value is exec'd
+    # inside the container below (#356, row 3). cmd_update in the bash wrapper
+    # calls agent_binary for the same reason.
+    $binary = Get-AgentBinary -ProjectRoot $ProjectRoot
     Write-Host "Updating $binary CLI to latest version" -ForegroundColor White
     Write-Host ''
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -27,7 +27,9 @@ if ($PSVersionTable.PSEdition -eq 'Core' -and $PSVersionTable.OS -and $PSVersion
 
 # Canonical .env key list (must be written by all platform installers):
 #   HOME, PROJECT_DIR, CONTAINER_PROJECT_DIR, CLAUDE_CONFIG_SOURCE (optional),
-#   CLAUDE_CODE_VERSION (optional), CLAUDE_API_KEY_A/B (Path B only),
+#   <runtime buildArg> (optional; CLAUDE_CODE_VERSION, CODEX_CLI_VERSION or
+#     GEMINI_CLI_VERSION, whichever the selected runtime names),
+#   CLAUDE_API_KEY_A/B (Path B only),
 #   PROJECT_DIR_A/B + CONTAINER_PROJECT_DIR_A/B (Tier B only),
 #   GIT_USER_NAME, GIT_USER_EMAIL (optional),
 #   GH_AUTH_MODE + GH_USER_<LETTER>/GH_TOKEN_<LETTER> (per-account only),
@@ -49,7 +51,9 @@ $ProjectRoot = Split-Path $PSScriptRoot -Parent
 $Script:AuthPath = ''
 $Script:Tier = ''
 $Script:SourceDir = ''
-$Script:ClaudeVersion = ''
+$Script:RuntimeVersion = ''
+$Script:RuntimeBuildArg = ''
+$Script:RuntimeDisplayName = ''
 $Script:ApiKeyA = ''
 $Script:ApiKeyB = ''
 # Selected agent runtime (claude, codex, gemini, ...). Defaults to claude so a
@@ -327,14 +331,21 @@ function Get-Configuration {
 
     Write-LogInfo "Project directory: $($Script:SourceDir)"
 
-    # Claude Code version
-    $Script:ClaudeVersion = Read-Input -Question "Claude Code version (enter specific version or 'latest')" -Default 'latest'
-    if ($Script:ClaudeVersion -eq 'latest') {
-        $Script:ClaudeVersion = ''
-        Write-LogInfo 'Claude Code version: latest'
+    # Runtime CLI version. The prompt is unconditional, so it also runs for a
+    # codex or gemini install -- and the value used to be written as
+    # CLAUDE_CODE_VERSION regardless (#356, row 4). That dropped the chosen
+    # runtime's own pin and fed the number to the Claude installer inside the
+    # image instead. The variable name comes from the registry now, the same
+    # way generate-compose.ps1 resolves it.
+    $Script:RuntimeBuildArg = Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $Script:Runtime -Field 'buildArg'
+    $Script:RuntimeDisplayName = Get-RuntimeField -ProjectRoot $ProjectRoot -Runtime $Script:Runtime -Field 'displayName'
+    $Script:RuntimeVersion = Read-Input -Question "$($Script:RuntimeDisplayName) version (enter specific version or 'latest')" -Default 'latest'
+    if ($Script:RuntimeVersion -eq 'latest') {
+        $Script:RuntimeVersion = ''
+        Write-LogInfo "$($Script:RuntimeDisplayName) version: latest"
     }
     else {
-        Write-LogInfo "Claude Code version: $($Script:ClaudeVersion)"
+        Write-LogInfo "$($Script:RuntimeDisplayName) version: $($Script:RuntimeVersion)"
     }
 
     # Number of accounts. The upper bound is "zz" from Excel-style letter
@@ -504,9 +515,9 @@ function New-EnvFile {
     $lines += '#CLAUDE_CONFIG_SOURCE='
     $lines += ''
 
-    if ($Script:ClaudeVersion) {
-        $lines += '# ==== Claude Code Version ===='
-        $lines += "CLAUDE_CODE_VERSION=$($Script:ClaudeVersion)"
+    if ($Script:RuntimeVersion) {
+        $lines += "# ==== $($Script:RuntimeDisplayName) Version ===="
+        $lines += "$($Script:RuntimeBuildArg)=$($Script:RuntimeVersion)"
         $lines += ''
     }
 
@@ -688,8 +699,8 @@ function Invoke-ImageBuild {
     Push-Location $ProjectRoot
     try {
         $buildArgs = @()
-        if ($Script:ClaudeVersion) {
-            $buildArgs = @('--build-arg', "CLAUDE_CODE_VERSION=$($Script:ClaudeVersion)")
+        if ($Script:RuntimeVersion) {
+            $buildArgs = @('--build-arg', "$($Script:RuntimeBuildArg)=$($Script:RuntimeVersion)")
         }
 
         Write-LogInfo 'Building claude-code-base:latest (this may take a few minutes)...'
@@ -1097,7 +1108,7 @@ Write-Host "  Platform:        Windows"
 Write-Host "  Authentication:  Path $($Script:AuthPath)"
 Write-Host "  Source sharing:  Tier $($Script:Tier)"
 Write-Host "  Project:         $($Script:SourceDir)"
-Write-Host "  Claude version:  $(if ($Script:ClaudeVersion) { $Script:ClaudeVersion } else { 'latest' })"
+Write-Host "  $($Script:RuntimeDisplayName) version:  $(if ($Script:RuntimeVersion) { $Script:RuntimeVersion } else { 'latest' })"
 Write-Host ''
 
 if (-not (Read-Confirmation -Question 'Proceed with this configuration?' -Default 'y')) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,7 +26,9 @@ fi
 
 # Canonical .env key list (must be written by all platform installers):
 #   HOME, PROJECT_DIR, CONTAINER_PROJECT_DIR, CLAUDE_CONFIG_SOURCE (optional),
-#   CLAUDE_CODE_VERSION (optional), CLAUDE_API_KEY_A/B (Path B only),
+#   <runtime buildArg> (optional; CLAUDE_CODE_VERSION, CODEX_CLI_VERSION or
+#     GEMINI_CLI_VERSION, whichever the selected runtime names),
+#   CLAUDE_API_KEY_A/B (Path B only),
 #   PROJECT_DIR_A/B + CONTAINER_PROJECT_DIR_A/B (Tier B only),
 #   GIT_USER_NAME, GIT_USER_EMAIL (optional),
 #   GH_AUTH_MODE + GH_USER_<LETTER>/GH_TOKEN_<LETTER> (per-account only),
@@ -56,7 +58,9 @@ PLATFORM=""
 AUTH_PATH=""
 TIER=""
 SOURCE_DIR=""
-CLAUDE_VERSION=""
+RUNTIME_VERSION=""
+RUNTIME_BUILD_ARG=""
+RUNTIME_DISPLAY_NAME=""
 # Selected agent runtime (claude, codex, gemini, ...). Defaults to claude so a
 # non-interactive or default install behaves exactly as before (see #273).
 RUNTIME="claude"
@@ -577,13 +581,20 @@ collect_configuration() {
 
     log_info "Project directory: $SOURCE_DIR"
 
-    # Claude Code version
-    CLAUDE_VERSION=$(prompt_input "Claude Code version (enter specific version or 'latest')" "latest")
-    if [[ "$CLAUDE_VERSION" == "latest" ]]; then
-        CLAUDE_VERSION=""
-        log_info "Claude Code version: latest"
+    # Runtime CLI version. The prompt is unconditional, so it also runs for a
+    # codex or gemini install -- and the value used to be written as
+    # CLAUDE_CODE_VERSION regardless (#356, row 4). That dropped the chosen
+    # runtime's own pin and fed the number to the Claude installer inside the
+    # image instead. The variable name comes from the registry now, the same
+    # way generate-compose.sh resolves it.
+    RUNTIME_BUILD_ARG=$(runtime_field "$RUNTIME" buildArg)
+    RUNTIME_DISPLAY_NAME=$(runtime_field "$RUNTIME" displayName)
+    RUNTIME_VERSION=$(prompt_input "$RUNTIME_DISPLAY_NAME version (enter specific version or 'latest')" "latest")
+    if [[ "$RUNTIME_VERSION" == "latest" ]]; then
+        RUNTIME_VERSION=""
+        log_info "$RUNTIME_DISPLAY_NAME version: latest"
     else
-        log_info "Claude Code version: $CLAUDE_VERSION"
+        log_info "$RUNTIME_DISPLAY_NAME version: $RUNTIME_VERSION"
     fi
 
     # Number of accounts. The upper bound is "zz" from Excel-style letter
@@ -710,9 +721,9 @@ generate_env() {
         echo "#CLAUDE_CONFIG_SOURCE="
         echo ""
 
-        if [[ -n "$CLAUDE_VERSION" ]]; then
-            echo "# ==== Claude Code Version ===="
-            echo "CLAUDE_CODE_VERSION=$CLAUDE_VERSION"
+        if [[ -n "$RUNTIME_VERSION" ]]; then
+            echo "# ==== ${RUNTIME_DISPLAY_NAME} Version ===="
+            echo "${RUNTIME_BUILD_ARG}=$RUNTIME_VERSION"
             echo ""
         fi
 
@@ -846,7 +857,8 @@ generate_env() {
 # build_image still runs before this, on the committed docker-compose.yml. That
 # is deliberate and safe: the image does not depend on the account count, the
 # runtime or the isolation mode -- every service builds the one
-# claude-code-base image, and the only build argument is CLAUDE_CODE_VERSION.
+# claude-code-base image, and the only build argument is the runtime's
+# version pin, whose name the registry supplies (buildArg).
 generate_compose_files() {
     log_info "Generating compose files for $NUM_ACCOUNTS account(s)..."
     "$SCRIPT_DIR/generate-compose.sh"
@@ -907,8 +919,8 @@ build_image() {
     cd "$PROJECT_ROOT"
 
     local build_args=""
-    if [[ -n "$CLAUDE_VERSION" ]]; then
-        build_args="--build-arg CLAUDE_CODE_VERSION=$CLAUDE_VERSION"
+    if [[ -n "$RUNTIME_VERSION" ]]; then
+        build_args="--build-arg ${RUNTIME_BUILD_ARG}=$RUNTIME_VERSION"
     fi
 
     log_info "Building claude-code-base:latest (this may take a few minutes)..."
@@ -1330,7 +1342,7 @@ main() {
     echo -e "  Authentication:  Path $AUTH_PATH"
     echo -e "  Source sharing:  Tier $TIER"
     echo -e "  Project:         $SOURCE_DIR"
-    echo -e "  Claude version:  ${CLAUDE_VERSION:-latest}"
+    echo -e "  ${RUNTIME_DISPLAY_NAME} version:  ${RUNTIME_VERSION:-latest}"
     echo ""
 
     if ! prompt_confirm "Proceed with this configuration?" "y"; then

--- a/tests/test_runtime_buildarg_binary.sh
+++ b/tests/test_runtime_buildarg_binary.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# test_runtime_buildarg_binary.sh - per-runtime values come from the registry,
+# not from a hand-typed constant (issue #356, rows 3 and 4).
+#
+# Run:  bash tests/test_runtime_buildarg_binary.sh
+# Exits non-zero on any failure.
+#
+# Row 4 is the one with a consequence. The installer's version prompt is
+# unconditional, so it runs for a codex or gemini install too -- and both
+# installers wrote the answer as CLAUDE_CODE_VERSION regardless. The chosen
+# runtime's own pin (CODEX_CLI_VERSION, GEMINI_CLI_VERSION) was therefore never
+# set, and the number was passed to `docker compose build` under the Claude
+# arg, where Dockerfile feeds it to the Claude installer.
+#
+# Row 3 is asymptomatic today: claude-docker.ps1's update path exec'd the
+# registry *key* inside the container where the bash wrapper exec's the
+# `binary` field. Those are the same string for all three registered runtimes,
+# so this asserts the accessor exists and answers from the registry rather than
+# trying to observe a difference that does not exist yet.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=../scripts/lib/runtime.sh
+. "$PROJECT_ROOT/scripts/lib/runtime.sh"
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS  $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL  $1"; echo "        $2"; FAIL=$((FAIL + 1)); }
+
+RUNTIMES=(claude codex gemini)
+
+# ---------------------------------------------------------------------------
+echo "=== the registry answers for every runtime ==="
+# ---------------------------------------------------------------------------
+
+declare -a EXPECT_BUILD_ARG=("CLAUDE_CODE_VERSION" "CODEX_CLI_VERSION" "GEMINI_CLI_VERSION")
+
+i=0
+for rt in "${RUNTIMES[@]}"; do
+    got=$(runtime_field "$rt" buildArg)
+    want="${EXPECT_BUILD_ARG[$i]}"
+    if [ "$got" = "$want" ]; then
+        pass "$rt buildArg -> $got"
+    else
+        fail "$rt buildArg" "got '$got', want '$want'"
+    fi
+    i=$((i + 1))
+done
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== neither installer hardcodes a runtime's build arg ==="
+# ---------------------------------------------------------------------------
+#
+# Comments may name CLAUDE_CODE_VERSION -- explaining the default runtime's
+# variable is not the same as writing it into every install. Code may not.
+
+for f in "$PROJECT_ROOT/scripts/install.sh" "$PROJECT_ROOT/scripts/install.ps1"; do
+    name=$(basename "$f")
+    hits=$(grep -nE '(CLAUDE_CODE_VERSION|CODEX_CLI_VERSION|GEMINI_CLI_VERSION)' "$f" \
+        | grep -vE '^[0-9]+: *#' || true)
+    if [ -z "$hits" ]; then
+        pass "$name resolves the build arg from the registry"
+    else
+        fail "$name spells a runtime build arg in code" "$hits"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== the generator emits the selected runtime's build arg ==="
+# ---------------------------------------------------------------------------
+#
+# End to end through the real generator: the compose file a codex install
+# builds from must carry CODEX_CLI_VERSION and must not carry the Claude one.
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+i=0
+for rt in "${RUNTIMES[@]}"; do
+    dir="$WORK/$rt"
+    mkdir -p "$dir/tui/internal/config"
+    cp -r "$PROJECT_ROOT/scripts" "$dir/scripts"
+    cp "$PROJECT_ROOT/tui/internal/config/runtimes.json" "$dir/tui/internal/config/"
+    [ -f "$PROJECT_ROOT/VERSION" ] && cp "$PROJECT_ROOT/VERSION" "$dir/"
+    printf 'AGENT_RUNTIME=%s\nNUM_ACCOUNTS=1\n' "$rt" > "$dir/.env"
+
+    if ! (cd "$dir" && bash scripts/generate-compose.sh >/dev/null 2>&1); then
+        fail "$rt generator run" "generate-compose.sh exited non-zero"
+        i=$((i + 1))
+        continue
+    fi
+
+    want="${EXPECT_BUILD_ARG[$i]}"
+    if grep -q "$want" "$dir/docker-compose.yml"; then
+        pass "$rt compose carries $want"
+    else
+        fail "$rt compose is missing $want" "$(grep -n 'args:' -A3 "$dir/docker-compose.yml" | head -6)"
+    fi
+
+    # A non-claude runtime must not also carry the Claude arg.
+    if [ "$rt" != "claude" ] && grep -q 'CLAUDE_CODE_VERSION' "$dir/docker-compose.yml"; then
+        fail "$rt compose also carries CLAUDE_CODE_VERSION" "the wrong runtime would be pinned"
+    elif [ "$rt" != "claude" ]; then
+        pass "$rt compose does not carry CLAUDE_CODE_VERSION"
+    fi
+    i=$((i + 1))
+done
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== the container binary comes from the registry, in both languages ==="
+# ---------------------------------------------------------------------------
+
+for rt in "${RUNTIMES[@]}"; do
+    bash_binary=$(runtime_field "$rt" binary)
+    if [ -n "$bash_binary" ]; then
+        pass "$rt binary -> $bash_binary (bash)"
+    else
+        fail "$rt binary (bash)" "empty"
+    fi
+done
+
+if command -v pwsh >/dev/null 2>&1; then
+    for rt in "${RUNTIMES[@]}"; do
+        dir="$WORK/$rt"
+        pwsh_binary=$(pwsh -NoProfile -Command "
+            Import-Module '$dir/scripts/ClaudeDocker.psm1' -Force
+            Get-AgentBinary -ProjectRoot '$dir'
+        " 2>/dev/null | tr -d '\r')
+        bash_binary=$(runtime_field "$rt" binary)
+        if [ "$pwsh_binary" = "$bash_binary" ]; then
+            pass "$rt binary agrees across languages -> $bash_binary"
+        else
+            fail "$rt binary disagrees" "bash '$bash_binary' vs pwsh '$pwsh_binary'"
+        fi
+    done
+else
+    echo "  NOTE: pwsh unavailable; the cross-language half is skipped" >&2
+    if [ -n "${GITHUB_ACTIONS:-}" ]; then
+        echo "  ERROR: pwsh is preinstalled on the CI runner; a skip here hides a failure" >&2
+        exit 1
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== the Go fallback prefix comes from the registry ==="
+# ---------------------------------------------------------------------------
+
+if grep -qn 'prefix := config.RuntimeClaude' "$PROJECT_ROOT/tui/internal/docker/client.go"; then
+    fail "client.go still uses the RuntimeClaude constant as a service prefix" \
+        "it is a registry value spelled by hand"
+else
+    pass "client.go does not use RuntimeClaude as a prefix"
+fi
+
+if grep -q 'config.DefaultServicePrefix()' "$PROJECT_ROOT/tui/internal/docker/client.go"; then
+    pass "client.go resolves its fallback prefix through the registry"
+else
+    fail "client.go has no registry lookup for the fallback prefix" "expected DefaultServicePrefix()"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Results ==="
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+
+if [ "$PASS" -eq 0 ]; then
+    echo "  ERROR: no assertions ran" >&2
+    exit 1
+fi
+
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/tui/internal/config/runtime.go
+++ b/tui/internal/config/runtime.go
@@ -67,6 +67,24 @@ func LookupRuntime(name string) (RuntimeSpec, bool) {
 	return spec, ok
 }
 
+// DefaultServicePrefix returns the service prefix of the default runtime.
+//
+// For callers that have no *Env to ask -- the nil-env fallback in
+// docker.Client.ServiceNames is the only one -- and want the registry's answer
+// rather than the RuntimeClaude constant. The two are the same string today
+// because claude's key and servicePrefix both happen to be "claude", which is
+// exactly what makes the hand-spelled version silent if that ever stops being
+// true (#356, row 3).
+//
+// Falls back to RuntimeClaude only if the registry has no claude entry, which
+// would mean runtimes.json is unusable and every other lookup is failing too.
+func DefaultServicePrefix() string {
+	if spec, ok := LookupRuntime(RuntimeClaude); ok && spec.ServicePrefix != "" {
+		return spec.ServicePrefix
+	}
+	return RuntimeClaude
+}
+
 // KnownRuntimes returns the registered runtime names in sorted order.
 func KnownRuntimes() []string {
 	names := make([]string, 0, len(registry.Runtimes))

--- a/tui/internal/docker/client.go
+++ b/tui/internal/docker/client.go
@@ -203,9 +203,16 @@ func (c *Client) HasRunningContainers() bool {
 }
 
 // ServiceNames returns the expected service names based on NUM_ACCOUNTS.
+//
+// The nil-env fallback reads the default runtime's servicePrefix from the
+// registry rather than using the RuntimeClaude constant (#356, row 3). The two
+// happen to be the same string today, because claude's key and servicePrefix
+// are both "claude" -- so the constant was a registry value spelled by hand,
+// correct by coincidence and silent if the registry ever changed. Every other
+// prefix in this program comes from the registry; this one now does too.
 func (c *Client) ServiceNames() []string {
 	n := config.DefaultNumAccounts
-	prefix := config.RuntimeClaude
+	prefix := config.DefaultServicePrefix()
 	if c.env != nil {
 		n = c.env.NumAccounts()
 		prefix = c.env.ServicePrefix()


### PR DESCRIPTION
Relates to #356 (rows 3 and 4, child 3 of 6)

Third of six. **Merge note:** children 2 and 3 both touch `ClaudeDocker.psm1`'s export list and `claude-docker.ps1`; the edits are in different places but adjacent enough to conflict textually. [#381](https://github.com/kcenon/claude-docker/pull/381) first, then rebase this, is the cheaper order.

## Row 4 is the one a user reaches

The version prompt in both installers is unconditional — it runs for a codex or gemini install too. Both then wrote the answer as `CLAUDE_CODE_VERSION`:

```bash
# install.sh, before
CLAUDE_VERSION=$(prompt_input "Claude Code version ..." "latest")
...
echo "CLAUDE_CODE_VERSION=$CLAUDE_VERSION"
...
build_args="--build-arg CLAUDE_CODE_VERSION=$CLAUDE_VERSION"
```

So selecting **codex** and entering a version:

- writes `CLAUDE_CODE_VERSION=x` into `.env`, where nothing for codex reads it;
- leaves `CODEX_CLI_VERSION` unset, so the codex CLI is unpinned;
- passes `--build-arg CLAUDE_CODE_VERSION=x`, which `Dockerfile:94` hands to the **Claude** installer.

The user pinned a version and got it applied to a different tool. `generate-compose.sh` had the right shape all along — `runtime_field "$AGENT_RUNTIME" buildArg` — so the two disagreed about the same `.env` the moment a non-default runtime was chosen.

Both installers now resolve `buildArg` from the registry, and label the prompt with `displayName` rather than "Claude Code".

## Row 3 is correctness, not a live bug

`claude-docker.ps1`'s update path assigned `Get-AgentRuntime` — the registry **key** — to `$binary`, then exec'd it inside the container. `cmd_update` in the bash wrapper calls `agent_binary`, which reads the registry's `binary` field.

Key and `binary` are the same string for all three registered runtimes, so nothing misbehaves today. A runtime whose CLI is named differently from its key would exec something that does not exist. `Get-AgentBinary` is added to the module and used there.

Same class in Go: `docker.Client.ServiceNames`' nil-env fallback used `config.RuntimeClaude` as a **service prefix**. That is a registry value spelled by hand — right by coincidence, since claude's key and `servicePrefix` are both `"claude"` — and silent if that stops being true. `config.DefaultServicePrefix()` reads it from the registry, falling back to the constant only if the registry has no claude entry at all, which would mean every other lookup is failing too.

## Verification

`tests/test_runtime_buildarg_binary.sh` (new, 18 assertions, `bash-tests` matrix) — 18/0.

**Red first** against an `origin/develop` export:

```
  FAIL  install.sh spells a runtime build arg in code
  FAIL  install.ps1 spells a runtime build arg in code
  FAIL  claude binary disagrees      (bash 'claude' vs pwsh '' — Get-AgentBinary did not exist)
  FAIL  codex binary disagrees
  FAIL  gemini binary disagrees
  FAIL  client.go still uses the RuntimeClaude constant as a service prefix
  FAIL  client.go has no registry lookup for the fallback prefix
  Passed: 11  Failed: 7
```

The row-4 half is exercised **end to end through the real generator**, once per runtime: a codex `.env` must produce a compose file carrying `CODEX_CLI_VERSION` *and not* `CLAUDE_CODE_VERSION`. Asserting only the presence of the right arg would pass for a file that carries both, which is the failure mode that matters — the wrong runtime staying pinned alongside the right one.

Full `bash-tests` (25 files) and `pwsh-tests` (8 files): 0 non-passing. `go build`, `go vet`, `go test`, `gofmt -l`: clean. shellcheck at CI severity and PSScriptAnalyzer via the extracted CI step: clean.

### Why row 3 has no behavioral test

There is nothing to observe. Every registered runtime has `key == binary`, so a test comparing the two entry points passes before and after. What the test asserts instead is structural and honest about it: `Get-AgentBinary` exists, both languages return the same value from the registry, and `client.go` no longer names the constant. If a fourth runtime ever registers with a differing binary, the cross-language comparison becomes a real check without being touched.

### Not covered

No container is started and no image is built, so "the build arg actually reaches the Dockerfile" is asserted at the compose file rather than at `docker build`. The compose file is what `build` reads, so the gap is one layer thick.

## Where

- `scripts/install.sh`, `scripts/install.ps1` — registry `buildArg` and `displayName`
- `scripts/ClaudeDocker.psm1` — `Get-AgentBinary`, exported
- `scripts/claude-docker.ps1` — `Invoke-Update`
- `tui/internal/config/runtime.go` — `DefaultServicePrefix`
- `tui/internal/docker/client.go` — `ServiceNames` fallback
- `tests/test_runtime_buildarg_binary.sh` (new), `.github/workflows/ci.yml`
