### PR TITLE
fix(install): unify the .env backup filename and rotation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,10 @@ jobs:
           # Linux-only on purpose: this covers container bootstrap code, the
           # image is Debian, and the CRLF sweep needs GNU sed --follow-symlinks.
           - tests/test_bootstrap_helpers.sh
+          # Both installers name .env backups the same way, so the name-sort
+          # rotation keeps the newest three rather than the newest three from
+          # whichever installer used the longer format (#356).
+          - tests/test_env_backup_rotation.sh
           - scripts/test-entrypoint-settings.sh
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -409,6 +409,27 @@ function Get-Configuration {
 
 # --- .env Generation ----------------------------------------------------------
 
+function Get-EnvBackupTimestamp {
+    <#
+    .SYNOPSIS
+    The suffix both installers put on a .env backup: UTC, yyyyMMddHHmmss.
+    .DESCRIPTION
+    One format on both sides (#356, row 8). install.sh wrote a 10-digit
+    `date +%s` epoch while this wrote 14-digit yyyyMMddHHmmss, and both rotate
+    by name sort -- so a 14-digit "2026..." outranked every epoch and
+    alternating the two installers on one project root kept the three newest
+    *PowerShell* backups rather than the three newest backups.
+
+    UTC rather than local: local time is not monotonic across a DST
+    fall-back, and the rotation depends on name order matching chronological
+    order. This is the one change to the PowerShell side; the format itself
+    is unchanged, so existing backups here keep sorting correctly.
+    #>
+    [CmdletBinding()]
+    param()
+    return [DateTime]::UtcNow.ToString('yyyyMMddHHmmss')
+}
+
 function Remove-StaleEnvBackups {
     param(
         [Parameter(Mandatory)][string]$EnvFile,
@@ -432,7 +453,7 @@ function New-EnvFile {
             Write-LogWarn 'Keeping existing .env. Some settings may not match your choices.'
             return
         }
-        $timestamp = Get-Date -Format 'yyyyMMddHHmmss'
+        $timestamp = Get-EnvBackupTimestamp
         $backup = "${envFile}.backup.${timestamp}"
         Copy-Item $envFile $backup
         # Grant Modify (R,W,D) so Remove-StaleEnvBackups and remove.ps1 can

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -149,8 +149,30 @@ check_command() {
     command -v "$1" &>/dev/null
 }
 
+# env_backup_timestamp
+# The suffix both installers put on a .env backup: UTC, yyyymmddHHMMSS.
+#
+# One format on both sides (#356, row 8). This wrote `date +%s` -- a 10-digit
+# epoch -- while install.ps1 wrote a 14-digit yyyyMMddHHmmss, and both rotate
+# by name sort. A 14-digit "2026..." always sorts above any 10-digit epoch, so
+# alternating the two installers on one project root kept the three newest
+# *PowerShell* backups rather than the three newest backups.
+#
+# yyyymmddHHMMSS rather than epoch, and this direction rather than the other,
+# because the migration is self-correcting: existing 10-digit backups sort
+# below every new one, and they are also genuinely older, so rotation removes
+# them first. Standardizing on epoch would have done the reverse -- pre-existing
+# PowerShell backups would outrank every new one and never be rotated out.
+#
+# UTC, not local: local time is not monotonic across a DST fall-back, and the
+# rotation depends on name order matching chronological order.
+env_backup_timestamp() {
+    date -u +%Y%m%d%H%M%S
+}
+
 # Keep at most $keep newest ".env.backup.*" siblings of $env_file.
-# Sort is lexicographic by epoch suffix — monotonic for the foreseeable future.
+# Sort is lexicographic by the timestamp suffix, which env_backup_timestamp
+# keeps monotonic.
 rotate_env_backups() {
     local env_file="$1"
     local keep="${2:-3}"
@@ -645,7 +667,7 @@ generate_env() {
             return 0
         fi
         local backup
-        backup="${env_file}.backup.$(date +%s)"
+        backup="${env_file}.backup.$(env_backup_timestamp)"
         cp "$env_file" "$backup"
         chmod 600 "$backup"
         rotate_env_backups "$env_file" 3

--- a/tests/test_env_backup_rotation.sh
+++ b/tests/test_env_backup_rotation.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# test_env_backup_rotation.sh - both installers name .env backups the same way,
+# so name-sort rotation keeps the newest three (issue #356, row 8).
+#
+# Run:  bash tests/test_env_backup_rotation.sh
+# Exits non-zero on any failure.
+#
+# install.sh wrote a 10-digit `date +%s` epoch and install.ps1 wrote a 14-digit
+# yyyyMMddHHmmss, and both rotate by name sort. Lexicographically a 14-digit
+# "2026..." is above every 10-digit epoch, so a project root that had seen both
+# installers kept the three newest *PowerShell* backups and discarded newer
+# bash ones -- silently, since rotation prints nothing about what it removed.
+#
+# Note what changed and what did not. rotate_env_backups is untouched -- the
+# defect was never in the sorting, it was in the two names being sorted. So the
+# mixed-format case below is a regression guard rather than a red-first
+# demonstration: it passes against the old code too, because it stages files
+# directly instead of running an installer.
+#
+# The assertion that does fail against the old code is "a newly minted stamp
+# sorts above a legacy epoch", which is the migration property the choice of
+# format rests on, and the only thing a new backup's *name* can be judged by
+# without driving an interactive installer.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS  $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL  $1"; echo "        $2"; FAIL=$((FAIL + 1)); }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# The two functions under test are defined inside install.sh, which runs an
+# installer when sourced. Extract them, the way scripts/test-entrypoint-settings.sh
+# lifts generate_container_settings.
+BACKUP_SRC=$(sed -n '/^env_backup_timestamp()/,/^}/p;/^rotate_env_backups()/,/^}/p' \
+    "$PROJECT_ROOT/scripts/install.sh")
+if [ -z "$BACKUP_SRC" ]; then
+    echo "  ERROR: could not extract the backup helpers from scripts/install.sh" >&2
+    exit 1
+fi
+eval "$BACKUP_SRC"
+
+# ---------------------------------------------------------------------------
+echo "=== the two installers produce the same timestamp shape ==="
+# ---------------------------------------------------------------------------
+
+bash_ts=$(env_backup_timestamp)
+if [[ "$bash_ts" =~ ^[0-9]{14}$ ]]; then
+    pass "install.sh timestamp is 14 digits ($bash_ts)"
+else
+    fail "install.sh timestamp shape" "got '$bash_ts', want 14 digits"
+fi
+
+if command -v pwsh >/dev/null 2>&1; then
+    pwsh_ts=$(pwsh -NoProfile -Command "
+        Import-Module '$PROJECT_ROOT/scripts/ClaudeDocker.psm1' -Force -ErrorAction SilentlyContinue
+        \$src = Get-Content '$PROJECT_ROOT/scripts/install.ps1' -Raw
+        \$m = [regex]::Match(\$src, '(?ms)^function Get-EnvBackupTimestamp \{.*?\n\}')
+        if (-not \$m.Success) { 'NOTFOUND'; exit }
+        Invoke-Expression \$m.Value
+        Get-EnvBackupTimestamp
+    " 2>/dev/null | tr -d '\r' | tail -1)
+
+    if [[ "$pwsh_ts" =~ ^[0-9]{14}$ ]]; then
+        pass "install.ps1 timestamp is 14 digits ($pwsh_ts)"
+    else
+        fail "install.ps1 timestamp shape" "got '$pwsh_ts', want 14 digits"
+    fi
+
+    # Same second or adjacent: both are UTC now, so they must not differ by an
+    # hour, which is what a local-vs-UTC mismatch would look like.
+    if [ "${bash_ts:0:10}" = "${pwsh_ts:0:10}" ]; then
+        pass "both timestamps agree to the minute (both UTC)"
+    else
+        fail "the two timestamps disagree beyond seconds" \
+            "bash '$bash_ts' vs pwsh '$pwsh_ts' -- one of them is not UTC"
+    fi
+elif [ -n "${GITHUB_ACTIONS:-}" ]; then
+    echo "  ERROR: pwsh is preinstalled on the CI runner; a skip here hides a failure" >&2
+    exit 1
+else
+    echo "  NOTE: pwsh unavailable; the cross-language half is skipped" >&2
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== rotation keeps the newest three, mixed formats included ==="
+# ---------------------------------------------------------------------------
+#
+# Six backups: three in the legacy 10-digit epoch format and three in the
+# unified 14-digit one, with the epoch ones genuinely older. Name-sort
+# rotation must keep the three 14-digit files.
+
+dir="$WORK/mixed"
+mkdir -p "$dir"
+: > "$dir/.env"
+
+# Epoch values for 2024-01-01, -02, -03 -- older than any 2026 timestamp.
+for ts in 1704067200 1704153600 1704240000; do
+    : > "$dir/.env.backup.$ts"
+done
+for ts in 20260101000000 20260102000000 20260103000000; do
+    : > "$dir/.env.backup.$ts"
+done
+
+# The migration property, and the one assertion here that the old code fails:
+# a stamp minted now must sort above a legacy epoch, so an upgrade rotates the
+# old ones out first. With the epoch format the new stamp sorted *below* every
+# 14-digit PowerShell backup already on disk, and was discarded first instead.
+legacy_epoch="1704067200"          # 2024-01-01, older than anything new
+if [ "$(printf '%s\n%s\n' "$legacy_epoch" "$bash_ts" | sort | tail -1)" = "$bash_ts" ]; then
+    pass "a new timestamp sorts above a legacy epoch backup"
+else
+    fail "a new timestamp sorts below a legacy epoch backup" \
+        "new '$bash_ts' vs legacy '$legacy_epoch' -- rotation would discard the new one first"
+fi
+
+rotate_env_backups "$dir/.env" 3
+
+remaining=$(cd "$dir" && ls -1 .env.backup.* 2>/dev/null | sort | tr '\n' ' ')
+want=".env.backup.20260101000000 .env.backup.20260102000000 .env.backup.20260103000000 "
+if [ "$remaining" = "$want" ]; then
+    pass "the three newest survive and the legacy epoch ones are removed"
+else
+    fail "mixed-format rotation kept the wrong set" "got: $remaining"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== rotation is a no-op below the keep count ==="
+# ---------------------------------------------------------------------------
+#
+# Without this, "keeps the newest three" is satisfied by a rotation that
+# deletes everything down to three, including when there are fewer.
+
+dir2="$WORK/few"
+mkdir -p "$dir2"
+: > "$dir2/.env"
+for ts in 20260101000000 20260102000000; do
+    : > "$dir2/.env.backup.$ts"
+done
+
+rotate_env_backups "$dir2/.env" 3
+
+count=$(cd "$dir2" && ls -1 .env.backup.* 2>/dev/null | wc -l | tr -d ' ')
+if [ "$count" = "2" ]; then
+    pass "two backups are left alone"
+else
+    fail "rotation removed backups below the keep count" "left $count of 2"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== neither installer writes the legacy epoch format ==="
+# ---------------------------------------------------------------------------
+
+if grep -nE 'backup\.\$\(date \+%s\)' "$PROJECT_ROOT/scripts/install.sh" >/dev/null 2>&1; then
+    fail "install.sh still names backups with an epoch" "date +%s"
+else
+    pass "install.sh does not use the epoch format"
+fi
+
+if grep -nE "Get-Date -Format 'yyyyMMddHHmmss'" "$PROJECT_ROOT/scripts/install.ps1" >/dev/null 2>&1; then
+    fail "install.ps1 still stamps in local time" "Get-Date instead of UtcNow"
+else
+    pass "install.ps1 stamps through the shared helper"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Results ==="
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+
+if [ "$PASS" -eq 0 ]; then
+    echo "  ERROR: no assertions ran" >&2
+    exit 1
+fi
+
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
Relates to #356 (row 8, child 5 of 6)

Fifth of six. Independent of the others; touches only the two installers.

## What

`install.sh` named `.env` backups with a 10-digit `date +%s` epoch, `install.ps1` with a 14-digit `yyyyMMddHHmmss`. Both rotate by **name sort**, keeping three.

A 14-digit `2026...` is lexicographically above every 10-digit epoch. So on a project root that had seen both installers, rotation kept the three newest **PowerShell** backups and discarded newer bash ones — silently, because rotation prints nothing about what it removed.

## Which format wins, and why that direction

`yyyymmddHHMMSS` on both. The migration is what decides it:

| | existing on disk | new backup | rotation keeps |
|---|---|---|---|
| **unify on yyyymmddHHMMSS** | 10-digit epoch (older) | 14-digit | the new ones — correct, since the epoch ones are genuinely older |
| unify on epoch | 14-digit PowerShell (older) | 10-digit | the **old** ones — every new backup is discarded first |

Standardizing on the epoch would have inverted the bug rather than fixed it, for anyone with a PowerShell backup already on disk.

**UTC on both.** Local time is not monotonic across a DST fall-back — the same wall-clock hour repeats — and the rotation depends on name order matching chronological order. This is the only change to the PowerShell format.

Nothing parses the suffix: `cleanup` deletes by file age and `remove` globs `.env.backup.*`, so the format was free to change.

## Verification

`tests/test_env_backup_rotation.sh` (new, 8 assertions, `bash-tests` matrix) — 8/0.

**Red first** against an `origin/develop` export:

```
  FAIL  install.sh timestamp shape
  FAIL  install.ps1 timestamp shape
  FAIL  the two timestamps disagree beyond seconds
  FAIL  a new timestamp sorts below a legacy epoch backup
  FAIL  install.sh still names backups with an epoch
  FAIL  install.ps1 still stamps in local time
  Passed: 2  Failed: 6
```

### One assertion is a regression guard, not a red-first catch, and the test says so

`rotate_env_backups` is **untouched** — the defect was never in the sorting, it was in the two names being sorted. So the mixed-format rotation case passes against the old code too, because it stages files directly rather than running an interactive installer.

I initially wrote in the test header that this case "fails against the old code". It does not, and I removed the claim. What replaced it is the assertion that *is* red: **a stamp minted now must sort above a legacy epoch** — the migration property the format choice rests on, and the only thing a new backup's name can be judged by without driving the installer.

Both helpers are extracted from the installers with `sed` and `[regex]::Match` rather than restated, the way `test-entrypoint-settings.sh` lifts `generate_container_settings`.

The negatives are covered too: rotation below the keep count must be a no-op, or "keeps the newest three" is satisfied by a rotation that deletes everything.

Full `bash-tests` (25 files) and `pwsh-tests` (8 files): 0 non-passing. shellcheck at CI severity and PSScriptAnalyzer via the extracted CI step: clean.

### Not covered

Neither installer is run end to end — both are interactive and write to a real project root. The naming and rotation are exercised through their extracted functions; "the installer calls them" is asserted structurally, by the two greps that reject the old formats in installer source.

Two backups in the same UTC second would still collide and overwrite. That is unchanged from the epoch format, is not reachable outside a scripted double-install, and is noted here rather than fixed so it is not mistaken for something this PR introduced.

## Where

- `scripts/install.sh` — `env_backup_timestamp`, the backup call site, the rotation comment
- `scripts/install.ps1` — `Get-EnvBackupTimestamp`, the backup call site
- `tests/test_env_backup_rotation.sh` (new), `.github/workflows/ci.yml`
