### PR TITLE
fix(tui): apply the parse_env.sh value rule in the Go reader

### DIFF
--- a/scripts/ClaudeDocker.psm1
+++ b/scripts/ClaudeDocker.psm1
@@ -216,10 +216,17 @@ function ConvertFrom-EnvLine {
     $key = $trimmed.Substring(0, $eqIdx) -replace '\s+$', ''
     $value = $trimmed.Substring($eqIdx + 1)
 
-    $value = $value -replace '\s+#.*$', ''
+    # Unquote first, comment-strip second -- same rule as parse_env_value in
+    # scripts/lib/parse_env.sh, and for the same reason (#356, row 9). With
+    # the old order a # inside a quoted value started a comment, so
+    # set_env_value wrote FOO="a # b" and this read back `"a`.
     $value = $value -replace '\s+$', ''
-    if ($value -match '^"(.*)"$' -or $value -match "^'(.*)'$") {
+    if ($value -match '^"(.*)"(\s+#.*)?$' -or $value -match "^'(.*)'(\s+#.*)?$") {
         $value = $matches[1]
+    }
+    else {
+        $value = $value -replace '\s+#.*$', ''
+        $value = $value -replace '\s+$', ''
     }
     return @($key, $value)
 }

--- a/scripts/lib/parse_env.sh
+++ b/scripts/lib/parse_env.sh
@@ -53,13 +53,36 @@ parse_env_value() {
             rhs = substr($0, eq_idx + 1)
             # Strip Windows CR.
             sub(/\r$/, "", rhs)
-            # Strip inline comments: space(s) followed by # to end of line.
-            sub(/[[:space:]]+#.*$/, "", rhs)
             # Strip trailing whitespace.
             sub(/[[:space:]]+$/, "", rhs)
-            # Unquote single- or double-quoted values.
-            if ((match(rhs, /^".*"$/) != 0) || (match(rhs, /^'"'"'.*'"'"'$/) != 0)) {
-                rhs = substr(rhs, 2, length(rhs) - 2)
+            # Unquote first, comment-strip second (#356, row 9).
+            #
+            # The order used to be the other way round, so a # inside a quoted
+            # value started a comment: set_env_value wrote FOO="a # b" and this
+            # read it back as `"a`, quote included -- the writer and the reader
+            # in the same file disagreeing.
+            #
+            # Written with substr rather than a capture group because POSIX
+            # awk match() has none, and the obvious workaround -- match, then
+            # sub() the comment off -- eats the # inside the quotes, which is
+            # the very case being fixed.
+            q = substr(rhs, 1, 1)
+            if (q == "\"" || q == "'"'"'") {
+                # A trailing comment only exists if the value does not already
+                # end at its closing quote.
+                if (substr(rhs, length(rhs), 1) != q) {
+                    sub(/[[:space:]]+#.*$/, "", rhs)
+                    sub(/[[:space:]]+$/, "", rhs)
+                }
+                if (length(rhs) >= 2 && substr(rhs, length(rhs), 1) == q) {
+                    rhs = substr(rhs, 2, length(rhs) - 2)
+                }
+                # An opening quote with no closing one is not a quoted value;
+                # rhs is left as it stands, matching the other two readers.
+            } else {
+                # Unquoted: a whitespace-preceded # starts a comment.
+                sub(/[[:space:]]+#.*$/, "", rhs)
+                sub(/[[:space:]]+$/, "", rhs)
             }
             last = rhs
         }
@@ -93,15 +116,18 @@ load_env_file() {
 
         # Trim trailing space on key.
         key="${key%"${key##*[![:space:]]}"}"
-        # Strip inline comment (whitespace + #).
-        if [[ "$value" =~ [[:space:]]#.*$ ]]; then
-            value="${value%%[[:space:]]#*}"
-        fi
         # Trim trailing whitespace on value.
         value="${value%"${value##*[![:space:]]}"}"
-        # Unquote.
-        if [[ "$value" =~ ^\".*\"$ ]] || [[ "$value" =~ ^\'.*\'$ ]]; then
-            value="${value:1:${#value}-2}"
+        # Unquote first, comment-strip second -- same rule as parse_env_value
+        # above, and for the same reason (#356, row 9).
+        if [[ "$value" =~ ^\"(.*)\"([[:space:]]+#.*)?$ ]] ||
+           [[ "$value" =~ ^\'(.*)\'([[:space:]]+#.*)?$ ]]; then
+            value="${BASH_REMATCH[1]}"
+        else
+            if [[ "$value" =~ [[:space:]]#.*$ ]]; then
+                value="${value%%[[:space:]]#*}"
+            fi
+            value="${value%"${value##*[![:space:]]}"}"
         fi
 
         if (( force )) || [[ -z "${!key:-}" ]]; then

--- a/tests/test_parse_env_equivalence.sh
+++ b/tests/test_parse_env_equivalence.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
-# test_parse_env_equivalence.sh -- Verify bash and pwsh parsers produce
+# test_parse_env_equivalence.sh -- Verify the three .env parsers produce
 # identical output for the same input (cross-language equivalence).
 #
-# The bash implementation lives in scripts/lib/parse_env.sh
-# (parse_env_value) and the PowerShell implementation lives in
-# scripts/ClaudeDocker.psm1 (Get-EnvValue). Both parse the same .env
-# files, but their functional equivalence has not been asserted by any
-# test until now. This harness invokes both for every (fixture, key)
-# pair in tests/env_fixtures/ and asserts byte equality so any future
-# drift between the two parsers fails CI loudly.
+# The implementations are scripts/lib/parse_env.sh (parse_env_value),
+# scripts/ClaudeDocker.psm1 (Get-EnvValue), and tui/internal/config
+# (LoadEnv, reached through cmd/envprobe). This harness invokes all three
+# for every (fixture, key) pair in tests/env_fixtures/ and asserts byte
+# equality so any future drift fails CI loudly.
+#
+# Go joined in #356, row 9. Until then it was the odd one out on four
+# reachable inputs: it did not strip inline comments at all, so
+# `NUM_ACCOUNTS=4  # four` made Atoi fail and the TUI silently used the
+# default of 2 while both generators read 4; and strings.Trim(val, "\"'")
+# is a cutset trim rather than a paired-quote strip, so `"unclosed` lost
+# its lone leading quote. Nothing compared the two, because this harness
+# only knew about the shells.
 #
 # Run:  bash tests/test_parse_env_equivalence.sh
 
@@ -35,6 +41,25 @@ fi
 
 PSM1_PATH="$PROJECT_ROOT/scripts/ClaudeDocker.psm1"
 
+# The Go reader lives in an internal/ package, which no external module may
+# import, so it is reached through tui/cmd/envprobe. Built once here rather
+# than `go run` per assertion: there are several hundred (fixture, key) pairs.
+if ! command -v go >/dev/null 2>&1; then
+    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+        echo "FAIL: go unavailable in CI environment (it is preinstalled on ubuntu-latest)" >&2
+        exit 1
+    fi
+    echo "SKIP: go not installed locally; CI will exercise the real path" >&2
+    exit 0
+fi
+
+GO_PROBE="$(mktemp -d)/envprobe"
+trap 'rm -rf "$(dirname "$GO_PROBE")"' EXIT
+if ! (cd "$PROJECT_ROOT/tui" && go build -o "$GO_PROBE" ./cmd/envprobe) 2>/dev/null; then
+    echo "FAIL: could not build tui/cmd/envprobe" >&2
+    exit 1
+fi
+
 PASS=0
 FAIL=0
 
@@ -45,20 +70,21 @@ FAIL=0
 # convention.
 assert_equiv() {
     local fixture="$1" key="$2"
-    local bash_val pwsh_val
+    local bash_val pwsh_val go_val
     bash_val=$(parse_env_value "$fixture" "$key")
     pwsh_val=$(pwsh -NoProfile -Command "
         Import-Module '$PSM1_PATH' -Force
         \$v = Get-EnvValue -Path '$fixture' -Key '$key'
         if (\$null -eq \$v) { '' } else { \$v }
     ")
+    go_val=$("$GO_PROBE" "$fixture" "$key")
 
-    if [[ "$bash_val" == "$pwsh_val" ]]; then
+    if [[ "$bash_val" == "$pwsh_val" && "$pwsh_val" == "$go_val" ]]; then
         printf '  PASS  %s : %s\n' "$(basename "$fixture")" "$key"
         PASS=$((PASS + 1))
     else
-        printf '  FAIL  %s : %s\n        bash: %q\n        pwsh: %q\n' \
-            "$(basename "$fixture")" "$key" "$bash_val" "$pwsh_val"
+        printf '  FAIL  %s : %s\n        bash: %q\n        pwsh: %q\n        go:   %q\n' \
+            "$(basename "$fixture")" "$key" "$bash_val" "$pwsh_val" "$go_val"
         FAIL=$((FAIL + 1))
     fi
 }
@@ -106,6 +132,69 @@ run_fixture "$FIXTURES/duplicate-keys.env"
 echo "== missing-key behavior =="
 assert_equiv "$FIXTURES/minimal.env" "NOPE"
 assert_equiv "$FIXTURES/edge-cases.env" "DOES_NOT_EXIST"
+
+# The lines the three readers actually disagreed on, written at runtime.
+#
+# None of them is in a checked-in fixture: edge-cases.env's HASH_IN_QUOTES uses
+# a `#` with no space before it, which no implementation treats as a comment,
+# so the fixtures could not tell the readers apart. These can, and did --
+# every one of them is a case where Go answered differently from the shells,
+# or where all three agreed on the wrong answer (#356, row 9).
+SYNTH_DIR="$(mktemp -d)"
+trap 'rm -rf "$(dirname "$GO_PROBE")" "$SYNTH_DIR"' EXIT
+SYNTH="$SYNTH_DIR/synthetic.env"
+cat > "$SYNTH" <<'SYNTH_EOF'
+PLAIN=bar
+COMMENT_AFTER_VALUE=bar  # note
+HASH_NO_SPACE=bar# note
+HASH_INSIDE_QUOTES="a # b"
+QUOTED_SPACE="a b"
+SINGLE_QUOTED='a b'
+LEADING_SPACE= bar
+QUOTED_THEN_COMMENT="bar"  # note
+INNER_QUOTE=a"b
+UNCLOSED_QUOTE="unclosed
+EMBEDDED_QUOTES=say "hi" now
+HASH_FIRST=#nospace
+TRAILING_HASH="abc #"
+SYNTH_EOF
+
+echo "== synthetic edge cases =="
+while IFS= read -r key; do
+    [[ -z "$key" ]] && continue
+    assert_equiv "$SYNTH" "$key"
+done < <(enumerate_keys "$SYNTH")
+
+# Agreement is not enough on its own: three readers can be wrong together, and
+# two of them were. Before #356, bash and pwsh both returned `"a` for
+# HASH_INSIDE_QUOTES -- consistent, and not the value in the file. These pin
+# what each value must actually be.
+assert_value() {
+    local key="$1" want="$2" got
+    got=$(parse_env_value "$SYNTH" "$key")
+    if [[ "$got" == "$want" ]]; then
+        printf '  PASS  value  %s\n' "$key"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL  value  %s\n        want: %q\n        got:  %q\n' "$key" "$want" "$got"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "== synthetic edge cases: absolute values =="
+assert_value PLAIN                'bar'
+assert_value COMMENT_AFTER_VALUE  'bar'
+assert_value HASH_NO_SPACE        'bar# note'
+assert_value HASH_INSIDE_QUOTES   'a # b'
+assert_value QUOTED_SPACE         'a b'
+assert_value SINGLE_QUOTED        'a b'
+assert_value LEADING_SPACE        ' bar'
+assert_value QUOTED_THEN_COMMENT  'bar'
+assert_value INNER_QUOTE          'a"b'
+assert_value UNCLOSED_QUOTE       '"unclosed'
+assert_value EMBEDDED_QUOTES      'say "hi" now'
+assert_value HASH_FIRST           '#nospace'
+assert_value TRAILING_HASH        'abc #'
 
 echo
 printf '== Summary: PASS=%d FAIL=%d ==\n' "$PASS" "$FAIL"

--- a/tui/cmd/envprobe/main.go
+++ b/tui/cmd/envprobe/main.go
@@ -1,0 +1,39 @@
+// Command envprobe prints one value as config.LoadEnv reads it.
+//
+// It exists for tests/test_parse_env_equivalence.sh, which compares the three
+// .env readers -- bash parse_env_value, PowerShell Get-EnvValue, and this one
+// -- against each other. internal/ packages cannot be imported from outside
+// the module, so a shell harness has no way to reach LoadEnv without a command
+// inside it.
+//
+// Deliberately not a debug flag on the TUI binary: this has to print exactly
+// the value and nothing else, and it must keep working when the dashboard is
+// mid-refactor.
+//
+//	go run ./cmd/envprobe <env-file> <key>
+//
+// Prints the value with no trailing newline, so the caller compares bytes.
+// A file that cannot be read prints nothing and exits 1.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kcenon/claude-docker/tui/internal/config"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintln(os.Stderr, "usage: envprobe <env-file> <key>")
+		os.Exit(2)
+	}
+
+	env, err := config.LoadEnv(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "envprobe: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Print(env.Get(os.Args[2]))
+}

--- a/tui/internal/config/env.go
+++ b/tui/internal/config/env.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -83,8 +84,7 @@ func LoadEnv(path string) (*Env, error) {
 			continue
 		}
 		key := strings.TrimSpace(trimmed[:idx])
-		val := strings.TrimSpace(trimmed[idx+1:])
-		val = strings.Trim(val, `"'`)
+		val := parseEnvValue(trimmed[idx+1:])
 		e.index[key] = len(e.entries)
 		e.entries = append(e.entries, entry{key: key, value: val, raw: line})
 	}
@@ -92,6 +92,54 @@ func LoadEnv(path string) (*Env, error) {
 		return nil, fmt.Errorf("scan env: %w", err)
 	}
 	return e, nil
+}
+
+// quotedEnvValue matches a fully quoted value with an optional trailing
+// comment: "a # b", 'a b', or "bar"  # note. Group 1 is the content.
+var quotedEnvValue = regexp.MustCompile(`^"(.*)"(\s+#.*)?$|^'(.*)'(\s+#.*)?$`)
+
+// inlineEnvComment matches a comment introduced by whitespace-then-hash. A
+// bare `#` with no space before it is data: FOO=a#b is the value a#b.
+var inlineEnvComment = regexp.MustCompile(`\s+#.*$`)
+
+// parseEnvValue normalizes the text after `KEY=` the way parse_env_value in
+// scripts/lib/parse_env.sh does (#356, row 9).
+//
+// This reader used to do `strings.TrimSpace` then `strings.Trim(val, "\"'")`,
+// which differs from the shells in four ways, each of them reachable:
+//
+//   - No inline-comment handling at all. `NUM_ACCOUNTS=4  # four` produced
+//     "4  # four", so Atoi failed and NumAccounts silently returned the
+//     default of 2 while both generators read 4. `GH_USER_A=alice  # main`
+//     was handed to `gh auth token --user` with the comment attached.
+//   - `strings.Trim` is a *cutset* trim, not a paired-quote strip, so
+//     `"unclosed` lost its lone leading quote where the shells keep it.
+//   - Leading whitespace after `=` was trimmed here and kept by the shells.
+//   - `"bar"  # note` kept the closing quote and the comment.
+//
+// The quote check runs before the comment strip, which is a change on the
+// shell side too: with the old order a `#` inside a quoted value started a
+// comment, so set_env_value wrote FOO="a # b" and every reader returned `"a`.
+// Writer and reader in the same file disagreed. Now all three agree, and the
+// round trip is lossless for that value.
+//
+// Still lossy for an embedded double quote: the wrapper is stripped without
+// unescaping, so `say "hi" now` round-trips as `say \"hi\" now`. All three
+// implementations agree on that, and set_env_value's own comment documents it.
+func parseEnvValue(raw string) string {
+	val := strings.TrimRight(raw, " \t\r\n\v\f")
+
+	if m := quotedEnvValue.FindStringSubmatch(val); m != nil {
+		// Alternation: group 1 for the double-quoted branch, group 3 for the
+		// single-quoted one. Exactly one branch participates in a match.
+		if m[1] != "" || strings.HasPrefix(val, `"`) {
+			return m[1]
+		}
+		return m[3]
+	}
+
+	val = inlineEnvComment.ReplaceAllString(val, "")
+	return strings.TrimRight(val, " \t\r\n\v\f")
 }
 
 // NewEmptyEnv returns a fresh empty Env with the given path.


### PR DESCRIPTION
Closes #356
Relates to #377

Sixth and last child of #356. Children 1–5 are [#380](https://github.com/kcenon/claude-docker/pull/380), [#381](https://github.com/kcenon/claude-docker/pull/381), [#382](https://github.com/kcenon/claude-docker/pull/382), [#383](https://github.com/kcenon/claude-docker/pull/383), [#384](https://github.com/kcenon/claude-docker/pull/384).

**Merge note:** this and #383 both touch `parse_env.sh` and `ClaudeDocker.psm1`, in different functions. #383 first, then rebase.

## What was wrong

The Go reader did `strings.TrimSpace` then `strings.Trim(val, "\"'")`. Four differences from the shells, all reachable — and two of them show up on **checked-in fixtures**, which is how the red-first run found them:

```
edge-cases.env : GH_TOKEN
  bash, pwsh  gho_abc123
  go          gho_abc123  # personal token with inline comment

with-special-chars.env : PROJECT_DIR
  bash, pwsh  /tmp/claude test/project
  go          /tmp/claude test/project  # path with a space and inline comment
```

- **No inline-comment handling.** `NUM_ACCOUNTS=4  # four` made `Atoi` fail, so `NumAccounts` silently returned the default of 2 while both generators read 4. `GH_USER_A=alice  # main` reached `gh auth token --user` with the comment attached.
- **`strings.Trim` is a cutset trim**, not a paired-quote strip, so `"unclosed` lost its lone leading quote.
- Leading whitespace after `=` trimmed here, kept by the shells.
- `"bar"  # note` kept both the closing quote and the comment.

## Why this changes the shells too

Fixing only Go would have meant **copying a defect into it**. The shells stripped inline comments *before* unquoting, so a `#` inside a quoted value started a comment:

```
$ set_env_value .env FOO 'a # b'   # the bash writer
$ cat .env
FOO="a # b"
$ parse_env_value .env FOO         # the bash reader
"a
```

Writer and reader in the same file disagreeing. That is the defect I measured in [#377](https://github.com/kcenon/claude-docker/pull/377) and deferred, saying in that PR body that it belonged to this child. Go was the only implementation that got it *right*, by accident of not handling comments at all.

**One rule, three implementations:** strip CR → trim trailing whitespace → if the value is fully quoted (allowing a comment after the closing quote) unquote it → otherwise strip a whitespace-preceded comment and trim again.

Verified across all three, every case agreeing:

| line | before (bash / pwsh / go) | after (all three) |
|---|---|---|
| `FOO=bar  # note` | `bar` / `bar` / `bar  # note` | `bar` |
| `FOO="a # b"` | `"a` / `"a` / `a # b` | `a # b` |
| `FOO= bar` | ` bar` / ` bar` / `bar` | ` bar` |
| `FOO="bar"  # note` | `bar` / `bar` / `bar"  # note` | `bar` |
| `FOO="unclosed` | `"unclosed` / `"unclosed` / `unclosed` | `"unclosed` |

The `set_env_value` round trip is now lossless for a value containing ` # ` and for one ending in a hash. Still lossy for an embedded double quote — the wrapper is stripped without unescaping — which all three agree on and `set_env_value`'s own comment documents.

## Verification

`tests/test_parse_env_equivalence.sh` — **PASS=70 FAIL=0**, up from 44 assertions over two implementations.

**Red first** against an `origin/develop` export (with the probe copied in): failures on `edge-cases.env : GH_TOKEN`, `with-special-chars.env : PROJECT_DIR`, `with-special-chars.env : GH_TOKEN`, and six synthetic keys including `HASH_INSIDE_QUOTES`, where bash and pwsh returned `"a`.

Full `bash-tests` (24 files) and `pwsh-tests` (8 files): 0 non-passing. `go test -race`, `go vet`, `gofmt -l`, the benchmark smoke run, shellcheck at CI severity, PSScriptAnalyzer: all clean.

### Three things the harness needed before it could catch any of this

1. **A way to reach the Go reader.** `internal/` cannot be imported from another module, so a shell harness had no route to `LoadEnv`. `tui/cmd/envprobe` is a ~20-line command that prints one value and nothing else; the test builds it once rather than `go run` per assertion.

2. **Inputs that discriminate.** No checked-in fixture contained a line the readers disagreed on — `edge-cases.env`'s `HASH_IN_QUOTES` uses a `#` with no preceding space, which no implementation treats as a comment. Thirteen synthetic lines are written at runtime. (Runtime rather than appended to the fixture because this session's sensitive-file guard blocks editing `*.env`; generating them also keeps the discriminating cases next to the assertions that explain them.)

3. **Absolute values, not just agreement.** Agreement is satisfied by three readers that are wrong together, which is precisely what `HASH_INSIDE_QUOTES` was. Thirteen `assert_value` checks pin what each value must be.

### A mistake worth recording

The first awk version matched the quoted pattern and then ran `sub(/[[:space:]]+#.*$/, "", rhs)` to drop a trailing comment — which ate the `#` *inside* the quotes and returned empty. POSIX awk `match()` has no capture groups, and the obvious workaround is exactly wrong for the case being fixed. It is written with `substr` and an explicit closing-quote check now. The three-reader probe caught it immediately; reading the diff would not have.

## Where

- `tui/internal/config/env.go` — `parseEnvValue`, `quotedEnvValue`, `inlineEnvComment`
- `tui/cmd/envprobe/main.go` (new) — test-support command
- `scripts/lib/parse_env.sh` — `parse_env_value` (awk) and `load_env_file`
- `scripts/ClaudeDocker.psm1` — `ConvertFrom-EnvLine`
- `tests/test_parse_env_equivalence.sh` — Go leg, synthetic cases, absolute values
