### PR TITLE
docs: name the WSL2 exception where README explains UID/GID

### DIFF
--- a/README.md
+++ b/README.md
@@ -978,9 +978,17 @@ generated in every mode; the resolved mode decides which one is selected.
 
 On native Linux, set `UID` / `GID` in `.env` (or export them before running
 `docker compose up`) to match the host user that owns the selected runtime's
-state root. The interactive bash installer does this automatically. Without
-matching IDs, bind-mounted paths such as `~/.claude-state/account-a/` are not
-writable from inside the container, producing errors like
+state root. The interactive bash installer does this automatically **on native
+Linux only**: `scripts/install.sh` classifies WSL2 as its own platform, not as
+`linux`, so a WSL2 install writes no `UID`/`GID` at all and you have to add
+them yourself:
+
+```bash
+printf 'UID=%s\nGID=%s\n' "$(id -u)" "$(id -g)" >> .env
+```
+
+Without matching IDs, bind-mounted paths such as `~/.claude-state/account-a/`
+are not writable from inside the container, producing errors like
 `hook: /home/node/.claude/hooks/<name>.sh: not found` (failure to stat
 under non-matching UID) and Bash tool failures caused by the harness
 being unable to create `session-env/` subdirectories.
@@ -1019,9 +1027,14 @@ scripts/claude-docker exec claude-a claude auth login
 
 **Permission denied on bind mount (or `hook: ... not found`, `session-env` write failures):**
 
-On native Linux, the container UID/GID must match the owner of the selected
-runtime's state root. Add them to `.env` and restart — the base compose reads
-these directly, so no extra overlay is required.
+On native Linux **and under WSL2**, the container UID/GID must match the owner
+of the selected runtime's state root. Add them to `.env` and restart — the base
+compose reads these directly, so no extra overlay is required.
+
+This is the usual cause under WSL2 specifically, because `scripts/install.sh`
+writes the pair only when it classifies the platform as `linux`, and WSL2 is
+classified separately — so a WSL2 install reaches this state by default rather
+than by misconfiguration.
 
 ```bash
 cat >> .env <<EOF

--- a/tests/test_docs_contracts.sh
+++ b/tests/test_docs_contracts.sh
@@ -147,6 +147,72 @@ done
 
 # ---------------------------------------------------------------------------
 echo ""
+echo "=== wherever UID/GID are explained, the WSL2 exception is named ==="
+# ---------------------------------------------------------------------------
+#
+# scripts/install.sh writes the UID/GID pair into .env only when it classifies
+# the platform as `linux`, and detect_platform returns `wsl2` for WSL2 -- so a
+# WSL2 install gets no UID/GID and hits permission errors on the bind mount by
+# default, not by misconfiguration. Any document that explains the pair and
+# omits that is telling a WSL2 reader something untrue about their own install
+# (#360).
+#
+# This is an enumeration check like the two above, not a prose check: the set
+# of documents that explain UID/GID must equal the set that names WSL2. It is
+# discovered rather than listed, so a new document explaining the pair is
+# covered without editing this test.
+
+# The behaviour the documents have to match. Asserted here rather than assumed,
+# because if the installer ever starts writing the pair on WSL2 this whole
+# section is checking for a caveat that should no longer exist.
+if grep -q 'PLATFORM" == "linux"' "$PROJECT_ROOT/scripts/install.sh" &&
+   grep -q 'echo "wsl2"' "$PROJECT_ROOT/scripts/install.sh"; then
+    pass "install.sh still gates UID/GID on linux while classifying wsl2 separately"
+else
+    fail "install.sh no longer matches the premise of the WSL2 caveat; recheck the docs"
+fi
+
+# Proximity, not "the file mentions WSL2 somewhere".
+#
+# A whole-file grep is worthless here and was tried first: README names WSL2
+# eight times in its platform tables and its filesystem-performance note, so
+# the check passed against the very text that was missing the caveat. The
+# anchor is each place the reader is told to write the pair into .env -- a
+# `UID=` assignment -- and WSL2 has to appear in the surrounding window.
+uid_anchors=0
+while IFS= read -r doc; do
+    [ -n "$doc" ] || continue
+    docname="$(basename "$doc")"
+    while IFS= read -r lineno; do
+        [ -n "$lineno" ] || continue
+        uid_anchors=$((uid_anchors + 1))
+        # The window looks mostly backwards: the caveat belongs in the prose
+        # introducing the snippet. A wide forward window let an unrelated
+        # "Windows through WSL2" heading ten lines below satisfy an anchor.
+        from=$((lineno - 25)); [ "$from" -lt 1 ] && from=1
+        to=$((lineno + 4))
+        if sed -n "${from},${to}p" "$doc" | grep -qi 'wsl2'; then
+            pass "$docname:$lineno writes UID/GID and names WSL2 nearby"
+        else
+            fail "$docname:$lineno tells the reader to write UID/GID with no WSL2 caveat in range"
+        fi
+    done < <(grep -n '^[[:space:]]*\(export \)\?UID=\|UID=%s' "$doc" | cut -d: -f1)
+done <<EOF
+$PROJECT_ROOT/README.md
+$PROJECT_ROOT/docs/ISOLATION.md
+$PROJECT_ROOT/.env.example
+EOF
+
+# Without this the section passes by finding nothing to check -- which is what
+# happens if the snippets are reworded, and is indistinguishable from a pass.
+if [ "$uid_anchors" -ge 4 ]; then
+    pass "found $uid_anchors UID/GID instructions to check"
+else
+    fail "expected at least 4 UID/GID instructions across the three documents, found $uid_anchors"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
 echo "=== Results ==="
 echo "  Passed: $PASS"
 echo "  Failed: $FAIL"


### PR DESCRIPTION
Relates to #360

The one acceptance criterion of #360 the merged work did not satisfy, found by an audit of all 11 after #379 landed.

## What was missing

> `docs/ISOLATION.md:183-184` matches `docker-compose.linux.yml:7`, **and the WSL2 case is documented wherever `UID`/`GID` are explained**

The first clause landed. The second landed in `docs/ISOLATION.md` and `.env.example` — and not in `README.md`, which explains the pair **twice** and was silent in both:

- the Compose Overrides section: *"On native Linux, set `UID` / `GID` in `.env` … The interactive bash installer does this automatically."*
- the troubleshooting entry **Permission denied on bind mount**, which is the symptom.

README is the location the issue's own Why section named.

The claim is wrong for WSL2. `scripts/install.sh` writes the pair only under `[[ "$PLATFORM" == "linux" ]]`, and `detect_platform` returns `wsl2` — so a WSL2 install gets no `UID`/`GID` and hits permission-denied on the bind mount **by default, not by misconfiguration**. The troubleshooting entry for that exact symptom was the second silent passage, which is the unlucky part: the reader who lands there is already experiencing the WSL2 case.

Both passages now name it, and the first carries the one-liner that fixes it.

## The regression check, and the version of it that did not work

A file-wide `grep -qi wsl2` was written first and is **worthless here**: README names WSL2 eight times in its platform tables and its filesystem-performance note, so it passed against the very text that was missing the caveat. Measured, not assumed — that is why the first version was thrown away.

What replaced it is a proximity check. The anchor is each place the reader is told to write the pair into `.env` (a `UID=` assignment), and WSL2 must appear in the window around it — weighted backwards, because the caveat belongs in the prose introducing a snippet. A wide forward window let an unrelated *"Slow file operations (Windows through WSL2)"* heading ten lines below satisfy an anchor; narrowing it to +4 removed that.

Two guards on the check itself:

- **It asserts its own premise** — that `install.sh` still gates the write on `linux` while classifying `wsl2` separately. If that ever changes, the caveat should be removed and this check should say so rather than keep demanding it.
- **It asserts the anchor count.** A section that finds nothing to check prints the same thing as a section that passes, and reworded snippets would silently produce the former.

## Verification

Red first, in a sandbox with the README reverted to the merged text:

```
FAIL  README.md:1028 tells the reader to write UID/GID with no WSL2 caveat in range
FAIL  README.md:1037 tells the reader to write UID/GID with no WSL2 caveat in range
PASS  ISOLATION.md:201 writes UID/GID and names WSL2 nearby
FAIL  expected at least 4 UID/GID instructions across the three documents, found 3
```

Green after, 4 anchors checked, `test_docs_contracts.sh` 32/32. `bash-tests` 31/31 and shellcheck `-e SC1091 --severity=warning` clean.

The sandbox needed `git init` — `test_docs_contracts.sh` discovers the compose files with `git ls-files` and refuses to report anything when that returns nothing. That guard firing is what told me the first sandbox run had proven nothing.

No VERSION bump: nothing here is inside a directory the Dockerfile COPYs.
