### PR TITLE
fix(tui): retry the atomic-write rename past a Windows sharing violation

### DIFF
--- a/tui/internal/account/manager.go
+++ b/tui/internal/account/manager.go
@@ -2,7 +2,9 @@ package account
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sync"
@@ -239,10 +241,68 @@ func writeFileAtomic(path string, data []byte) error {
 	if err := os.Chmod(tmpName, 0600); err != nil {
 		return fmt.Errorf("chmod tmp: %w", err)
 	}
-	if err := os.Rename(tmpName, path); err != nil {
+	if err := renameRetryingSharingViolation(func() error {
+		return os.Rename(tmpName, path)
+	}); err != nil {
 		return fmt.Errorf("rename: %w", err)
 	}
 	return nil
+}
+
+const (
+	// How long renameRetryingSharingViolation keeps trying, and how long it
+	// waits between attempts. Measured against a reader looping with no pause
+	// at all -- the worst case this code can face -- the rename succeeded
+	// within 13 attempts, about 65ms. Two seconds is headroom, not a target.
+	renameRetryBudget = 2 * time.Second
+	renameRetryPause  = 5 * time.Millisecond
+)
+
+// renameRetryingSharingViolation calls rename until it succeeds, fails for a
+// reason retrying cannot fix, or the budget runs out.
+//
+// This exists for Windows. os.Rename there is MoveFileEx, and it fails with
+// "Access is denied" whenever another handle has the destination open, because
+// Go's os.Open does not request FILE_SHARE_DELETE. Measured, not assumed: with
+// no reader the rename succeeds; with a plain os.Open held on the destination
+// the same rename fails.
+//
+// It is a regression this file introduced. os.WriteFile truncated in place and
+// did not care about readers, so switching to a rename traded "a reader can
+// see a torn file" for "a write can fail" -- and the same change stopped
+// discarding write errors, so the failure now reaches the user. A reader holds
+// the handle for microseconds, which makes the violation transient by nature
+// and a bounded retry the right shape of fix.
+//
+// The gate is the error, not the platform, so the loop is reachable from a
+// test on any OS -- see rename_retry_test.go, which injects a rename that
+// fails a fixed number of times. On POSIX the condition effectively cannot
+// arise here anyway: the temp file is created in the destination's own
+// directory, so a directory this process cannot write to fails at CreateTemp
+// long before the rename. If some other permission error did occur there, the
+// cost is one delayed failure, not a wrong answer.
+func renameRetryingSharingViolation(rename func() error) error {
+	err := rename()
+	if err == nil || !errors.Is(err, fs.ErrPermission) {
+		return err
+	}
+
+	deadline := time.Now().Add(renameRetryBudget)
+	for time.Now().Before(deadline) {
+		time.Sleep(renameRetryPause)
+		err = rename()
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, fs.ErrPermission) {
+			return err
+		}
+	}
+	// Say that retrying happened. Otherwise the message is identical to the
+	// one a single failed attempt produces, and the reader cannot tell a
+	// momentary collision from a file that is permanently unwritable.
+	return fmt.Errorf("%w (still denied after retrying for %s; another process may be holding the file open)",
+		err, renameRetryBudget)
 }
 
 const apiCooldownDuration = 25 * time.Second

--- a/tui/internal/account/rename_retry_test.go
+++ b/tui/internal/account/rename_retry_test.go
@@ -1,0 +1,148 @@
+package account
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The retry loop is here for a Windows-only failure, so a test that could only
+// run on Windows would leave it unexercised in CI. These inject the rename
+// instead, which pins the decision the loop makes -- retry this error, do not
+// retry that one -- on every platform.
+
+// A sharing violation surfaces as a permission error; that classification is
+// what the loop gates on, and it was measured before the gate was written.
+func TestRenameRetriesUntilThePermissionErrorClears(t *testing.T) {
+	remaining := 5
+	calls := 0
+	err := renameRetryingSharingViolation(func() error {
+		calls++
+		if remaining > 0 {
+			remaining--
+			return &os.LinkError{Op: "rename", Err: fs.ErrPermission}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("renameRetryingSharingViolation: %v, want nil once the error clears", err)
+	}
+	if calls != 6 {
+		t.Errorf("rename called %d times, want 6 (five denials then a success)", calls)
+	}
+}
+
+// A rename that succeeds outright must not pay for the retry machinery.
+func TestRenameDoesNotRetryOnSuccess(t *testing.T) {
+	calls := 0
+	start := time.Now()
+	if err := renameRetryingSharingViolation(func() error { calls++; return nil }); err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if calls != 1 {
+		t.Errorf("rename called %d times, want 1", calls)
+	}
+	if elapsed := time.Since(start); elapsed > renameRetryPause {
+		t.Errorf("a successful rename slept for %v; the retry path should not be entered", elapsed)
+	}
+}
+
+// The point of gating on the error rather than retrying everything: an error
+// no amount of waiting can fix has to come back immediately, and unchanged.
+func TestRenameDoesNotRetryOtherErrors(t *testing.T) {
+	sentinel := errors.New("cross-device link")
+	calls := 0
+	start := time.Now()
+	err := renameRetryingSharingViolation(func() error { calls++; return sentinel })
+	if !errors.Is(err, sentinel) {
+		t.Errorf("err = %v, want the original error unwrapped to sentinel", err)
+	}
+	if calls != 1 {
+		t.Errorf("rename called %d times, want 1", calls)
+	}
+	if elapsed := time.Since(start); elapsed > renameRetryPause {
+		t.Errorf("a non-retryable error slept for %v", elapsed)
+	}
+}
+
+// An error that never clears must still terminate, and the message has to say
+// that retrying happened -- otherwise it reads exactly like a single failed
+// attempt and a momentary collision cannot be told from a file that is
+// permanently unwritable.
+func TestRenameGivesUpAndSaysSo(t *testing.T) {
+	calls := 0
+	start := time.Now()
+	err := renameRetryingSharingViolation(func() error {
+		calls++
+		return &os.LinkError{Op: "rename", Err: fs.ErrPermission}
+	})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("err = nil, want a failure after the budget is spent")
+	}
+	if !errors.Is(err, fs.ErrPermission) {
+		t.Errorf("err = %v, want it to still unwrap to a permission error", err)
+	}
+	if got := err.Error(); !strings.Contains(got, "retrying") {
+		t.Errorf("err = %q, want it to mention that retrying happened", got)
+	}
+	if elapsed < renameRetryBudget {
+		t.Errorf("gave up after %v, before the %v budget", elapsed, renameRetryBudget)
+	}
+	if elapsed > renameRetryBudget*2 {
+		t.Errorf("took %v, far past the %v budget", elapsed, renameRetryBudget)
+	}
+	if calls < 2 {
+		t.Errorf("rename called %d times; the loop did not run", calls)
+	}
+}
+
+// The primitive still has to work end to end, with the real os.Rename behind
+// it: the injected tests above would pass against a loop that was never wired
+// into writeFileAtomic.
+func TestWriteFileAtomicStillWritesThroughTheRetryPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	want := []byte(`{"ok":true}`)
+
+	if err := writeFileAtomic(path, want); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("content = %q, want %q", got, want)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	// 0600 on POSIX; Windows reports 0666 for a writable file and the mode
+	// bits are not the thing under test there.
+	if perm := info.Mode().Perm(); perm&0o077 != 0 && !windowsPerms(perm) {
+		t.Errorf("mode = %o, want owner-only", perm)
+	}
+	// No temp file may survive a successful write.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 1 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("directory holds %v, want only state.json", names)
+	}
+}
+
+// Windows does not model POSIX permission bits; os.Stat reports 0666 for any
+// writable file regardless of the chmod that preceded it.
+func windowsPerms(p fs.FileMode) bool { return p == 0o666 }


### PR DESCRIPTION
Relates to #358

`go test ./...` failed on Windows on every run — `TestWriteFileAtomicIsNeverPartiallyVisible` and `TestLimitlineCacheIsNeverPartiallyVisible`, both with `rename: Access is denied`. CI is Linux, so it was green throughout.

It is not a test-environment quirk. It is a regression #377 introduced, and it can hit a real write.

## Measured, not inferred

`os.Rename` is `MoveFileEx` on Windows, and it fails with `ACCESS_DENIED` whenever another handle has the destination open — Go's `os.Open` does not request `FILE_SHARE_DELETE`. A minimal probe:

```
no reader                    rename ok
os.Open held                 rename FAILED: ... Access is denied.
```

`os.WriteFile` truncated in place and did not care about readers. Switching to a rename traded *"a reader can see a torn file"* for *"a write can fail"* — and the same PR correctly stopped discarding write errors, which is what makes this visible rather than silent.

A reader holds the handle for microseconds, so the violation is transient by construction. A bounded retry is the shape of the fix, not a workaround for one.

## Both parameters come from measurement

Against a reader looping with **no pause at all** — worse than anything real, and exactly what the two tests do:

```
reader pause 0s     : 0/20 renames failed, worst attempt count 13, total 659ms
reader pause 1ms    : 0/20 renames failed, worst attempt count 10, total 272ms
```

Worst case ~65 ms. The budget is 2 s, which is headroom rather than a target.

That result decided the design. Because the retry wins even in the pathological case, **neither test needed weakening** — no sleep was added to the reader, so the torn-read detection they exist for is untouched. The alternative I was ready to fall back on (pause the reader so the writer can find a gap) would have traded away exactly the property under test.

## The gate is the error, not the platform

`errors.Is(err, fs.ErrPermission)` was confirmed **true** for this failure before the gate was written. A gate keyed on a guessed classification would simply never fire, and nothing would have noticed.

Keeping it platform-independent also makes the loop reachable from a test on any OS — which matters because CI is Linux and would otherwise never execute a line of it. On POSIX the condition effectively cannot arise here anyway: the temp file is created in the destination's own directory, so a directory this process cannot write to fails at `CreateTemp` long before the rename.

The give-up message says that retrying happened. Without that it is byte-identical to the message a single failed attempt produces, and a momentary collision cannot be told from a permanently unwritable file.

## Verification

`rename_retry_test.go` injects the rename and pins the four decisions the loop makes:

- retry until the permission error clears (five denials, then success, six calls)
- do not enter the loop on success (one call, no sleep)
- return a non-retryable error immediately and **unwrapped**
- terminate at the budget, still unwrapping to a permission error, with a message that mentions retrying

A fifth test writes through the real primitive, because all four injected tests would pass against a retry loop that was never wired into `writeFileAtomic`.

`go test ./...` passes on Windows for the first time. `go vet`, `gofmt -l` and the benchmark smoke run are clean.

No VERSION bump — nothing here is inside a directory the Dockerfile COPYs.
