### PR TITLE
fix(tui): keep and cache what a truncated session file yielded

### DIFF
--- a/tui/internal/usage/parser.go
+++ b/tui/internal/usage/parser.go
@@ -32,6 +32,11 @@ type SessionEntry struct {
 type Session struct {
 	Path    string
 	Entries []SessionEntry
+	// Truncated is set when the scanner stopped before the end of the file.
+	// The entries above are still the ones it decoded; the totals derived
+	// from them are a floor, not the file's real total. Callers that report
+	// usage should say so rather than present a short count as exact.
+	Truncated bool
 }
 
 // cacheEntry records a previously parsed session along with the file
@@ -204,9 +209,14 @@ func ScanAccountSessionsWithCache(projectsDir string, cache *Cache) ([]Session, 
 		info, infoErr := d.Info()
 		if infoErr != nil {
 			// Fall back to a stat-less parse; never cache without a fingerprint.
+			// Same partial-result rule as the cached path below, minus the
+			// caching, which has no fingerprint to key on here.
 			s, parseErr := parseSessionFile(path)
 			if parseErr != nil {
-				return nil
+				s.Truncated = true
+				if len(s.Entries) == 0 {
+					return nil
+				}
 			}
 			sessions = append(sessions, s)
 			seen[path] = struct{}{}
@@ -224,7 +234,28 @@ func ScanAccountSessionsWithCache(projectsDir string, cache *Cache) ([]Session, 
 
 		s, parseErr := parseSessionFile(path)
 		if parseErr != nil {
-			return nil // skip unparseable files
+			// A scanner error is not the same thing as an unparseable file,
+			// and this treated them the same: it dropped the whole session
+			// and skipped the cache (#358, item 14).
+			//
+			// parseSessionFile returns the entries it decoded before the
+			// failure alongside the error, and the usual cause -- one JSONL
+			// line past the 10 MB scanner limit -- leaves every other line in
+			// the file intact. Everything before the long line was thrown
+			// away for the sake of the one line after it.
+			//
+			// Skipping the cache made it permanent rather than momentary:
+			// nothing recorded that the file had been looked at, so the next
+			// scan re-read it from the start and failed on the same line, at
+			// the same cost, forever. Caching under the (size, mtime)
+			// fingerprint is safe -- editing the file changes the fingerprint
+			// and forces a re-read.
+			s.Truncated = true
+			if len(s.Entries) == 0 {
+				// Nothing decoded at all: not worth a cache entry, and there
+				// is no partial result to keep.
+				return nil
+			}
 		}
 		cache.put(path, size, modUnix, s)
 		sessions = append(sessions, s)

--- a/tui/internal/usage/truncated_test.go
+++ b/tui/internal/usage/truncated_test.go
@@ -1,0 +1,133 @@
+package usage
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A JSONL line past the scanner's 10 MB token limit. bufio.Scanner stops at
+// the first one and reports ErrTooLong, which is the realistic way a session
+// file becomes unreadable: one enormous tool result in the middle of a file
+// whose other lines are ordinary.
+func oversizedLine() string {
+	return `{"type":"assistant","timestamp":"2026-01-01T00:00:00Z","message":{"model":"sonnet","filler":"` +
+		strings.Repeat("x", 11*1024*1024) + `"}}` + "\n"
+}
+
+func assistantLine() string {
+	return `{"type":"assistant","timestamp":"2026-01-01T00:00:00Z","message":{"model":"sonnet",` +
+		`"usage":{"input_tokens":1,"output_tokens":2,"cache_creation_input_tokens":3,"cache_read_input_tokens":4}}}` + "\n"
+}
+
+// stageTruncatable writes a session file whose first two entries are ordinary
+// and whose third line exceeds the scanner limit, plus an ordinary entry after
+// it that the scanner will never reach.
+func stageTruncatable(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	proj := filepath.Join(root, "project-a")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	content := assistantLine() + assistantLine() + oversizedLine() + assistantLine()
+	if err := os.WriteFile(filepath.Join(proj, "session-1.jsonl"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return root
+}
+
+// A scanner error used to discard the whole file. Every entry decoded before
+// the oversized line was thrown away for the sake of the one line after it
+// (#358, item 14).
+func TestScannerErrorKeepsWhatWasDecoded(t *testing.T) {
+	root := stageTruncatable(t)
+
+	sessions, err := ScanAccountSessions(root)
+	if err != nil {
+		t.Fatalf("ScanAccountSessions: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("len(sessions) = %d, want 1 -- the file was dropped entirely", len(sessions))
+	}
+	if len(sessions[0].Entries) != 2 {
+		t.Errorf("len(Entries) = %d, want 2 (the entries before the oversized line)",
+			len(sessions[0].Entries))
+	}
+	// The count is a floor, and a caller has to be able to tell. Without this
+	// the fix would trade a visible loss for a silent undercount.
+	if !sessions[0].Truncated {
+		t.Error("Truncated = false, want true -- a short count must not look exact")
+	}
+}
+
+// The other half: skipping the cache made the loss permanent instead of
+// momentary. Nothing recorded that the file had been looked at, so every
+// later scan re-read it from the start and failed on the same line again.
+func TestScannerErrorIsCachedSoTheCostDoesNotRepeat(t *testing.T) {
+	root := stageTruncatable(t)
+	cache := NewCache()
+
+	first, err := ScanAccountSessionsWithCache(root, cache)
+	if err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	if len(first) != 1 {
+		t.Fatalf("first scan returned %d sessions, want 1", len(first))
+	}
+
+	// Make the file unreadable. A second scan that still returns the session
+	// can only be reading it from the cache; one that re-reads the file would
+	// come back empty.
+	path := filepath.Join(root, "project-a", "session-1.jsonl")
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	// Recreate it with the same size and mtime so the fingerprint still
+	// matches but the content cannot be parsed -- the cache must be consulted
+	// before the file is opened.
+	if err := os.WriteFile(path, make([]byte, 0), 0o000); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+
+	// The fingerprint changed, so this scan legitimately re-reads. What it
+	// must not do is return the stale entry: that would mean the cache is
+	// keyed on the path alone.
+	second, err := ScanAccountSessionsWithCache(root, cache)
+	if err != nil {
+		t.Fatalf("second scan: %v", err)
+	}
+	for _, s := range second {
+		if len(s.Entries) != 0 {
+			t.Errorf("a rewritten file returned %d cached entries; the fingerprint is not being checked",
+				len(s.Entries))
+		}
+	}
+}
+
+// The cache entry itself, checked directly: after a truncated parse the
+// fingerprint must be recorded, because that record is what stops the next
+// scan from repeating the work.
+func TestTruncatedSessionIsStoredInTheCache(t *testing.T) {
+	root := stageTruncatable(t)
+	cache := NewCache()
+
+	if _, err := ScanAccountSessionsWithCache(root, cache); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	path := filepath.Join(root, "project-a", "session-1.jsonl")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	cached, ok := cache.get(path, info.Size(), info.ModTime().UnixNano())
+	if !ok {
+		t.Fatal("the truncated file was not cached; the next scan would re-read and re-fail it")
+	}
+	if len(cached.Entries) != 2 || !cached.Truncated {
+		t.Errorf("cached session = %d entries, Truncated=%v; want 2 entries, Truncated=true",
+			len(cached.Entries), cached.Truncated)
+	}
+}


### PR DESCRIPTION
Relates to #358

The half of item 14 that neither branch of the disjunction was applied to, found by an audit of all 18 criteria after #376–#378 landed.

## What was left

Item 14 named **two** locations. The per-refresh directory walk in `manager_helpers.go` was deleted. The other — `tui/internal/usage/parser.go`, *"a scanner error discards the whole file and is never cached"* — was untouched. The anchors did not even move: it is still those lines.

```go
s, parseErr := parseSessionFile(path)
if parseErr != nil {
    return nil // skip unparseable files
}
cache.put(path, size, modUnix, s)
```

`parseSessionFile` returns the entries it decoded **alongside** the error. The caller threw both away.

The realistic cause is one JSONL line past the scanner's 10 MB limit — a single enormous tool result in the middle of a file whose other lines are ordinary. Everything before the long line was discarded for the sake of the one line after it.

Skipping the cache made that **permanent rather than momentary**: nothing recorded that the file had been looked at, so the next scan re-read it from the start and failed on the same line, at the same cost, on every refresh. Caching under the `(size, mtime)` fingerprint is safe — editing the file changes the fingerprint and forces a re-read.

## Session gains a Truncated flag

Without it the fix would trade a visible loss for a **silent undercount**: a short token total that looks exact. The totals derived from a truncated session are a floor, and the type now says so.

The stat-less fallback branch had the same discard and gets the same rule, minus the caching, which has no fingerprint to key on there.

## Verification

Three tests, red first against the pre-fix branches restored by mutation — with the mutation's presence asserted *before* the run, because a regex that matches nothing reports `ok` and proves nothing:

```
substitutions: cached=1 statless=1
MUTATED markers present: 2
--- FAIL: TestScannerErrorKeepsWhatWasDecoded
    len(sessions) = 0, want 1 -- the file was dropped entirely
--- FAIL: TestScannerErrorIsCachedSoTheCostDoesNotRepeat
    first scan returned 0 sessions, want 1
--- FAIL: TestTruncatedSessionIsStoredInTheCache
    the truncated file was not cached; the next scan would re-read and re-fail it
```

The second test also pins that the cache is keyed on the fingerprint and not on the path alone, so "it came back from the cache" cannot be satisfied by returning stale content for a rewritten file.

`go test`, `go vet`, `gofmt -l` and the benchmark smoke run are clean. No VERSION bump — nothing here is inside a directory the Dockerfile COPYs.

## What this PR does not do

`internal/usage` stays in the tree, unreachable from production, for the reason recorded in #378: `docs/PERFORMANCE.md` is written about this cache and it holds the repository's only benchmark. Removing the package is a separate decision from removing the walk, and it is the one part of item 14 still open — worth taking deliberately rather than as a side effect of this fix.
